### PR TITLE
fix(transcriptome-bam): write per-record `RG:Z:` tag matching `@RG` header

### DIFF
--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -588,9 +588,6 @@ impl SamWriter {
         let n_alignments = projected.len();
         let mut records = Vec::with_capacity(n_alignments);
 
-        // STAR pushes ATTR_RG onto both outSAMattrOrder and outSAMattrOrderQuant
-        // when --outSAMattrRGline is set; mirror that here so transcriptome
-        // records get the per-record RG:Z:<id> tag matching the @RG header.
         let rg_id_owned = params.primary_rg_id()?;
         let rg_id = rg_id_owned.as_deref();
 
@@ -1534,10 +1531,6 @@ mod tests {
 
     #[test]
     fn test_build_transcriptome_records_stamps_rg_tag() {
-        // Regression test for #32: when --outSAMattrRGline is supplied, every
-        // transcriptome record must carry the RG:Z:<id> tag matching the @RG
-        // header (mirroring STAR's outSAMattrOrderQuant.push_back(ATTR_RG) at
-        // Parameters_samAttributes.cpp:201-205).
         let params = Parameters::parse_from(vec![
             "rustar-aligner",
             "--readFilesIn",
@@ -1610,9 +1603,6 @@ mod tests {
 
     #[test]
     fn test_build_transcriptome_records_no_rg_when_unset() {
-        // When --outSAMattrRGline is not supplied, no RG:Z: tag should be
-        // emitted on transcriptome records (matching the existing genome-BAM
-        // behavior gated on `rg_id.is_some()`).
         let params = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "test.fq"]);
 
         let projected = vec![Transcript {

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -588,6 +588,12 @@ impl SamWriter {
         let n_alignments = projected.len();
         let mut records = Vec::with_capacity(n_alignments);
 
+        // STAR pushes ATTR_RG onto both outSAMattrOrder and outSAMattrOrderQuant
+        // when --outSAMattrRGline is set; mirror that here so transcriptome
+        // records get the per-record RG:Z:<id> tag matching the @RG header.
+        let rg_id_owned = params.primary_rg_id()?;
+        let rg_id = rg_id_owned.as_deref();
+
         for (hit_idx, t) in projected.iter().enumerate() {
             let mut record = RecordBuf::default();
             record.name_mut().replace(read_name.into());
@@ -652,6 +658,8 @@ impl SamWriter {
             if attrs.contains("NM") || attrs.contains("nM") {
                 data.insert(Tag::new(b'n', b'M'), Value::from(t.n_mismatch as i32));
             }
+
+            maybe_insert_rg_tag(&mut record, rg_id);
 
             records.push(record);
         }
@@ -1522,6 +1530,123 @@ mod tests {
         assert_eq!(record.alignment_start().map(|p| usize::from(p)), Some(11)); // 1-based
         // hit_index=1, so NOT secondary
         assert!(!record.flags().is_secondary());
+    }
+
+    #[test]
+    fn test_build_transcriptome_records_stamps_rg_tag() {
+        // Regression test for #32: when --outSAMattrRGline is supplied, every
+        // transcriptome record must carry the RG:Z:<id> tag matching the @RG
+        // header (mirroring STAR's outSAMattrOrderQuant.push_back(ATTR_RG) at
+        // Parameters_samAttributes.cpp:201-205).
+        let params = Parameters::parse_from(vec![
+            "rustar-aligner",
+            "--readFilesIn",
+            "test.fq",
+            "--outSAMattrRGline",
+            "ID:rg0",
+            "SM:sample0",
+        ]);
+
+        let projected = vec![
+            Transcript {
+                chr_idx: 0,
+                genome_start: 0,
+                genome_end: 4,
+                is_reverse: false,
+                exons: vec![],
+                cigar: vec![CigarOp::Match(4)],
+                score: 100,
+                n_mismatch: 0,
+                n_gap: 0,
+                n_junction: 0,
+                junction_motifs: vec![],
+                junction_annotated: vec![],
+                read_seq: vec![0, 1, 2, 3],
+            },
+            Transcript {
+                chr_idx: 0,
+                genome_start: 2,
+                genome_end: 6,
+                is_reverse: true,
+                exons: vec![],
+                cigar: vec![CigarOp::Match(4)],
+                score: 90,
+                n_mismatch: 1,
+                n_gap: 0,
+                n_junction: 0,
+                junction_motifs: vec![],
+                junction_annotated: vec![],
+                read_seq: vec![0, 1, 2, 3],
+            },
+        ];
+
+        let records = SamWriter::build_transcriptome_records(
+            "read1",
+            &[0, 1, 2, 3],
+            &[30, 30, 30, 30],
+            &projected,
+            255,
+            &params,
+            0,
+        )
+        .expect("build_transcriptome_records");
+
+        assert_eq!(records.len(), 2, "expected one record per projected hit");
+        for (i, rec) in records.iter().enumerate() {
+            let rg = rec
+                .data()
+                .get(&Tag::READ_GROUP)
+                .unwrap_or_else(|| panic!("record {i} missing RG tag"));
+            match rg {
+                Value::String(s) => assert_eq!(
+                    s.as_slice(),
+                    b"rg0",
+                    "record {i}: expected RG:Z:rg0, got {s:?}"
+                ),
+                other => panic!("record {i}: RG tag is not a string: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_transcriptome_records_no_rg_when_unset() {
+        // When --outSAMattrRGline is not supplied, no RG:Z: tag should be
+        // emitted on transcriptome records (matching the existing genome-BAM
+        // behavior gated on `rg_id.is_some()`).
+        let params = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "test.fq"]);
+
+        let projected = vec![Transcript {
+            chr_idx: 0,
+            genome_start: 0,
+            genome_end: 4,
+            is_reverse: false,
+            exons: vec![],
+            cigar: vec![CigarOp::Match(4)],
+            score: 100,
+            n_mismatch: 0,
+            n_gap: 0,
+            n_junction: 0,
+            junction_motifs: vec![],
+            junction_annotated: vec![],
+            read_seq: vec![0, 1, 2, 3],
+        }];
+
+        let records = SamWriter::build_transcriptome_records(
+            "read1",
+            &[0, 1, 2, 3],
+            &[30, 30, 30, 30],
+            &projected,
+            255,
+            &params,
+            0,
+        )
+        .expect("build_transcriptome_records");
+
+        assert_eq!(records.len(), 1);
+        assert!(
+            records[0].data().get(&Tag::READ_GROUP).is_none(),
+            "RG tag should not be present when --outSAMattrRGline is unset"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When `--outSAMattrRGline ID:... SM:...` is supplied, rustar writes the `@RG` header to both the genome and transcriptome BAMs. It also writes `RG:Z:<id>` per record on the **genome** BAM - but not on the **transcriptome** BAM. STAR writes `RG:Z:` on every transcriptome record (78886/78886 in the issue's test sample), while rustar wrote 0.

Any tool that splits transcriptome BAM records by read group (multi-sample bundled BAMs, custom QC keyed on RG) silently sees no RG.

## Fix

Add the per-record `RG:Z:` stamp to the transcriptome record builder (paired-end and single-end paths), mirroring the genome record builder. The approach matches STAR's `outSAMattrOrderQuant.push_back(ATTR_RG)` at [`Parameters_samAttributes.cpp:201-205`](https://github.com/alexdobin/STAR/blob/master/source/Parameters_samAttributes.cpp#L201-L205).

`SamWriter::build_transcriptome_records` already receives `&Parameters`, and the existing `maybe_insert_rg_tag` helper (already used by every genome-BAM record builder) is reused unchanged. Both the SE and PE call sites in `lib.rs` go through this single builder, so the fix lands on both paths without touching them.

## Test plan

- [x] New unit test asserts every transcriptome record carries `RG:Z:<id>` when `--outSAMattrRGline ID:foo ...` is supplied
- [x] New unit test asserts no `RG:Z:` tag is emitted when `--outSAMattrRGline` is unset (mirrors genome-BAM gating)
- [x] Existing lib tests pass (385 passed, 0 failed)
- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib -- -D warnings` clean; `cargo clippy --all-targets` has 46 pre-existing errors on `main` unrelated to this change (deprecated `assert_cmd::Command::cargo_bin`, `modulo_one` in integration tests, unused import in `src/chimeric/output.rs`). Picked up separately by [`pa/lint-all-targets`](https://github.com/scverse/rustar-aligner/tree/pa/lint-all-targets).

Fixes #32