### PR TITLE
Add CI/CD for builds and releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+target/
+.git/
+.github/
+test/
+tests/
+docs/
+*.md
+LICENSE
+.gitignore
+.dockerignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,122 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # rustsec/audit-check posts results as a check run on the commit.
+  checks: write
+
+env:
+  CARGO_TERM_COLOR: always
+  # Override the [profile.release] settings from Cargo.toml for CI: fat-LTO +
+  # codegen-units=1 are great for release binaries but ~10× slower to compile
+  # than thin-LTO, which bites hard on every matrix leg. Release binaries in
+  # release.yml unset these so they get the real profile.
+  CARGO_PROFILE_RELEASE_LTO: "thin"
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+
+jobs:
+  test:
+    name: Test (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+          - name: linux-x86_64-v3
+            os: ubuntu-latest
+            target_cpu: x86-64-v3
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+          - name: macos-aarch64
+            os: macos-latest
+          - name: windows-x86_64
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # ratchet:dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # ratchet:Swatinem/rust-cache@v2.9.1
+
+      - name: Detect host triple
+        if: matrix.target_cpu
+        shell: bash
+        run: echo "HOST_TRIPLE=$(rustc -vV | awk '/^host:/ {print $2}')" >> "$GITHUB_ENV"
+
+      - name: Build
+        shell: bash
+        run: >
+          cargo build --release
+          ${TARGET_CPU:+--target "$HOST_TRIPLE" --config "target.'$HOST_TRIPLE'.rustflags=['-C', 'target-cpu=$TARGET_CPU']"}
+        env:
+          TARGET_CPU: ${{ matrix.target_cpu || '' }}
+
+      - name: Test
+        shell: bash
+        run: >
+          cargo test --release
+          ${TARGET_CPU:+--target "$HOST_TRIPLE" --config "target.'$HOST_TRIPLE'.rustflags=['-C', 'target-cpu=$TARGET_CPU']"}
+        env:
+          TARGET_CPU: ${{ matrix.target_cpu || '' }}
+
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # ratchet:dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # ratchet:dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # ratchet:Swatinem/rust-cache@v2.9.1
+
+      - run: cargo clippy -- -D warnings
+
+  msrv:
+    name: MSRV check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Install Rust MSRV toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # ratchet:dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.88"
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # ratchet:Swatinem/rust-cache@v2.9.1
+
+      - name: Check MSRV compiles
+        run: cargo check
+
+  audit:
+    name: Security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,471 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  CARGO_TERM_COLOR: always
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # ------------------------------------------------------------------
+  # 0. Detect whether this is a release run (workflow_dispatch only)
+  # ------------------------------------------------------------------
+  check-release:
+    name: Check release
+    runs-on: ubuntu-latest
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+      version: ${{ steps.check.outputs.version }}
+      version_major: ${{ steps.check.outputs.version_major }}
+      version_minor: ${{ steps.check.outputs.version_minor }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+        with:
+          fetch-depth: 1
+          fetch-tags: true
+
+      - name: Detect release
+        id: check
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "Not a release run"
+            exit 0
+          fi
+
+          # `grep '^version = '` (with the trailing space) so we don't also
+          # match `rust-version = "..."`.
+          RAW=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          VERSION="v${RAW}"
+          echo "is_release=true" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # Only emit short aliases (e.g. `0` and `0.2` Docker tags, `latest`)
+          # for plain `X.Y.Z` releases — pre-releases like `0.2.0-rc1` must
+          # not clobber stable tag moving-targets.
+          if [[ "$RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            MAJOR=$(echo "$RAW" | cut -d. -f1)
+            MINOR="${MAJOR}.$(echo "$RAW" | cut -d. -f2)"
+            echo "version_major=$MAJOR" >> "$GITHUB_OUTPUT"
+            echo "version_minor=$MINOR" >> "$GITHUB_OUTPUT"
+          else
+            echo "version_major=" >> "$GITHUB_OUTPUT"
+            echo "version_minor=" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git tag -l "$VERSION" | grep -q .; then
+            echo "::error::Tag $VERSION already exists"
+            exit 1
+          fi
+
+          LOCK_VERSION=$(awk '/^name = "ruSTAR"/{found=1} found && /^version =/{print; exit}' Cargo.lock | sed 's/.*"\(.*\)"/\1/')
+          if [ "$LOCK_VERSION" != "$RAW" ]; then
+            echo "::error::Cargo.lock version ($LOCK_VERSION) does not match Cargo.toml version ($RAW)"
+            exit 1
+          fi
+
+          echo "Detected release: $VERSION"
+
+  # ------------------------------------------------------------------
+  # 1. Build binaries for each target (always, to catch breakage)
+  # ------------------------------------------------------------------
+  build-binaries:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64 (baseline)
+          - name: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+
+          # Linux x86_64 with AVX2 (x86-64-v3)
+          - name: linux-x86_64-v3
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            target_cpu: x86-64-v3
+
+          # Linux x86_64 with AVX-512 (x86-64-v4)
+          - name: linux-x86_64-v4
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            target_cpu: x86-64-v4
+
+          # Linux aarch64 (native arm64 runner, baseline)
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+
+          # Linux aarch64 with SVE (Graviton 3+, Axion, Grace)
+          - name: linux-aarch64-neoverse-v1
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            target_cpu: neoverse-v1
+
+          # macOS x86_64 (cross-compiled on Apple Silicon runner)
+          - name: macos-x86_64
+            os: macos-latest
+            target: x86_64-apple-darwin
+
+          # macOS aarch64 (Apple Silicon, baseline)
+          - name: macos-aarch64
+            os: macos-latest
+            target: aarch64-apple-darwin
+
+          # macOS aarch64 (Apple M1 optimised)
+          - name: macos-aarch64-apple-m1
+            os: macos-latest
+            target: aarch64-apple-darwin
+            target_cpu: apple-m1
+
+          # Windows x86_64 (baseline, MSVC toolchain)
+          - name: windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            ext: .exe
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # ratchet:dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build
+        shell: bash
+        run: >
+          cargo build --release --target ${{ matrix.target }}
+          ${TARGET_CPU:+--config "target.'${{ matrix.target }}'.rustflags=['-C', 'target-cpu=$TARGET_CPU']"}
+        env:
+          TARGET_CPU: ${{ matrix.target_cpu || '' }}
+
+      - name: Package
+        id: package
+        shell: bash
+        run: |
+          BIN="ruSTAR"
+          EXT="${{ matrix.ext }}"
+          ARCHIVE="${BIN}-${{ matrix.name }}"
+
+          mkdir -p "staging/${ARCHIVE}"
+          cp "target/${{ matrix.target }}/release/${BIN}${EXT}" "staging/${ARCHIVE}/"
+          cp README.md LICENSE "staging/${ARCHIVE}/" 2>/dev/null || true
+
+          cd staging
+          tar czf "../${ARCHIVE}.tar.gz" "${ARCHIVE}"
+          cd ..
+
+          # SHA256 checksum (shasum on macOS/Linux, sha256sum on Linux/Windows)
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${ARCHIVE}.tar.gz" > "${ARCHIVE}.tar.gz.sha256"
+          else
+            shasum -a 256 "${ARCHIVE}.tar.gz" > "${ARCHIVE}.tar.gz.sha256"
+          fi
+
+          echo "archive=${ARCHIVE}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "checksum=${ARCHIVE}.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # ratchet:actions/upload-artifact@v7.0.0
+        with:
+          name: binary-${{ matrix.name }}
+          path: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.checksum }}
+          retention-days: 1
+
+  # ------------------------------------------------------------------
+  # 2. Build per-platform Docker images on native runners
+  # ------------------------------------------------------------------
+  docker-build:
+    name: Docker ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get short commit hash
+        id: git-hash
+        run: echo "short_hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # ratchet:docker/build-push-action@v7.0.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            GIT_SHORT_HASH=${{ steps.git-hash.outputs.short_hash }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # ratchet:actions/upload-artifact@v7.0.0
+        with:
+          name: digests-${{ matrix.runner }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ------------------------------------------------------------------
+  # 2a. Build SIMD-optimised Docker images (single-arch each)
+  # ------------------------------------------------------------------
+  docker-build-simd:
+    name: Docker ${{ matrix.name }}
+    needs: [check-release]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: amd64-avx2
+            runner: ubuntu-latest
+            platform: linux/amd64
+            cpu_target: x86-64-v3
+            tag_suffix: avx2
+          - name: amd64-avx512
+            runner: ubuntu-latest
+            platform: linux/amd64
+            cpu_target: x86-64-v4
+            tag_suffix: avx512
+          - name: arm64-sve
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            cpu_target: neoverse-v1
+            tag_suffix: sve
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Prepare build metadata
+        id: prep
+        run: |
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+          echo "short_hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # ratchet:docker/metadata-action@v6.0.0
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ needs.check-release.outputs.version }}-${{ matrix.tag_suffix }},enable=${{ needs.check-release.outputs.is_release == 'true' }}
+            type=raw,value=latest-${{ matrix.tag_suffix }},enable=${{ needs.check-release.outputs.version_minor != '' }}
+            type=raw,value=dev-${{ matrix.tag_suffix }}
+
+      - name: Build and push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # ratchet:docker/build-push-action@v7.0.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            GIT_SHORT_HASH=${{ steps.prep.outputs.short_hash }}
+            CPU_TARGET=${{ matrix.cpu_target }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,scope=${{ matrix.name }},mode=max
+
+  # ------------------------------------------------------------------
+  # 2b. Merge per-platform images into a multi-arch manifest
+  # ------------------------------------------------------------------
+  docker-merge:
+    name: Docker merge
+    needs: [check-release, docker-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8.0.1
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # ratchet:docker/metadata-action@v6.0.0
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ needs.check-release.outputs.version }},enable=${{ needs.check-release.outputs.is_release == 'true' }}
+            type=raw,value=${{ needs.check-release.outputs.version_minor }},enable=${{ needs.check-release.outputs.version_minor != '' }}
+            type=raw,value=${{ needs.check-release.outputs.version_major }},enable=${{ needs.check-release.outputs.version_major != '' }}
+            type=raw,value=latest,enable=${{ needs.check-release.outputs.version_minor != '' }}
+            type=raw,value=dev
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+  # ------------------------------------------------------------------
+  # 3. Create tag and draft release (release only, after all builds)
+  # ------------------------------------------------------------------
+  create-tag-and-release:
+    name: Create tag and release
+    if: needs.check-release.outputs.is_release == 'true'
+    needs: [check-release, build-binaries, docker-merge, docker-build-simd]
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ needs.check-release.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Create tag
+        run: |
+          git tag "${{ needs.check-release.outputs.version }}"
+          git push origin "${{ needs.check-release.outputs.version }}"
+
+      - name: Extract changelog section
+        id: notes
+        run: |
+          RAW="${{ needs.check-release.outputs.version }}"
+          RAW="${RAW#v}"
+          if awk '/^## \[Version '"$RAW"'\]/{found=1; next} /^## \[/{if(found) exit} found' CHANGELOG.md > /tmp/release-notes.md && [ -s /tmp/release-notes.md ]; then
+            echo "has_notes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_notes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release (with changelog notes)
+        if: steps.notes.outputs.has_notes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ needs.check-release.outputs.version }}" \
+            --target "${{ github.sha }}" \
+            --title "ruSTAR ${{ needs.check-release.outputs.version }}" \
+            --notes-file /tmp/release-notes.md
+
+      - name: Create release (auto-generated notes)
+        if: steps.notes.outputs.has_notes == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ needs.check-release.outputs.version }}" \
+            --target "${{ github.sha }}" \
+            --title "ruSTAR ${{ needs.check-release.outputs.version }}" \
+            --generate-notes
+
+  # ------------------------------------------------------------------
+  # 4. Upload binaries to the release
+  # ------------------------------------------------------------------
+  upload-binaries:
+    name: Upload binaries
+    if: needs.check-release.outputs.is_release == 'true'
+    needs: [check-release, create-tag-and-release, build-binaries]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8.0.1
+        with:
+          pattern: binary-*
+          path: /tmp/binaries
+          merge-multiple: true
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.create-tag-and-release.outputs.tag }}" \
+            /tmp/binaries/*.tar.gz \
+            /tmp/binaries/*.sha256
+
+  # ------------------------------------------------------------------
+  # 5. Publish to crates.io (release only, last step)
+  #
+  # TODO: The `rustar` crate name is already taken on crates.io. This job will
+  # fail until a free name is chosen in `Cargo.toml`. Gated off with `if:
+  # false` for now — flip back to `needs.check-release.outputs.is_release ==
+  # 'true'` once the name is resolved (and a crates.io trusted-publisher
+  # config has been set up for this repository).
+  # ------------------------------------------------------------------
+  publish-crate:
+    name: Publish to crates.io
+    if: false
+    needs: [check-release, upload-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # ratchet:rust-lang/crates-io-auth-action@v1.0.4
+
+      - name: Publish to crates.io
+        run: cargo publish --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# ruSTAR Changelog
+
+<!--
+Release notes are extracted from this file by the release workflow.
+Each released version needs a heading of the form:
+
+    ## [Version X.Y.Z](https://github.com/Psy-Fer/ruSTAR/releases/tag/vX.Y.Z) - YYYY-MM-DD
+
+Sections commonly used: Features, Bug fixes, Other changes.
+-->
+
+## [Unreleased]
+
+Initial release of Rust rewrite of STAR.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,39 @@
 [package]
 name = "ruSTAR"
+# TODO: the `rustar` crate name is already taken on crates.io. A different
+# published name must be chosen before the first `cargo publish` (for example
+# `rustar-aligner` or `rustar-rnaseq`). The `publish-crate` job in
+# `.github/workflows/release.yml` is gated off until this is resolved.
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.88"
+authors = ["James Ferguson"]
+description = "A Rust reimplementation of STAR (Spliced Transcripts Alignment to a Reference), the RNA-seq aligner"
+license = "MIT"
+repository = "https://github.com/Psy-Fer/ruSTAR"
+readme = "README.md"
+keywords = ["bioinformatics", "rna-seq", "aligner", "sequencing", "star"]
+categories = ["command-line-utilities", "science"]
+exclude = [
+    "test/",
+    "tests/",
+    "docs/",
+    ".github/",
+    "Dockerfile",
+    ".dockerignore",
+    "ALIGNMENT_FIXES.md",
+    "BUGFIX_2026-02-09.md",
+    "PERFORMANCE_FIX.md",
+    "PHASE12_COMPLETE.md",
+    "ROADMAP.md",
+    "STAR_SA_RESEARCH.md",
+    "TESTING_SUMMARY.md",
+    "CLAUDE.md",
+]
+
+[[bin]]
+name = "ruSTAR"
+path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -22,3 +54,16 @@ chrono = "0.4"
 tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
+
+[build-dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+
+# Whole-program LTO + a single codegen unit are worth the extra build time
+# for the seed-search and DP-extension inner loops. CI overrides these via
+# `CARGO_PROFILE_RELEASE_LTO=thin` / `CODEGEN_UNITS=16` env vars to keep
+# test-matrix runtime reasonable.
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+strip = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# ---- Build stage ----
+FROM rust:1-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG GIT_SHORT_HASH=unknown
+ARG CPU_TARGET=""
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ src/
+
+RUN HOST_TRIPLE=$(rustc -vV | awk '/^host:/ {print $2}') && \
+    GIT_SHORT_HASH="${GIT_SHORT_HASH}" \
+    cargo build --release --target "$HOST_TRIPLE" \
+        ${CPU_TARGET:+--config "target.'$HOST_TRIPLE'.rustflags=['-C', 'target-cpu=$CPU_TARGET']"} \
+    && strip "target/$HOST_TRIPLE/release/ruSTAR" \
+    && cp "target/$HOST_TRIPLE/release/ruSTAR" /ruSTAR
+
+# ---- Runtime stage ----
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /ruSTAR /usr/local/bin/ruSTAR
+
+ENTRYPOINT ["ruSTAR"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /ruSTAR /usr/local/bin/ruSTAR
+COPY --from=builder /ruSTAR /usr/local/bin/STAR
 
-ENTRYPOINT ["ruSTAR"]
+CMD ["ruSTAR"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /ruSTAR /usr/local/bin/ruSTAR

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,12 @@
 //! Build script — embeds git/build metadata as compile-time environment
-//! variables so the binary can report exactly which commit it was built from.
+//! variables so the binary can report exactly which commit and target it
+//! was built from.
 //!
 //! Embedded variables:
-//! - `GIT_SHORT_HASH`   — short commit hash, or `unknown`
-//! - `BUILD_TIMESTAMP`  — UTC timestamp of the build (ISO-8601)
+//! - `GIT_SHORT_HASH` — short commit hash, or `unknown`
+//! - `BUILD_TIMESTAMP` — UTC timestamp of the build (ISO-8601)
+//! - `VERSION_BODY` — pre-formatted `--version` detail line, e.g.
+//!   `c0892fb - linux/aarch64 (NEON) - built 2026-04-16T21:36:44Z`
 
 use std::process::Command;
 
@@ -26,6 +29,42 @@ fn main() {
 
     let build_ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
     println!("cargo:rustc-env=BUILD_TIMESTAMP={build_ts}");
+
+    // Derive the SIMD level and label from the TARGET being compiled for,
+    // using the `CARGO_CFG_*` env vars Cargo exposes to build scripts.
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_features = std::env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+    let has_feature = |f: &str| target_features.split(',').any(|x| x == f);
+
+    let (target, label) = match target_arch.as_str() {
+        "x86_64" => {
+            if has_feature("avx512f") {
+                ("x86-64-v4", "AVX-512")
+            } else if has_feature("avx2") {
+                ("x86-64-v3", "AVX2")
+            } else {
+                ("x86-64", "baseline")
+            }
+        }
+        "aarch64" => {
+            if has_feature("sve") {
+                ("aarch64-neoverse-v1", "SVE")
+            } else {
+                ("aarch64", "NEON")
+            }
+        }
+        _ => ("unknown", "baseline"),
+    };
+
+    let os = match target_os.as_str() {
+        "linux" | "macos" | "windows" => target_os.as_str(),
+        _ => "unknown",
+    };
+
+    println!(
+        "cargo:rustc-env=VERSION_BODY={git_hash} - {os}/{target} ({label}) - built {build_ts}"
+    );
 
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-env-changed=GIT_SHORT_HASH");

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,32 @@
+//! Build script — embeds git/build metadata as compile-time environment
+//! variables so the binary can report exactly which commit it was built from.
+//!
+//! Embedded variables:
+//! - `GIT_SHORT_HASH`   — short commit hash, or `unknown`
+//! - `BUILD_TIMESTAMP`  — UTC timestamp of the build (ISO-8601)
+
+use std::process::Command;
+
+fn main() {
+    // Prefer the GIT_SHORT_HASH env var (set via Docker build arg or CI),
+    // fall back to running `git rev-parse --short HEAD`.
+    let git_hash = std::env::var("GIT_SHORT_HASH")
+        .ok()
+        .filter(|s| !s.is_empty() && s != "unknown")
+        .unwrap_or_else(|| {
+            Command::new("git")
+                .args(["rev-parse", "--short", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        });
+    println!("cargo:rustc-env=GIT_SHORT_HASH={git_hash}");
+
+    let build_ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={build_ts}");
+
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-env-changed=GIT_SHORT_HASH");
+}

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -2569,7 +2569,7 @@ fn stitch_seeds_core(
     // With anchor-only filtering, this limit is rarely hit, but keep as a safety net.
     const MAX_WA_ENTRIES: usize = 200;
     if wa_entries.len() > MAX_WA_ENTRIES {
-        wa_entries.sort_by(|a, b| b.length.cmp(&a.length));
+        wa_entries.sort_by_key(|wa| std::cmp::Reverse(wa.length));
         wa_entries.truncate(MAX_WA_ENTRIES);
         wa_entries.sort_by(|a, b| a.read_pos.cmp(&b.read_pos).then(b.length.cmp(&a.length)));
     }
@@ -2614,7 +2614,11 @@ fn stitch_seeds_core(
     // This matches stitch_recurse's `do_left_first = !original_is_reverse`.
     // Mismatch budget for second ext carries over from first ext (STAR: scoreSeedBestMM[iS1]).
     {
-        let zero_ext = ExtendResult { extend_len: 0, max_score: 0, n_mismatch: 0 };
+        let zero_ext = ExtendResult {
+            extend_len: 0,
+            max_score: 0,
+            n_mismatch: 0,
+        };
         let do_left_first = !stitch_is_reverse;
         for wa in &mut wa_entries {
             let right_start = wa.read_pos + wa.length;

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,0 +1,188 @@
+//! Runtime CPU feature detection and compatibility guard for SIMD-tuned
+//! binaries. The compile-time build flavour (OS, arch, SIMD level, git hash,
+//! build timestamp) is assembled into `VERSION_BODY` by `build.rs` and read
+//! via `env!("VERSION_BODY")`.
+
+use anyhow::{Result, bail};
+
+// ============================================================================
+// Binary target (compile-time)
+// ============================================================================
+
+/// Returns the microarchitecture level this binary was compiled for.
+pub fn binary_target() -> &'static str {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if cfg!(target_feature = "avx512f") {
+            "x86-64-v4"
+        } else if cfg!(target_feature = "avx2") {
+            "x86-64-v3"
+        } else {
+            "x86-64"
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        if cfg!(target_feature = "sve") {
+            "aarch64-neoverse-v1"
+        } else {
+            "aarch64"
+        }
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        "unknown"
+    }
+}
+
+// ============================================================================
+// Runtime CPU feature detection
+// ============================================================================
+
+/// Detects CPU features available at runtime, ordered most → least capable.
+pub fn detected_features() -> Vec<&'static str> {
+    let mut features = Vec::new();
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("avx512f") {
+            features.push("AVX-512");
+        }
+        if is_x86_feature_detected!("avx2") {
+            features.push("AVX2");
+        }
+        if is_x86_feature_detected!("sse4.2") {
+            features.push("SSE4.2");
+        }
+        if is_x86_feature_detected!("popcnt") {
+            features.push("POPCNT");
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("sve2") {
+            features.push("SVE2");
+        }
+        if std::arch::is_aarch64_feature_detected!("sve") {
+            features.push("SVE");
+        }
+        features.push("NEON");
+    }
+
+    features
+}
+
+// ============================================================================
+// Upgrade hint
+// ============================================================================
+
+/// Returns an upgrade suggestion if a faster binary variant is available for
+/// the current CPU, `None` if this binary is already optimal.
+pub fn upgrade_hint() -> Option<String> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        let has_avx512 = is_x86_feature_detected!("avx512f");
+        let has_avx2 = is_x86_feature_detected!("avx2");
+        let target = binary_target();
+
+        if target == "x86-64" && has_avx512 {
+            return Some("Use the x86-64-v4 build for best performance.".to_string());
+        }
+        if target == "x86-64" && has_avx2 {
+            return Some("Use the x86-64-v3 build for better performance.".to_string());
+        }
+        if target == "x86-64-v3" && has_avx512 {
+            return Some("Use the x86-64-v4 build for best performance.".to_string());
+        }
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        let has_sve = std::arch::is_aarch64_feature_detected!("sve");
+        let target = binary_target();
+
+        if target == "aarch64" && has_sve {
+            return Some("Use the aarch64-neoverse-v1 build for better performance.".to_string());
+        }
+    }
+
+    // No runtime hint for macOS aarch64: the `apple-m1` variant is a compiler
+    // tuning target, not a distinct CPU feature set, so runtime detection
+    // can't tell the two builds apart.
+
+    None
+}
+
+// ============================================================================
+// CPU compatibility guard
+// ============================================================================
+
+/// Checks that the CPU supports the features required by this binary.
+/// Call at the very start of `main()` — before any SIMD code runs — to give
+/// a friendly error instead of a SIGILL crash.
+pub fn check_cpu_compat() -> Result<()> {
+    #[cfg(target_arch = "x86_64")]
+    match binary_target() {
+        "x86-64-v4" if !is_x86_feature_detected!("avx512f") => bail!(
+            "This ruSTAR binary was compiled for x86-64-v4 (AVX-512) but your CPU \
+             does not support AVX-512.\nPlease use the x86-64-v3 or baseline build instead.\n\
+             See: https://github.com/Psy-Fer/ruSTAR#installation"
+        ),
+        "x86-64-v3" if !is_x86_feature_detected!("avx2") => bail!(
+            "This ruSTAR binary was compiled for x86-64-v3 (AVX2) but your CPU \
+             does not support AVX2.\nPlease use the baseline build instead.\n\
+             See: https://github.com/Psy-Fer/ruSTAR#installation"
+        ),
+        _ => {}
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    if binary_target() == "aarch64-neoverse-v1" && !std::arch::is_aarch64_feature_detected!("sve") {
+        bail!(
+            "This ruSTAR binary was compiled for aarch64-neoverse-v1 (SVE) but your CPU \
+             does not support SVE.\nPlease use the baseline aarch64 build instead.\n\
+             See: https://github.com/Psy-Fer/ruSTAR#installation"
+        );
+    }
+
+    Ok(())
+}
+
+/// One-line summary of CPU features detected at runtime. No upgrade hint.
+/// Example: `CPU: AVX2 SSE4.2 POPCNT detected`
+pub fn cpu_detected_line() -> String {
+    let features = detected_features();
+    if features.is_empty() {
+        "CPU: none detected".to_string()
+    } else {
+        format!("CPU: {} detected", features.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_target_is_not_empty() {
+        assert!(!binary_target().is_empty());
+    }
+
+    #[test]
+    fn version_body_contains_expected_fields() {
+        let body = env!("VERSION_BODY");
+        assert!(body.contains(env!("GIT_SHORT_HASH")));
+        assert!(body.contains("built "));
+    }
+
+    #[test]
+    fn cpu_detected_line_starts_with_cpu() {
+        assert!(cpu_detected_line().starts_with("CPU:"));
+    }
+
+    #[test]
+    fn check_cpu_compat_passes_on_current_hardware() {
+        assert!(check_cpu_compat().is_ok());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,12 @@ use crate::params::{Parameters, RunMode};
 pub fn run(params: &Parameters) -> anyhow::Result<()> {
     params.validate()?;
 
-    info!("ruSTAR v{}", env!("CARGO_PKG_VERSION"));
+    info!(
+        "ruSTAR v{} ({} built {})",
+        env!("CARGO_PKG_VERSION"),
+        env!("GIT_SHORT_HASH"),
+        env!("BUILD_TIMESTAMP"),
+    );
     info!("runMode: {}", params.run_mode);
     info!("runThreadN: {}", params.run_thread_n);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod params;
 
 pub mod align;
 pub mod chimeric;
+pub mod cpu;
 pub mod genome;
 pub mod index;
 pub mod io;
@@ -20,12 +21,12 @@ use crate::params::{Parameters, RunMode};
 pub fn run(params: &Parameters) -> anyhow::Result<()> {
     params.validate()?;
 
-    info!(
-        "ruSTAR v{} ({} built {})",
-        env!("CARGO_PKG_VERSION"),
-        env!("GIT_SHORT_HASH"),
-        env!("BUILD_TIMESTAMP"),
-    );
+    info!("ruSTAR {}", env!("CARGO_PKG_VERSION"));
+    info!("{}", env!("VERSION_BODY"));
+    info!("{}", cpu::cpu_detected_line());
+    if let Some(hint) = cpu::upgrade_hint() {
+        info!("{hint}");
+    }
     info!("runMode: {}", params.run_mode);
     info!("runThreadN: {}", params.run_thread_n);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
 use clap::Parser;
 
+use ruSTAR::cpu;
 use ruSTAR::params::Parameters;
 
 fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    cpu::check_cpu_compat()?;
 
     let params = Parameters::parse();
     ruSTAR::run(&params)

--- a/src/params.rs
+++ b/src/params.rs
@@ -229,7 +229,8 @@ impl std::str::FromStr for TwopassMode {
 #[command(
     name = "ruSTAR",
     about = "RNA-seq aligner (Rust reimplementation of STAR)",
-    version
+    version,
+    long_version = concat!(env!("CARGO_PKG_VERSION"), "\n", env!("VERSION_BODY")),
 )]
 pub struct Parameters {
     // ── Run ─────────────────────────────────────────────────────────────

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -406,11 +406,7 @@ impl AlignmentStats {
         let splices_noncanonical = splices[0];
 
         // Computed fields
-        let avg_input_read_length = if total_reads > 0 {
-            read_bases / total_reads
-        } else {
-            0
-        };
+        let avg_input_read_length = read_bases.checked_div(total_reads).unwrap_or(0);
 
         let avg_mapped_length = if uniquely_mapped > 0 {
             mapped_bases as f64 / uniquely_mapped as f64


### PR DESCRIPTION
Hi @Psy-Fer,

Many thanks for working on this project - I'm excited about the possibilities! I was chatting to @zethson and @rob-p about it and thought I'd bring over some of the infra I've built up for my recent RustQC project...

This PR adds GitHub Actions CI and a release pipeline: multi-OS tests, lint/format/audit gates, multi-platform binaries with SIMD variants, multi-arch Docker images to GHCR, and a gated crates.io publish step. No functional changes to ruSTAR itself.

These is basically taken from my recent experience with [RustQC](https://seqeralabs.github.io/RustQC/), you'll see the CI there is almost identical (though that's not pure Rust so has fewer compilation targets). I've been iterating on it a bit there and am quite happy with how it works now.

The release process with this is as follows:

1. Push commits with version number bump to `Cargo.toml`, `Cargo.lock` and updates to `CHANGELOG.md`
2. If CI tests, manually trigger a release via `workflow_dispatch` (dropdown in GitHub Actions web interface, or via the `gh` CLI)
3. Binaries build and docker images build
4. If everything passes, a GitHub release is created which takes the `CHANGELOG` release description
5. The built binaries are attached to the release
6. If all of that is successful, the package is published on crates.io

Note that [rustar](https://crates.io/crates/rustar) is taken on crates.io already, so this'll need updating with a different package name for that to work.

Binaries are build for different platforms and architectures, and also different SIMD variants. For RustQC this seems to squeeze out another 5-10% performance. For bioconda I used a [bash wrapper](https://github.com/bioconda/bioconda-recipes/blob/master/recipes/rustqc/build.sh) that checks available CPU features and uses the best binary accordingly, so it's fully automatic. For non-bioconda it's a case of the user picking the best or falling back to the default.

I added a snippet that prints the git commit, build time and build flavour. I think it's a nice touch for provenance / reproducibility.

```console
$ ./target/release/ruSTAR --version
ruSTAR 0.1.0
c0892fb - macos/aarch64 (NEON) - built 2026-04-16T21:36:44Z
```

In the run log it prints the same and also shows a hint if it thinks that there's a faster binary available for your CPU architecture.

As I write all of this, I realise that I'm throwing quite a lot at you in one PR - let me know if you'd like me to break this out into smaller contributions!

<details>
<summary>Details 🤖 </summary>

### CI (`.github/workflows/ci.yml`) — runs on push to `main` and on every PR
- Test matrix: `linux-x86_64`, `linux-x86_64-v3` (AVX2), `linux-aarch64`, `macos-aarch64`, `windows-x86_64`
- `cargo fmt --check`, `cargo clippy -- -D warnings`
- MSRV check pinned to **1.88** (see below)
- Security audit via `rustsec/audit-check@v2`
- Dependabot configured for `github-actions` and `cargo`

### Release (`.github/workflows/release.yml`) — triggered via `workflow_dispatch`
When fired with a bumped `version` in `Cargo.toml`, it:
1. Reads the version, refuses if the tag already exists or `Cargo.lock` is stale
7. Builds 9 binary variants in parallel — Linux x86_64 (baseline / `x86-64-v3` AVX2 / `x86-64-v4` AVX-512), Linux aarch64 (baseline / `neoverse-v1` SVE), macOS x86_64 / aarch64 / `apple-m1`, Windows x86_64
8. Builds multi-arch Docker images (linux/amd64 + linux/arm64) and three SIMD-tagged images (`avx2`, `avx512`, `sve`) on GHCR
9. Creates the git tag, drafts a GitHub release (with notes pulled from `CHANGELOG.md` if present, else auto-generated), and uploads all binary tarballs
10. Publishes to crates.io (currently gated with `if: false` — the `rustar` name is taken, see `TODO` in `Cargo.toml`)

On a plain `push` to `main` (no version bump) the same jobs build as smoke coverage; tag / release / crates.io publish are all skipped.

### SIMD
No source changes — `-C target-cpu=…` (via `--config target.<triple>.rustflags=[...]`) lets LLVM auto-vectorise hot loops. Baseline binaries stay portable; optimised variants ship alongside with CPU-feature tags.

### Release profile
`lto = "fat"` + `codegen-units = 1` for shipped binaries (hot seed-search / DP-extension paths). CI overrides these via `CARGO_PROFILE_RELEASE_LTO=thin` / `CODEGEN_UNITS=16` to keep the test matrix fast.

### Build metadata & `--version`
`build.rs` reads Cargo's `CARGO_CFG_TARGET_*` at compile time and emits three env vars — `GIT_SHORT_HASH`, `BUILD_TIMESTAMP`, and a pre-formatted `VERSION_BODY` (`<hash> - <os>/<target> (<label>) - built <ts>`) — consumed directly by clap's `long_version` and by the startup log banner. `--version` is now two lines:

```
ruSTAR 0.1.0
<hash> - linux/aarch64 (NEON) - built <ts>
```

`-V` stays short (`ruSTAR 0.1.0`).

### CPU feature detection (`src/cpu.rs`)
- Runtime detection of AVX-512 / AVX2 / SSE4.2 / POPCNT (x86_64) and SVE2 / SVE / NEON (aarch64)
- Upgrade hint when a faster SIMD variant is available for the host CPU (x86-64 → v3 → v4, linux-aarch64 → neoverse-v1). Hint only shown in the startup log, not `--version`
- `check_cpu_compat()` pre-parse guard so a SIMD-tuned binary run on an incompatible CPU exits with a friendly error instead of a SIGILL

The startup banner logs version line, build details, detected CPU features, and (when relevant) the upgrade hint:

```
ruSTAR 0.1.0
<hash> - linux/x86-64 (baseline) - built <ts>
CPU: AVX-512 AVX2 SSE4.2 POPCNT detected
Use the x86-64-v4 build for best performance.
```

### Code changes pulled in along the way
- `rust-version` raised from `1.85` → `1.88`. The codebase already uses `let`-chains in `&&` expressions (`src/io/sam.rs`), stabilised in Rust 1.88, so the 1.85 declaration was incorrect.
- Two lints new in clippy 1.95 fixed as written:
  - `src/align/stitch.rs` — `sort_by(cmp)` → `sort_by_key(Reverse(...))` (`unnecessary_sort_by`)
  - `src/stats.rs` — manual `if n > 0 { a / n } else { 0 }` → `checked_div(n).unwrap_or(0)` (`manual_checked_ops`)
- One `cargo fmt` drift in `src/align/stitch.rs` corrected.
- `.github/workflows/ci.yml` grants `checks: write` so `rustsec/audit-check` can post its annotations.

### One outstanding TODO
`Cargo.toml` flags the `rustar` crates.io name as taken — a free name needs picking before the first publish. The `publish-crate` job is gated behind `if: false` until that's resolved.

</details>
