### PR TITLE
chore: clippy borrow and infallible functions

### DIFF
--- a/src/align/read_align.rs
+++ b/src/align/read_align.rs
@@ -311,7 +311,7 @@ pub fn align_read(
             junction_db,
             params.align_transcripts_per_window_nmax,
             debug_name,
-        )?;
+        );
         if debug_read {
             eprintln!(
                 "[DEBUG {}] Cluster[{}]: {} transcripts from DP",
@@ -814,7 +814,7 @@ pub fn align_paired_read(
             params.align_transcripts_per_window_nmax,
             params.align_mates_gap_max.into(),
             debug_name,
-        )?;
+        );
 
         for wt in &wts {
             let split_result =

--- a/src/align/score.rs
+++ b/src/align/score.rs
@@ -206,7 +206,7 @@ impl AlignmentScorer {
                         genome_pos
                     };
                     let motif = self.detect_splice_motif(donor, len, genome);
-                    let score = self.score_splice_junction(&motif);
+                    let score = self.score_splice_junction(motif);
                     (
                         score,
                         GapType::SpliceJunction {
@@ -235,7 +235,7 @@ impl AlignmentScorer {
                                 rc_donor
                             };
                             let motif = self.detect_splice_motif(donor, del_len, genome);
-                            let score = self.score_splice_junction(&motif);
+                            let score = self.score_splice_junction(motif);
                             (
                                 score,
                                 GapType::SpliceJunction {
@@ -389,7 +389,7 @@ impl AlignmentScorer {
                     donor_sa
                 };
                 let motif = self.detect_splice_motif(donor_fwd, del as u32, genome);
-                let motif_score = self.score_splice_junction(&motif);
+                let motif_score = self.score_splice_junction(motif);
                 let score2 = score1 + motif_score;
 
                 if score2 > max_score2 {
@@ -493,7 +493,7 @@ impl AlignmentScorer {
                     donor_sa
                 };
                 best_motif = self.detect_splice_motif(donor_fwd, del as u32, genome);
-                best_motif_score = self.score_splice_junction(&best_motif);
+                best_motif_score = self.score_splice_junction(best_motif);
             }
         }
 
@@ -518,7 +518,7 @@ impl AlignmentScorer {
     }
 
     /// Score a splice junction based on motif
-    pub(crate) fn score_splice_junction(&self, motif: &SpliceMotif) -> i32 {
+    pub(crate) fn score_splice_junction(&self, motif: SpliceMotif) -> i32 {
         match motif {
             SpliceMotif::GtAg | SpliceMotif::CtAc => self.score_gap,
             SpliceMotif::GcAg | SpliceMotif::CtGc => self.score_gap_gcag,
@@ -695,7 +695,7 @@ mod tests {
         let motif = scorer.detect_splice_motif(2, 12, &genome);
         assert_eq!(motif, SpliceMotif::GtAg);
 
-        let score = scorer.score_splice_junction(&motif);
+        let score = scorer.score_splice_junction(motif);
         assert_eq!(score, 0); // Canonical
     }
 
@@ -738,7 +738,7 @@ mod tests {
         let motif = scorer.detect_splice_motif(2, 12, &genome);
         assert_eq!(motif, SpliceMotif::GcAg);
 
-        let score = scorer.score_splice_junction(&motif);
+        let score = scorer.score_splice_junction(motif);
         assert_eq!(score, -4);
     }
 
@@ -781,7 +781,7 @@ mod tests {
         let motif = scorer.detect_splice_motif(2, 12, &genome);
         assert_eq!(motif, SpliceMotif::AtAc);
 
-        let score = scorer.score_splice_junction(&motif);
+        let score = scorer.score_splice_junction(motif);
         assert_eq!(score, -8);
     }
 
@@ -822,7 +822,7 @@ mod tests {
         let motif = scorer.detect_splice_motif(2, 12, &genome);
         assert_eq!(motif, SpliceMotif::NonCanonical);
 
-        let score = scorer.score_splice_junction(&motif);
+        let score = scorer.score_splice_junction(motif);
         assert_eq!(score, -8);
     }
 
@@ -1017,7 +1017,7 @@ mod tests {
         let motif = scorer.detect_splice_motif(2, 12, &genome_ctac);
         assert_eq!(motif, SpliceMotif::CtAc);
         // Should score same as canonical GT-AG
-        assert_eq!(scorer.score_splice_junction(&motif), 0);
+        assert_eq!(scorer.score_splice_junction(motif), 0);
 
         // CT-GC motif: (1,3,2,1) — reverse complement of GC-AG
         let seq_ctgc = vec![
@@ -1030,7 +1030,7 @@ mod tests {
         let genome_ctgc = make_test_genome(&seq_ctgc);
         let motif = scorer.detect_splice_motif(2, 12, &genome_ctgc);
         assert_eq!(motif, SpliceMotif::CtGc);
-        assert_eq!(scorer.score_splice_junction(&motif), -4);
+        assert_eq!(scorer.score_splice_junction(motif), -4);
 
         // GT-AT motif: (2,3,0,3) — reverse complement of AT-AC
         let seq_gtat = vec![
@@ -1043,7 +1043,7 @@ mod tests {
         let genome_gtat = make_test_genome(&seq_gtat);
         let motif = scorer.detect_splice_motif(2, 12, &genome_gtat);
         assert_eq!(motif, SpliceMotif::GtAt);
-        assert_eq!(scorer.score_splice_junction(&motif), -8);
+        assert_eq!(scorer.score_splice_junction(motif), -8);
     }
 
     #[test]

--- a/src/align/seed.rs
+++ b/src/align/seed.rs
@@ -69,7 +69,7 @@ impl Seed {
             false,
             debug_name,
             &mut seeds,
-        )?;
+        );
 
         // Cap check between directions (STAR: seedPerReadNmax applies across both)
         if seeds.len() >= params.seed_per_read_nmax {
@@ -87,7 +87,7 @@ impl Seed {
             true,
             debug_name,
             &mut seeds,
-        )?;
+        );
 
         // STAR's storeAligns dedup: same rStart + same Length → skip duplicate.
         // Multiple istart chains can find the same (read_pos, length, direction) seed.
@@ -217,7 +217,7 @@ fn search_direction_sparse(
     is_rc: bool,
     debug_name: &str,
     seeds: &mut Vec<Seed>,
-) -> Result<(), Error> {
+) {
     let read_len = read_seq.len();
 
     // STAR (ReadAlign_mapOneRead.cpp lines 41-42):
@@ -262,7 +262,7 @@ fn search_direction_sparse(
             }
 
             let result =
-                find_seed_at_position(read_seq, pos, index, min_seed_length, false, params)?;
+                find_seed_at_position(read_seq, pos, index, min_seed_length, false, params);
 
             if !debug_name.is_empty() {
                 let dir = if is_rc { "RC" } else { "FWD" };
@@ -292,7 +292,7 @@ fn search_direction_sparse(
                 seeds.push(seed);
 
                 if seeds.len() >= params.seed_per_read_nmax {
-                    return Ok(());
+                    return;
                 }
             }
 
@@ -300,8 +300,6 @@ fn search_direction_sparse(
             // Remaining-length check at loop top: stop when < seedMapMin bases remain
         }
     }
-
-    Ok(())
 }
 
 /// Find a seed starting at a specific position in the read.
@@ -317,12 +315,12 @@ fn find_seed_at_position(
     min_seed_length: usize,
     is_reverse: bool,
     params: &Parameters,
-) -> Result<MmpResult, Error> {
+) -> MmpResult {
     if read_pos >= read_seq.len() {
-        return Ok(MmpResult {
+        return MmpResult {
             seed: None,
             advance: 1,
-        });
+        };
     }
 
     // Extract k-mer for SAindex lookup
@@ -330,10 +328,10 @@ fn find_seed_at_position(
     let remaining = read_seq.len() - read_pos;
 
     if remaining < min_seed_length {
-        return Ok(MmpResult {
+        return MmpResult {
             seed: None,
             advance: 1,
-        });
+        };
     }
 
     // Build k-mer for SAindex lookup, stopping at first N base
@@ -351,10 +349,10 @@ fn find_seed_at_position(
     }
 
     if actual_len == 0 {
-        return Ok(MmpResult {
+        return MmpResult {
             seed: None,
             advance: 1,
-        }); // First base is N
+        }; // First base is N
     }
 
     // Hierarchical SAindex lookup (STAR's maxMappableLength2strands approach).
@@ -367,17 +365,17 @@ fn find_seed_at_position(
         .hierarchical_lookup(kmer_idx, actual_len as u32, n_sa);
 
     let Some((sa_start, sa_end, matched_level, bounds_tight)) = result else {
-        return Ok(MmpResult {
+        return MmpResult {
             seed: None,
             advance: 1,
-        });
+        };
     };
 
     if sa_start >= sa_end {
-        return Ok(MmpResult {
+        return MmpResult {
             seed: None,
             advance: 1,
-        });
+        };
     }
 
     // STAR short-circuit (maxMappableLength2strands.cpp):
@@ -407,14 +405,14 @@ fn find_seed_at_position(
     // Uses narrowed range (accurate loci count, not overestimated k-mer range)
     let n_loci = narrowed_end - narrowed_start;
     if n_loci > params.seed_multimap_nmax {
-        return Ok(MmpResult {
+        return MmpResult {
             seed: None,
             advance,
-        });
+        };
     }
 
     if match_length >= min_seed_length {
-        Ok(MmpResult {
+        MmpResult {
             seed: Some(Seed {
                 read_pos,
                 length: match_length,
@@ -425,12 +423,12 @@ fn find_seed_at_position(
                 mate_id: 2, // Single-end default
             }),
             advance,
-        })
+        }
     } else {
-        Ok(MmpResult {
+        MmpResult {
             seed: None,
             advance,
-        })
+        }
     }
 }
 
@@ -1023,7 +1021,7 @@ mod tests {
         // Count how many seeds dense would produce (every position that has a match)
         let mut dense_count = 0;
         for read_pos in 0..read.len() {
-            let result = find_seed_at_position(&read, read_pos, &index, 4, false, &params).unwrap();
+            let result = find_seed_at_position(&read, read_pos, &index, 4, false, &params);
             if result.seed.is_some() {
                 dense_count += 1;
             }
@@ -1031,8 +1029,7 @@ mod tests {
         // Also count R→L dense seeds
         let rc_read = reverse_complement_read(&read);
         for rc_pos in 0..rc_read.len() {
-            let result =
-                find_seed_at_position(&rc_read, rc_pos, &index, 4, false, &params).unwrap();
+            let result = find_seed_at_position(&rc_read, rc_pos, &index, 4, false, &params);
             if result.seed.is_some() {
                 dense_count += 1;
             }

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -2,7 +2,6 @@
 use crate::align::score::AlignmentScorer;
 use crate::align::seed::Seed;
 use crate::align::transcript::{CigarOpExt as _, Transcript};
-use crate::error::Error;
 use crate::index::GenomeIndex;
 use noodles::sam::alignment::record::cigar;
 
@@ -1500,7 +1499,7 @@ pub fn stitch_seeds(
     read_seq: &[u8],
     index: &GenomeIndex,
     scorer: &AlignmentScorer,
-) -> Result<Vec<Transcript>, Error> {
+) -> Vec<Transcript> {
     stitch_seeds_with_jdb(cluster, read_seq, index, scorer, None, 1)
 }
 
@@ -1519,7 +1518,7 @@ pub fn stitch_seeds_with_jdb(
     scorer: &AlignmentScorer,
     junction_db: Option<&crate::junction::SpliceJunctionDb>,
     max_transcripts_per_window: usize,
-) -> Result<Vec<Transcript>, Error> {
+) -> Vec<Transcript> {
     stitch_seeds_with_jdb_debug(
         cluster,
         read_seq,
@@ -2469,7 +2468,7 @@ pub(crate) fn stitch_seeds_with_jdb_debug(
     junction_db: Option<&crate::junction::SpliceJunctionDb>,
     max_transcripts_per_window: usize,
     debug_read_name: &str,
-) -> Result<Vec<Transcript>, Error> {
+) -> Vec<Transcript> {
     let (working_transcripts, stitch_cluster, stitch_is_reverse, stitch_read) = stitch_seeds_core(
         cluster,
         read_seq,
@@ -2479,7 +2478,7 @@ pub(crate) fn stitch_seeds_with_jdb_debug(
         max_transcripts_per_window,
         0,
         debug_read_name,
-    )?;
+    );
 
     // Finalize working transcripts → Transcript (filtering by overhang+repeat check)
     let mut transcripts: Vec<Transcript> = Vec::with_capacity(working_transcripts.len());
@@ -2583,7 +2582,7 @@ pub(crate) fn stitch_seeds_with_jdb_debug(
     });
     transcripts.truncate(max_transcripts_per_window);
 
-    Ok(transcripts)
+    transcripts
 }
 
 /// Shared core: preprocessing + recursive stitcher, returns working transcripts + context.
@@ -2597,7 +2596,7 @@ pub(crate) fn stitch_seeds_core(
     max_transcripts_per_window: usize,
     align_mates_gap_max: u64,
     debug_read_name: &str,
-) -> Result<(Vec<WorkingTranscript>, SeedCluster, bool, Vec<u8>), Error> {
+) -> (Vec<WorkingTranscript>, SeedCluster, bool, Vec<u8>) {
     let debug = !debug_read_name.is_empty();
 
     // Include ALL seeds (anchor and non-anchor) in the stitcher.
@@ -2730,12 +2729,12 @@ pub(crate) fn stitch_seeds_core(
     }
 
     if wa_entries.is_empty() {
-        return Ok((
+        return (
             Vec::new(),
             stitch_cluster,
             stitch_is_reverse,
             stitch_read_owned,
-        ));
+        );
     }
 
     if debug {
@@ -2924,12 +2923,12 @@ pub(crate) fn stitch_seeds_core(
         );
     }
 
-    Ok((
+    (
         working_transcripts,
         stitch_cluster,
         stitch_is_reverse,
         stitch_read_owned,
-    ))
+    )
 }
 
 #[cfg(test)]

--- a/src/chimeric/detect.rs
+++ b/src/chimeric/detect.rs
@@ -82,7 +82,7 @@ impl<'a> ChimericDetector<'a> {
             } else {
                 Some(&index.junction_db)
             };
-            let clip_trs = stitch_seeds_with_jdb(&clusters[0], clip_seq, index, &scorer, jdb, 1)?;
+            let clip_trs = stitch_seeds_with_jdb(&clusters[0], clip_seq, index, &scorer, jdb, 1);
 
             let Some(clip_tr_raw) = clip_trs.into_iter().next() else {
                 continue;
@@ -269,7 +269,7 @@ impl<'a> ChimericDetector<'a> {
             } else {
                 Some(&index.junction_db)
             };
-            let clip_trs = stitch_seeds_with_jdb(&clusters[0], clip_seq, index, &scorer, jdb, 1)?;
+            let clip_trs = stitch_seeds_with_jdb(&clusters[0], clip_seq, index, &scorer, jdb, 1);
 
             let Some(clip_tr_raw) = clip_trs.into_iter().next() else {
                 continue;
@@ -425,8 +425,8 @@ impl<'a> ChimericDetector<'a> {
         use crate::align::score::AlignmentScorer;
         let scorer = AlignmentScorer::from_params(self.params);
 
-        let transcripts1 = stitch_seeds(cluster1, read_seq, index, &scorer)?;
-        let transcripts2 = stitch_seeds(cluster2, read_seq, index, &scorer)?;
+        let transcripts1 = stitch_seeds(cluster1, read_seq, index, &scorer);
+        let transcripts2 = stitch_seeds(cluster2, read_seq, index, &scorer);
 
         if transcripts1.is_empty() || transcripts2.is_empty() {
             return Ok(None);

--- a/src/genome/mod.rs
+++ b/src/genome/mod.rs
@@ -344,11 +344,11 @@ mod tests {
     use std::io::Write;
     use tempfile::NamedTempFile;
 
-    fn make_params(fasta_paths: Vec<std::path::PathBuf>, bin_nbits: u32) -> Parameters {
+    fn make_params(fasta_paths: &[std::path::PathBuf], bin_nbits: u32) -> Parameters {
         use clap::Parser;
         let mut args = vec!["rustar-aligner", "--runMode", "genomeGenerate"];
 
-        for path in &fasta_paths {
+        for path in fasta_paths {
             args.push("--genomeFastaFiles");
             args.push(path.to_str().unwrap());
         }
@@ -365,7 +365,7 @@ mod tests {
         writeln!(file, ">chr1").unwrap();
         writeln!(file, "ACGT").unwrap(); // 4 bases
 
-        let params = make_params(vec![file.path().to_path_buf()], 3); // bin_size = 8
+        let params = make_params(&[file.path().to_path_buf()], 3); // bin_size = 8
         let genome = Genome::from_fasta(&params).unwrap();
 
         // Padding formula: n=4, then ((4+1)/8 + 1)*8 = (0+1)*8 = 8
@@ -401,7 +401,7 @@ mod tests {
         writeln!(file, ">chr2").unwrap();
         writeln!(file, "TT").unwrap(); // 2 bases
 
-        let params = make_params(vec![file.path().to_path_buf()], 2); // bin_size = 4
+        let params = make_params(&[file.path().to_path_buf()], 2); // bin_size = 4
         let genome = Genome::from_fasta(&params).unwrap();
 
         // chr1 starts at 0, length 2
@@ -431,7 +431,7 @@ mod tests {
         writeln!(file, ">test").unwrap();
         writeln!(file, "ACGTN").unwrap(); // A=0, C=1, G=2, T=3, N=4
 
-        let params = make_params(vec![file.path().to_path_buf()], 3); // bin_size = 8
+        let params = make_params(&[file.path().to_path_buf()], 3); // bin_size = 8
         let genome = Genome::from_fasta(&params).unwrap();
 
         let n = genome.n_genome as usize;
@@ -460,7 +460,7 @@ mod tests {
         writeln!(file, ">chr2").unwrap();
         writeln!(file, "TTT").unwrap();
 
-        let params = make_params(vec![file.path().to_path_buf()], 2); // bin_size = 4
+        let params = make_params(&[file.path().to_path_buf()], 2); // bin_size = 4
         let genome = Genome::from_fasta(&params).unwrap();
 
         // chr1: positions 0-2 (starts at 0, length 3)
@@ -488,7 +488,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, ">chr1").unwrap();
         writeln!(file, "ACGT").unwrap();
-        let params = make_params(vec![file.path().to_path_buf()], 3);
+        let params = make_params(&[file.path().to_path_buf()], 3);
         let mut genome = Genome::from_fasta(&params).unwrap();
         assert_eq!(genome.n_genome, 8);
 
@@ -518,7 +518,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, ">chr1").unwrap();
         writeln!(file, "ACGT").unwrap();
-        let params = make_params(vec![file.path().to_path_buf()], 3);
+        let params = make_params(&[file.path().to_path_buf()], 3);
         let mut genome = Genome::from_fasta(&params).unwrap();
         let before = genome.sequence.clone();
         let before_n = genome.n_genome;

--- a/src/junction/gtf.rs
+++ b/src/junction/gtf.rs
@@ -103,7 +103,7 @@ fn parse_gtf_line(line: &str) -> Result<GtfRecord, Error> {
         .ok_or_else(|| Error::Gtf("Empty strand field".to_string()))?;
 
     // Parse attributes (semicolon-separated key-value pairs)
-    let attributes = parse_attributes(fields[8])?;
+    let attributes = parse_attributes(fields[8]);
 
     Ok(GtfRecord {
         seqname,
@@ -118,7 +118,7 @@ fn parse_gtf_line(line: &str) -> Result<GtfRecord, Error> {
 /// Parse GTF attributes field
 ///
 /// Format: key1 "value1"; key2 "value2";
-fn parse_attributes(attr_str: &str) -> Result<HashMap<String, String>, Error> {
+fn parse_attributes(attr_str: &str) -> HashMap<String, String> {
     let mut attributes = HashMap::new();
 
     for pair in attr_str.split(';') {
@@ -142,7 +142,7 @@ fn parse_attributes(attr_str: &str) -> Result<HashMap<String, String>, Error> {
         attributes.insert(key, value);
     }
 
-    Ok(attributes)
+    attributes
 }
 
 /// Extract junctions from exon records, grouping by `transcript_tag`.
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn test_parse_attributes() {
         let attr = r#"gene_id "ENSG001"; transcript_id "ENST001"; gene_name "MYC";"#;
-        let attrs = parse_attributes(attr).unwrap();
+        let attrs = parse_attributes(attr);
 
         assert_eq!(attrs.get("gene_id"), Some(&"ENSG001".to_string()));
         assert_eq!(attrs.get("transcript_id"), Some(&"ENST001".to_string()));
@@ -252,7 +252,7 @@ mod tests {
     #[test]
     fn test_parse_attributes_no_trailing_semicolon() {
         let attr = r#"gene_id "ENSG001"; transcript_id "ENST001""#;
-        let attrs = parse_attributes(attr).unwrap();
+        let attrs = parse_attributes(attr);
 
         assert_eq!(attrs.get("gene_id"), Some(&"ENSG001".to_string()));
         assert_eq!(attrs.get("transcript_id"), Some(&"ENST001".to_string()));

--- a/src/junction/sjdb_insert.rs
+++ b/src/junction/sjdb_insert.rs
@@ -380,16 +380,16 @@ mod tests {
     // Callers who only exercise compute_shifts / prepare_junction don't
     // need a valid reverse complement; we fill the RC half with padding.
     fn make_test_genome(forward: Vec<u8>) -> Genome {
-        let n = forward.len() as u64;
-        let mut seq = vec![5u8; (n * 2) as usize];
-        seq[..forward.len()].copy_from_slice(&forward);
+        let n = forward.len();
+        let mut seq = forward;
+        seq.extend(std::iter::repeat_n(5u8, n));
         Genome {
             sequence: seq,
-            n_genome: n,
+            n_genome: n as u64,
             n_chr_real: 1,
             chr_name: vec!["chr1".to_string()],
-            chr_length: vec![n],
-            chr_start: vec![0, n],
+            chr_length: vec![n as u64],
+            chr_start: vec![0, n as u64],
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,11 @@
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
     clippy::must_use_candidate,
-    clippy::needless_pass_by_value,
     clippy::redundant_closure_for_method_calls,
     clippy::similar_names,
     clippy::too_many_lines,
-    clippy::trivially_copy_pass_by_ref,
     clippy::uninlined_format_args,
-    clippy::unnecessary_wraps
+    // trailing comment because of https://github.com/rust-lang/rustfmt/issues/3277
 )]
 // These should stay disabled
 #![allow(


### PR DESCRIPTION
adapt the APIs of some internal functions to no longer
- take things by value if they don’t actually use them up
- return results if they don’t fail