### PR TITLE
fix(params): treat `--outFileNamePrefix` as a literal string prefix

### DIFF
--- a/src/chimeric/output.rs
+++ b/src/chimeric/output.rs
@@ -22,8 +22,7 @@ impl ChimericJunctionWriter {
     ///
     /// Creates file: {prefix}Chimeric.out.junction
     pub fn new(prefix: &str) -> Result<Self, Error> {
-        let mut path = PathBuf::from(prefix);
-        path.push("Chimeric.out.junction");
+        let path = PathBuf::from(format!("{prefix}Chimeric.out.junction"));
 
         let file = File::create(&path).map_err(|e| Error::io(e, &path))?;
 
@@ -277,22 +276,38 @@ mod tests {
     #[test]
     fn test_chimeric_junction_writer_creation() {
         let dir = tempdir().unwrap();
-        let prefix = dir.path().to_str().unwrap();
+        let prefix = format!("{}/", dir.path().display());
 
-        let writer = ChimericJunctionWriter::new(prefix);
+        let writer = ChimericJunctionWriter::new(&prefix);
         assert!(writer.is_ok());
 
-        let mut path = PathBuf::from(prefix);
-        path.push("Chimeric.out.junction");
+        let path = PathBuf::from(format!("{prefix}Chimeric.out.junction"));
         assert!(path.exists());
+    }
+
+    #[test]
+    fn test_chimeric_junction_writer_bare_dot_prefix() {
+        let dir = tempdir().unwrap();
+        let prefix = format!("{}/SAMPLE.", dir.path().display());
+
+        let writer = ChimericJunctionWriter::new(&prefix);
+        assert!(writer.is_ok());
+
+        let path = PathBuf::from(format!("{prefix}Chimeric.out.junction"));
+        assert!(path.exists(), "expected {} to exist", path.display());
+        assert!(
+            path.file_name().unwrap().to_str().unwrap() == "SAMPLE.Chimeric.out.junction",
+            "expected literal concatenation, got {}",
+            path.display()
+        );
     }
 
     #[test]
     fn test_write_inter_chromosomal() {
         let dir = tempdir().unwrap();
-        let prefix = dir.path().to_str().unwrap();
+        let prefix = format!("{}/", dir.path().display());
 
-        let mut writer = ChimericJunctionWriter::new(prefix).unwrap();
+        let mut writer = ChimericJunctionWriter::new(&prefix).unwrap();
 
         // Create mock chimeric alignment (chr9 -> chr22, BCR-ABL fusion)
         let donor = ChimericSegment {
@@ -337,8 +352,7 @@ mod tests {
         writer.flush().unwrap();
 
         // Read file and verify
-        let mut path = PathBuf::from(prefix);
-        path.push("Chimeric.out.junction");
+        let path = PathBuf::from(format!("{prefix}Chimeric.out.junction"));
 
         let mut content = String::new();
         File::open(&path)
@@ -369,9 +383,9 @@ mod tests {
     #[test]
     fn test_write_strand_break() {
         let dir = tempdir().unwrap();
-        let prefix = dir.path().to_str().unwrap();
+        let prefix = format!("{}/", dir.path().display());
 
-        let mut writer = ChimericJunctionWriter::new(prefix).unwrap();
+        let mut writer = ChimericJunctionWriter::new(&prefix).unwrap();
 
         // Create mock chimeric alignment (same chr, opposite strands)
         let donor = ChimericSegment {
@@ -416,8 +430,7 @@ mod tests {
         writer.flush().unwrap();
 
         // Read file and verify
-        let mut path = PathBuf::from(prefix);
-        path.push("Chimeric.out.junction");
+        let path = PathBuf::from(format!("{prefix}Chimeric.out.junction"));
 
         let mut content = String::new();
         File::open(&path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ fn align_reads(params: &Parameters) -> anyhow::Result<()> {
     let time_finish = chrono::Local::now();
 
     // Write Log.final.out
-    let log_path = params.out_file_name_prefix.join("Log.final.out");
+    let log_path = params.output_path("Log.final.out");
     if let Some(parent) = log_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -260,7 +260,7 @@ fn align_reads(params: &Parameters) -> anyhow::Result<()> {
 
     // Write ReadsPerGene.out.tab if quantMode GeneCounts was requested.
     if let Some(ref ctx) = quant_ctx {
-        let quant_path = params.out_file_name_prefix.join("ReadsPerGene.out.tab");
+        let quant_path = params.output_path("ReadsPerGene.out.tab");
         ctx.counts.write_output(&quant_path, &ctx.gene_ann)?;
         info!("Wrote {}", quant_path.display());
     }
@@ -291,9 +291,7 @@ fn run_single_pass(
 
     // Open transcriptome BAM writer if requested.
     let mut tr_writer: Option<BamWriter> = if let Some(tidx) = tr.as_ref() {
-        let path = params
-            .out_file_name_prefix
-            .join("Aligned.toTranscriptome.out.bam");
+        let path = params.output_path("Aligned.toTranscriptome.out.bam");
         info!("Writing transcriptome BAM to {}", path.display());
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -310,7 +308,7 @@ fn run_single_pass(
     let is_paired = params.read_files_in.len() == 2;
     let mut unmapped_w1: Option<UnmappedFastqWriter> =
         if params.out_reads_unmapped == OutReadsUnmapped::Fastx {
-            let path = params.out_file_name_prefix.join("Unmapped.out.mate1");
+            let path = params.output_path("Unmapped.out.mate1");
             info!("Writing unmapped reads to {}", path.display());
             Some(UnmappedFastqWriter::create(&path)?)
         } else {
@@ -318,7 +316,7 @@ fn run_single_pass(
         };
     let mut unmapped_w2: Option<UnmappedFastqWriter> =
         if params.out_reads_unmapped == OutReadsUnmapped::Fastx && is_paired {
-            let path = params.out_file_name_prefix.join("Unmapped.out.mate2");
+            let path = params.output_path("Unmapped.out.mate2");
             info!("Writing unmapped mate2 reads to {}", path.display());
             Some(UnmappedFastqWriter::create(&path)?)
         } else {
@@ -357,7 +355,7 @@ fn run_single_pass(
         }
         OutStd::None => match out_type.format {
             OutSamFormat::Sam => {
-                let output_path = params.out_file_name_prefix.join("Aligned.out.sam");
+                let output_path = params.output_path("Aligned.out.sam");
                 info!("Writing SAM to {}", output_path.display());
                 if let Some(parent) = output_path.parent() {
                     std::fs::create_dir_all(parent)?;
@@ -367,11 +365,9 @@ fn run_single_pass(
             OutSamFormat::Bam => {
                 let sorted = out_type.sort_order == Some(OutSamSortOrder::SortedByCoordinate);
                 let output_path = if sorted {
-                    params
-                        .out_file_name_prefix
-                        .join("Aligned.sortedByCoord.out.bam")
+                    params.output_path("Aligned.sortedByCoord.out.bam")
                 } else {
-                    params.out_file_name_prefix.join("Aligned.out.bam")
+                    params.output_path("Aligned.out.bam")
                 };
                 info!("Writing BAM to {}", output_path.display());
                 if let Some(parent) = output_path.parent() {
@@ -429,7 +425,7 @@ fn run_single_pass(
     }
 
     // 5. Write SJ.out.tab file
-    let sj_output_path = params.out_file_name_prefix.join("SJ.out.tab");
+    let sj_output_path = params.output_path("SJ.out.tab");
     if !sj_stats.is_empty() {
         info!(
             "Writing splice junction statistics to {}",
@@ -458,7 +454,7 @@ fn run_two_pass(
     let (sj_stats_pass1, novel_junctions) = run_pass1(index, params)?;
 
     // Write SJ.pass1.out.tab
-    let pass1_path = params.out_file_name_prefix.join("SJ.pass1.out.tab");
+    let pass1_path = params.output_path("SJ.pass1.out.tab");
 
     // Create output directory if it doesn't exist
     if let Some(parent) = pass1_path.parent() {
@@ -858,12 +854,11 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
     // Create chimeric output writer if enabled
     let mut chimeric_writer = if params.chim_segment_min > 0 && params.chim_out_junctions() {
         use crate::chimeric::ChimericJunctionWriter;
-        let prefix = params.out_file_name_prefix.to_str().unwrap_or(".");
         info!(
             "Chimeric detection enabled (chimSegmentMin={})",
             params.chim_segment_min
         );
-        Some(ChimericJunctionWriter::new(prefix)?)
+        Some(ChimericJunctionWriter::new(&params.out_file_name_prefix)?)
     } else {
         None
     };
@@ -1292,12 +1287,11 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
     // Create chimeric output writer if enabled
     let mut chimeric_writer = if params.chim_segment_min > 0 && params.chim_out_junctions() {
         use crate::chimeric::ChimericJunctionWriter;
-        let prefix = params.out_file_name_prefix.to_str().unwrap_or(".");
         info!(
             "Chimeric detection enabled (chimSegmentMin={})",
             params.chim_segment_min
         );
-        Some(ChimericJunctionWriter::new(prefix)?)
+        Some(ChimericJunctionWriter::new(&params.out_file_name_prefix)?)
     } else {
         None
     };

--- a/src/params.rs
+++ b/src/params.rs
@@ -344,7 +344,7 @@ pub struct Parameters {
     // ── Output ──────────────────────────────────────────────────────────
     /// Output file name prefix (including path)
     #[arg(long = "outFileNamePrefix", default_value = "./")]
-    pub out_file_name_prefix: PathBuf,
+    pub out_file_name_prefix: String,
 
     /// Output type: SAM, BAM Unsorted, BAM SortedByCoordinate, None.
     /// Provide as space-separated tokens, e.g. "BAM SortedByCoordinate".
@@ -704,6 +704,11 @@ pub struct Parameters {
 }
 
 impl Parameters {
+    /// Build an output path by concatenating `suffix` onto `out_file_name_prefix`.
+    pub fn output_path(&self, suffix: &str) -> PathBuf {
+        PathBuf::from(format!("{}{suffix}", self.out_file_name_prefix))
+    }
+
     /// Parse the raw `--outSAMtype` tokens into a structured `OutSamType`.
     pub fn out_sam_type(&self) -> Result<OutSamType, String> {
         match self
@@ -1010,7 +1015,7 @@ mod tests {
         assert_eq!(p.read_map_number, -1);
         assert_eq!(p.clip5p_nbases, 0);
         assert_eq!(p.clip3p_nbases, 0);
-        assert_eq!(p.out_file_name_prefix, PathBuf::from("./"));
+        assert_eq!(p.out_file_name_prefix, "./");
         assert_eq!(p.out_sam_type_raw, vec!["SAM".to_string()]);
         assert_eq!(p.out_sam_strand_field, "None");
         assert_eq!(p.out_sam_attributes, vec!["Standard".to_string()]);
@@ -1147,7 +1152,7 @@ mod tests {
             sam_type.sort_order,
             Some(OutSamSortOrder::SortedByCoordinate)
         );
-        assert_eq!(p.out_file_name_prefix, PathBuf::from("/out/sample1_"));
+        assert_eq!(p.out_file_name_prefix, "/out/sample1_");
         assert_eq!(p.out_filter_multimap_nmax, 20);
         assert_eq!(p.align_intron_max, 1_000_000);
         assert_eq!(p.sjdb_gtf_file, Some(PathBuf::from("gencode.gtf")));
@@ -1487,5 +1492,51 @@ mod tests {
             "3",
         ]);
         assert_eq!(p.align_sj_stitch_mismatch_nmax, vec![1, -1, 2, 3]);
+    }
+
+    #[test]
+    fn output_path_bare_dot_prefix() {
+        let p = parse(&["--readFilesIn", "r.fq", "--outFileNamePrefix", "SAMPLE."]);
+        assert_eq!(p.out_file_name_prefix, "SAMPLE.");
+        assert_eq!(
+            p.output_path("Aligned.out.bam"),
+            PathBuf::from("SAMPLE.Aligned.out.bam")
+        );
+        assert_eq!(
+            p.output_path("Log.final.out"),
+            PathBuf::from("SAMPLE.Log.final.out")
+        );
+    }
+
+    #[test]
+    fn output_path_trailing_slash_prefix() {
+        let p = parse(&["--readFilesIn", "r.fq", "--outFileNamePrefix", "out/"]);
+        assert_eq!(
+            p.output_path("Aligned.out.bam"),
+            PathBuf::from("out/Aligned.out.bam")
+        );
+    }
+
+    #[test]
+    fn output_path_default_prefix() {
+        let p = parse(&["--readFilesIn", "r.fq"]);
+        assert_eq!(
+            p.output_path("Aligned.out.bam"),
+            PathBuf::from("./Aligned.out.bam")
+        );
+    }
+
+    #[test]
+    fn output_path_path_with_underscore() {
+        let p = parse(&[
+            "--readFilesIn",
+            "r.fq",
+            "--outFileNamePrefix",
+            "/out/sample1_",
+        ]);
+        assert_eq!(
+            p.output_path("Aligned.out.bam"),
+            PathBuf::from("/out/sample1_Aligned.out.bam")
+        );
     }
 }

--- a/tests/alignment_features.rs
+++ b/tests/alignment_features.rs
@@ -799,3 +799,87 @@ fn test_two_pass_mode() {
         "expected at least 1 alignment record, got {record_count}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Test 9 — bare-dot prefix is treated as a literal string prefix (issue #26)
+//
+// STAR treats `--outFileNamePrefix SAMPLE.` as a literal prefix concatenated
+// onto each output filename (SAMPLE.Aligned.out.bam at the top level), not as
+// a directory name. This test asserts rustar-aligner matches that behaviour.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_bare_dot_prefix_is_literal_string() {
+    let tmpdir = TempDir::new().unwrap();
+    let genome = build_genome();
+    let fasta = write_fasta(&tmpdir, &genome);
+
+    let genome_dir = tmpdir.path().join("genome");
+    build_index(&fasta, &genome_dir, "7", None);
+
+    let fastq_path = tmpdir.path().join("reads.fq");
+    {
+        let mut f = fs::File::create(&fastq_path).unwrap();
+        for i in 0..50usize {
+            let start = 100 + i * 100;
+            let seq = &genome[start..start + 50];
+            writeln!(f, "@read{}", i + 1).unwrap();
+            f.write_all(seq).unwrap();
+            writeln!(f).unwrap();
+            writeln!(f, "+").unwrap();
+            writeln!(f, "{}", "I".repeat(50)).unwrap();
+        }
+    }
+
+    let run_dir = tmpdir.path().join("bare_dot_run");
+    fs::create_dir_all(&run_dir).unwrap();
+    // SAMPLE. is a bare-dot prefix; STAR writes SAMPLE.Aligned.out.bam at the top level.
+    let prefix = format!("{}/SAMPLE.", run_dir.display());
+
+    Command::cargo_bin("rustar-aligner")
+        .unwrap()
+        .args([
+            "--runMode",
+            "alignReads",
+            "--genomeDir",
+            genome_dir.to_str().unwrap(),
+            "--readFilesIn",
+            fastq_path.to_str().unwrap(),
+            "--outSAMtype",
+            "BAM",
+            "Unsorted",
+            "--outFileNamePrefix",
+            &prefix,
+        ])
+        .assert()
+        .success();
+
+    let bam_path = run_dir.join("SAMPLE.Aligned.out.bam");
+    let log_path = run_dir.join("SAMPLE.Log.final.out");
+    let bam_as_dir = run_dir.join("SAMPLE.").join("Aligned.out.bam");
+
+    assert!(
+        bam_path.exists(),
+        "expected literal prefix file at {}, but it was not created",
+        bam_path.display()
+    );
+    assert!(
+        log_path.exists(),
+        "expected literal prefix file at {}, but it was not created",
+        log_path.display()
+    );
+    assert!(
+        !bam_as_dir.exists(),
+        "bare-dot prefix was treated as a directory: {} should not exist",
+        bam_as_dir.display()
+    );
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&bam_path).unwrap());
+    let _header = reader.read_header().expect("BAM header readable");
+    let mut count = 0usize;
+    for rec in reader.records() {
+        rec.expect("valid BAM record");
+        count += 1;
+    }
+    assert!(count >= 1, "expected at least 1 BAM record, got {count}");
+}

--- a/tests/alignment_features.rs
+++ b/tests/alignment_features.rs
@@ -828,8 +828,7 @@ fn test_bare_dot_prefix_is_literal_string() {
     // SAMPLE. is a bare-dot prefix; STAR writes SAMPLE.Aligned.out.bam at the top level.
     let prefix = format!("{}/SAMPLE.", run_dir.display());
 
-    Command::cargo_bin("rustar-aligner")
-        .unwrap()
+    cargo_bin_cmd!("rustar-aligner")
         .args([
             "--runMode",
             "alignReads",


### PR DESCRIPTION
## Summary

`--outFileNamePrefix SAMPLE.` (or any value not ending in `/`) was treated as a directory by rustar - outputs landed in `SAMPLE./Aligned.out.bam` etc. STAR concatenates the prefix straight onto each output filename: `SAMPLE.Aligned.out.bam` at the top level. Every STAR wrapper assumes the latter convention; the directory behaviour breaks the output-glob convention nf-core/rnaseq and most STAR Snakemake wrappers rely on.

Root cause: `out_file_name_prefix` was typed as `PathBuf` and joined via `.push("Aligned.out.bam")`. That always treats the existing value as a directory component.

## Fix

Change the type to `String` and concatenate at every output-write site:

```rust
// before:
let mut path = PathBuf::from(&params.out_file_name_prefix);
path.push("Aligned.out.bam");

// after:
let path = PathBuf::from(format!("{}Aligned.out.bam", params.out_file_name_prefix));
```

A small `Parameters::output_path("Aligned.out.bam")` helper does this concatenation once so the call sites stay readable. The chimeric junction writer (which already took the prefix as `&str`) was using `PathBuf::push` internally and is fixed the same way.

Trailing-slash prefixes (`out/`) still work - `format!` produces `out/Aligned.out.bam`, a valid path. The bare-dot case now produces `SAMPLE.Aligned.out.bam` at the top level, matching STAR.

## Test plan

- [x] New unit tests on `Parameters::output_path` cover bare-dot, trailing-slash, default, and path-with-underscore prefixes
- [x] New integration test `test_bare_dot_prefix_is_literal_string` runs the binary with `<run_dir>/SAMPLE.` and asserts `SAMPLE.Aligned.out.bam` + `SAMPLE.Log.final.out` land at the top level and that no `SAMPLE./` directory is created
- [x] New chimeric writer unit test `test_chimeric_junction_writer_bare_dot_prefix` covers the same case for `Chimeric.out.junction`
- [x] Existing integration tests (`tests/alignment_features.rs`, `tests/phase9_threading.rs`, `tests/transcriptome_sam.rs`) all already use trailing-slash prefixes and continue to pass unchanged
- [x] `cargo build`
- [x] `cargo clippy --lib -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` - all 402 tests pass (388 lib + 9 alignment_features + 4 phase9_threading + 1 transcriptome_sam)

After this fix, no downstream wrapper needs the workaround that flattens `SAMPLE./` back to STAR-style filenames after the run.

Fixes #26