### PR TITLE
fix(chimeric): create output parent directory before writing

### DIFF
--- a/src/chimeric/output.rs
+++ b/src/chimeric/output.rs
@@ -295,10 +295,6 @@ mod tests {
 
     #[test]
     fn test_chimeric_junction_writer_creates_missing_parent() {
-        // Regression test for #35: when --twopassMode Basic is combined with
-        // --chimSegmentMin > 0 and --outFileNamePrefix doesn't end in `/`, the
-        // chim writer fires before any other output writer creates the parent
-        // directory. The writer must create the parent itself.
         let dir = tempdir().unwrap();
         let prefix_path = dir.path().join("sample.");
         let prefix = prefix_path.to_str().unwrap();

--- a/src/chimeric/output.rs
+++ b/src/chimeric/output.rs
@@ -25,6 +25,12 @@ impl ChimericJunctionWriter {
         let mut path = PathBuf::from(prefix);
         path.push("Chimeric.out.junction");
 
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| Error::io(e, parent))?;
+        }
+
         let file = File::create(&path).map_err(|e| Error::io(e, &path))?;
 
         let writer = BufWriter::new(file);
@@ -285,6 +291,30 @@ mod tests {
         let mut path = PathBuf::from(prefix);
         path.push("Chimeric.out.junction");
         assert!(path.exists());
+    }
+
+    #[test]
+    fn test_chimeric_junction_writer_creates_missing_parent() {
+        // Regression test for #35: when --twopassMode Basic is combined with
+        // --chimSegmentMin > 0 and --outFileNamePrefix doesn't end in `/`, the
+        // chim writer fires before any other output writer creates the parent
+        // directory. The writer must create the parent itself.
+        let dir = tempdir().unwrap();
+        let prefix_path = dir.path().join("sample.");
+        let prefix = prefix_path.to_str().unwrap();
+
+        assert!(!prefix_path.exists(), "parent dir should not exist yet");
+
+        let writer = ChimericJunctionWriter::new(prefix);
+        assert!(
+            writer.is_ok(),
+            "writer should create missing parent dir, got: {:?}",
+            writer.err()
+        );
+
+        let mut path = PathBuf::from(prefix);
+        path.push("Chimeric.out.junction");
+        assert!(path.exists(), "chim output file should exist at {:?}", path);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`rustar-aligner --chimSegmentMin > 0` combined with `--twopassMode Basic` aborts the run when `--outFileNamePrefix` doesn't end in `/`:

```
[INFO  rustar_aligner] Chimeric detection enabled (chimSegmentMin=12)
Error: I/O error: No such file or directory (os error 2) (SAMPLE./Chimeric.out.junction)
```

The chim writer constructs its path as `<prefix>/Chimeric.out.junction` (treating `--outFileNamePrefix` as a directory, per the existing behaviour tracked in #26). In two-pass mode the chim writer fires before any other output writer creates that directory, so the `File::create` call fails. Without two-pass mode the bug is masked because another output writer incidentally creates the dir first.

## Fix

Call `std::fs::create_dir_all` on the parent of the chim output path before opening the file. Minimal, scoped fix - does not change the existing prefix-as-dir behaviour (that's left to #26).

## Test plan

- [x] New unit test asserts the chim writer succeeds when the parent dir doesn't exist
- [x] Existing tests pass
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`

After the fix, `rustar-aligner --chimSegmentMin 12 --twopassMode Basic --outFileNamePrefix sample. ...` completes and writes `sample./Chimeric.out.junction` (with 14-column content matching STAR's format).

Fixes #35