### PR TITLE
feat(params): accept `--limitGenomeGenerateRAM` for STAR CLI compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,13 @@ fn genome_generate(params: &Parameters) -> anyhow::Result<()> {
             .collect::<Vec<_>>()
     );
 
+    if params.limit_genome_generate_ram != 31_000_000_000 {
+        log::warn!(
+            "--limitGenomeGenerateRAM {} accepted but not enforced; rustar manages genome-generation memory independently",
+            params.limit_genome_generate_ram
+        );
+    }
+
     info!("Building genome index...");
     let index = GenomeIndex::build(params)?;
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -363,6 +363,12 @@ pub struct Parameters {
     #[arg(long = "limitBAMsortRAM", default_value_t = 0)]
     pub limit_bam_sort_ram: u64,
 
+    /// Maximum available RAM (bytes) for genome generation.
+    ///
+    /// Accepted for STAR CLI compatibility. Not currently enforced — rustar uses its own memory management.
+    #[arg(long = "limitGenomeGenerateRAM", default_value_t = 31_000_000_000_u64)]
+    pub limit_genome_generate_ram: u64,
+
     /// Route primary alignment output to stdout instead of a file.
     /// Values: None (default), SAM, BAM_Unsorted, BAM_SortedByCoordinate.
     #[arg(long = "outStd", default_value = "None")]

--- a/src/params.rs
+++ b/src/params.rs
@@ -363,9 +363,7 @@ pub struct Parameters {
     #[arg(long = "limitBAMsortRAM", default_value_t = 0)]
     pub limit_bam_sort_ram: u64,
 
-    /// Maximum available RAM (bytes) for genome generation.
-    ///
-    /// Accepted for STAR CLI compatibility. Not currently enforced — rustar uses its own memory management.
+    /// Maximum RAM (bytes) for genome generation.
     #[arg(long = "limitGenomeGenerateRAM", default_value_t = 31_000_000_000_u64)]
     pub limit_genome_generate_ram: u64,
 


### PR DESCRIPTION
## Summary

Accepts the STAR-compatible `--limitGenomeGenerateRAM` flag at the CLI parser. The value is parsed and stored but not currently enforced — rustar's memory management is independent. This unblocks every wrapper that passes the flag derived from job resources (e.g. nf-core/rnaseq's `STAR_GENOMEGENERATE` Nextflow module).

## Before

```
$ rustar-aligner --runMode genomeGenerate --limitGenomeGenerateRAM 31000000000 ...
error: unexpected argument '--limitGenomeGenerateRAM' found
```

## After

```
$ rustar-aligner --runMode genomeGenerate --limitGenomeGenerateRAM 31000000000 ...
(proceeds; flag value accepted but not enforced)
```

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --lib`
- [x] Smoke test confirms flag is no longer rejected at the CLI parser.

A future PR can wire the value into the suffix-array build path if real RAM capping is desired.

Fixes #25