### PR TITLE
chore: unify parsing and validation

### DIFF
--- a/src/align/read_align.rs
+++ b/src/align/read_align.rs
@@ -1474,12 +1474,11 @@ mod tests {
     use crate::index::packed_array::PackedArray;
     use crate::index::sa_index::SaIndex;
     use crate::index::suffix_array::SuffixArray;
-    use clap::Parser;
     use noodles::sam::alignment::record::cigar;
 
-    fn make_test_params() -> Parameters {
+    fn default_params() -> Parameters {
         // Parse empty args to get default parameters
-        Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap()
+        Parameters::parse_from(["rustar-aligner", "--readFilesIn", "test.fq"])
     }
 
     fn make_test_index() -> GenomeIndex {
@@ -1578,7 +1577,7 @@ mod tests {
     #[test]
     fn test_align_read_no_seeds() {
         let index = make_test_index();
-        let params = make_test_params();
+        let params = default_params();
 
         // Read with all N's (no seeds possible)
         let read_seq = vec![4, 4, 4, 4, 4, 4, 4, 4, 4, 4];
@@ -1596,7 +1595,7 @@ mod tests {
     #[test]
     fn test_transcript_filtering_score() {
         let index = make_test_index();
-        let mut params = make_test_params();
+        let mut params = default_params();
         params.out_filter_score_min = 50;
 
         // Would need actual seeds and alignment to test this properly
@@ -1609,7 +1608,7 @@ mod tests {
     #[test]
     fn test_transcript_filtering_mismatch() {
         let index = make_test_index();
-        let mut params = make_test_params();
+        let mut params = default_params();
         params.out_filter_mismatch_nmax = 2;
 
         let read_seq = vec![0, 1, 2, 3]; // ACGT
@@ -1620,7 +1619,7 @@ mod tests {
     #[test]
     fn test_transcript_multimap_limit() {
         let index = make_test_index();
-        let mut params = make_test_params();
+        let mut params = default_params();
         params.out_filter_multimap_nmax = 5;
 
         let read_seq = vec![0, 1, 2, 3]; // ACGT
@@ -1634,7 +1633,7 @@ mod tests {
     #[test]
     fn test_align_paired_read_no_seeds() {
         let index = make_test_index();
-        let params = make_test_params();
+        let params = default_params();
 
         // Both mates with all N's
         let mate1 = vec![4, 4, 4, 4, 4, 4, 4, 4];
@@ -1653,7 +1652,7 @@ mod tests {
         use crate::align::transcript::Exon;
         use cigar::op::{Kind, Op};
 
-        let params = make_test_params();
+        let params = default_params();
 
         // Create two transcripts on same chromosome
         let t1 = Transcript {
@@ -1709,7 +1708,7 @@ mod tests {
         use crate::align::transcript::Exon;
         use cigar::op::{Kind, Op};
 
-        let mut params = make_test_params();
+        let mut params = default_params();
         params.align_mates_gap_max = 100;
 
         let t1 = Transcript {
@@ -2055,7 +2054,7 @@ mod tests {
     fn test_align_paired_both_unmapped() {
         // Both mates are all N's → both unmapped → empty Vec
         let index = make_test_index();
-        let params = make_test_params();
+        let params = default_params();
 
         let mate1 = vec![4, 4, 4, 4, 4, 4, 4, 4];
         let mate2 = vec![4, 4, 4, 4, 4, 4, 4, 4];

--- a/src/align/score.rs
+++ b/src/align/score.rs
@@ -621,6 +621,8 @@ pub enum GapType {
 
 #[cfg(test)]
 mod tests {
+    use crate::params::Parameters;
+
     use super::*;
 
     fn make_test_genome(seq: &[u8]) -> Genome {
@@ -1051,8 +1053,7 @@ mod tests {
         // When alignIntronMax=0 (default), scorer uses u32::MAX (no limit) — STAR-faithful.
         // STAR's stitchAlignToTranscript.cpp: `if (Del>alignIntronMax && alignIntronMax>0)`
         // meaning alignIntronMax=0 disables the check entirely.
-        use clap::Parser;
-        let params = crate::params::Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "reads.fq"]);
         assert_eq!(params.align_intron_max, 0);
         let scorer = AlignmentScorer::from_params(&params);
         assert_eq!(scorer.align_intron_max, u32::MAX);
@@ -1061,13 +1062,13 @@ mod tests {
     #[test]
     fn test_align_intron_max_custom() {
         // Custom alignIntronMax should be passed through directly
-        use clap::Parser;
-        let params = crate::params::Parameters::try_parse_from(vec![
+        let params = Parameters::parse_from([
             "rustar-aligner",
+            "--readFilesIn",
+            "reads.fq",
             "--alignIntronMax",
             "100000",
-        ])
-        .unwrap();
+        ]);
         assert_eq!(params.align_intron_max, 100_000);
         let scorer = AlignmentScorer::from_params(&params);
         assert_eq!(scorer.align_intron_max, 100_000);

--- a/src/align/seed.rs
+++ b/src/align/seed.rs
@@ -662,7 +662,6 @@ fn find_mult_range(
 mod tests {
     use super::*;
     use crate::params::Parameters;
-    use clap::Parser;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -703,13 +702,17 @@ mod tests {
             .collect()
     }
 
+    fn params(args: &[&str]) -> Parameters {
+        let mut full_args = vec!["rustar-aligner", "--readFilesIn", "reads.fq"];
+        full_args.extend_from_slice(args);
+        Parameters::parse_from(full_args)
+    }
+
     #[test]
     fn find_exact_match() {
         let index = make_test_index("ACGTACGT");
         let read = encode_sequence("ACGT");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&["--runMode", "alignReads"]);
 
         let seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
 
@@ -725,9 +728,7 @@ mod tests {
     fn min_seed_length_filter() {
         let index = make_test_index("AAAAAAAA");
         let read = encode_sequence("AAA");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         // With min_seed_length=4, should find nothing (read is only 3bp)
         let seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
@@ -742,9 +743,7 @@ mod tests {
     fn no_match() {
         let index = make_test_index("ACAC");
         let read = encode_sequence("GGGG");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let seeds = Seed::find_seeds(&read, &index, 2, &params, "").unwrap();
 
@@ -756,9 +755,7 @@ mod tests {
     fn get_genome_positions() {
         let index = make_test_index("ACGTACGT");
         let read = encode_sequence("ACGT");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
         assert!(!seeds.is_empty());
@@ -777,9 +774,7 @@ mod tests {
     fn test_single_end_mate_id() {
         let index = make_test_index("ACGTACGT");
         let read = encode_sequence("ACGT");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
         assert!(!seeds.is_empty());
@@ -795,9 +790,7 @@ mod tests {
         let index = make_test_index("ACGTACGTTTGGCCAA");
         let mate1 = encode_sequence("ACGT");
         let mate2 = encode_sequence("TTGG");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let seeds = Seed::find_paired_seeds(&mate1, &mate2, &index, 4, &params).unwrap();
 
@@ -824,9 +817,7 @@ mod tests {
         let index = make_test_index("ACGTACGT");
         let mate1 = encode_sequence("ACGT");
         let mate2 = encode_sequence("ACGT");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let seeds = Seed::find_paired_seeds(&mate1, &mate2, &index, 4, &params).unwrap();
 
@@ -875,9 +866,7 @@ mod tests {
         let index = make_test_index("AACCTTGG");
         // Read is RC of genome: CCAAGGTT
         let read = encode_sequence("CCAAGGTT");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
 
@@ -916,15 +905,7 @@ mod tests {
         // Test that combined L→R + R→L respects seedPerReadNmax
         let index = make_test_index("ACGTACGTACGTACGT");
         let read = encode_sequence("ACGTACGT");
-
-        let args = vec![
-            "rustar-aligner",
-            "--runMode",
-            "alignReads",
-            "--seedPerReadNmax",
-            "3",
-        ];
-        let params = Parameters::parse_from(args);
+        let params = params(&["--seedPerReadNmax", "3"]);
 
         let seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
         assert!(
@@ -976,9 +957,7 @@ mod tests {
         // original read coordinates: read_pos = original_read_len - rc_pos - length
         let index = make_test_index("AACCTTGG");
         let read = encode_sequence("CCAAGGTT");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
 
@@ -1008,12 +987,9 @@ mod tests {
         // than the old dense (every-position) search
         let genome_seq = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
         let index = make_test_index(genome_seq);
-
         // Use a read that's long enough for multiple start positions
         let read = encode_sequence("ACGTACGTACGTACGTACGTACGT"); // 24bp
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let sparse_seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
 
@@ -1048,9 +1024,7 @@ mod tests {
         // RC(read) = AACCTTGG matches forward genome
         let index = make_test_index("AACCTTGG");
         let read = encode_sequence("CCAAGGTT");
-
-        let args = vec!["rustar-aligner", "--runMode", "alignReads"];
-        let params = Parameters::parse_from(args);
+        let params = params(&[]);
 
         let seeds = Seed::find_seeds(&read, &index, 4, &params, "").unwrap();
 

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -3019,10 +3019,8 @@ mod tests {
         ];
 
         // Bin-based windowing with default parameters
-        let params = {
-            use clap::Parser;
-            crate::params::Parameters::parse_from(vec!["rustar-aligner"])
-        };
+        let params =
+            crate::params::Parameters::parse_from(["rustar-aligner", "--readFilesIn", "reads.fq"]);
         let clusters = cluster_seeds(&seeds, &index, &params, 150, false);
 
         // With empty SA ranges, no clusters will be created

--- a/src/chimeric/detect.rs
+++ b/src/chimeric/detect.rs
@@ -987,7 +987,6 @@ mod tests {
     use crate::index::sa_index::SaIndex;
     use crate::index::suffix_array::SuffixArray;
     use crate::junction::SpliceJunctionDb;
-    use clap::Parser;
     use noodles::sam::alignment::record::cigar;
 
     /// Minimal two-chromosome genome for chimeric tests.
@@ -1184,11 +1183,16 @@ mod tests {
 
     // --- detect_inter_mate_chimeric tests ---
 
+    fn params(args: &[&str]) -> Parameters {
+        let mut full_args = vec!["rustar-aligner", "--readFilesIn", "reads.fq"];
+        full_args.extend_from_slice(args);
+        Parameters::parse_from(full_args)
+    }
+
     #[test]
     fn test_inter_mate_chimeric_concordant_returns_none() {
         // Normal FR pair on the same chromosome, close together → not chimeric
-        let params =
-            Parameters::try_parse_from(vec!["rustar-aligner", "--chimSegmentMin", "10"]).unwrap();
+        let params = params(&["--chimSegmentMin", "10"]);
         let index = make_test_index();
 
         let t1 = make_transcript(0, 10, 60, false); // mate1 forward
@@ -1201,8 +1205,7 @@ mod tests {
 
     #[test]
     fn test_inter_mate_chimeric_different_chromosomes() {
-        let params =
-            Parameters::try_parse_from(vec!["rustar-aligner", "--chimSegmentMin", "10"]).unwrap();
+        let params = params(&["--chimSegmentMin", "10"]);
         let index = make_test_index();
 
         let t1 = make_transcript(0, 10, 60, false); // mate1 chr0
@@ -1219,8 +1222,7 @@ mod tests {
     #[test]
     fn test_inter_mate_chimeric_same_strand() {
         // Both mates forward on the same chromosome → chimeric (strand break)
-        let params =
-            Parameters::try_parse_from(vec!["rustar-aligner", "--chimSegmentMin", "10"]).unwrap();
+        let params = params(&["--chimSegmentMin", "10"]);
         let index = make_test_index();
 
         let t1 = make_transcript(0, 10, 60, false); // mate1 forward
@@ -1234,8 +1236,7 @@ mod tests {
     #[test]
     fn test_inter_mate_chimeric_too_far() {
         // Opposite-strand pair but >1Mb apart → chimeric
-        let params =
-            Parameters::try_parse_from(vec!["rustar-aligner", "--chimSegmentMin", "10"]).unwrap();
+        let params = params(&["--chimSegmentMin", "10"]);
         let index = make_test_index();
 
         // Use large positions — out-of-bounds for sequence but score.rs guards handle this
@@ -1250,8 +1251,7 @@ mod tests {
     #[test]
     fn test_inter_mate_chimeric_segment_too_short() {
         // chimSegmentMin=100 but segments are only 20bp → None
-        let params =
-            Parameters::try_parse_from(vec!["rustar-aligner", "--chimSegmentMin", "100"]).unwrap();
+        let params = params(&["--chimSegmentMin", "100"]);
         let index = make_test_index();
 
         let t1 = make_transcript(0, 10, 30, false);
@@ -1264,8 +1264,7 @@ mod tests {
 
     #[test]
     fn test_inter_mate_chimeric_empty_exons_returns_none() {
-        let params =
-            Parameters::try_parse_from(vec!["rustar-aligner", "--chimSegmentMin", "10"]).unwrap();
+        let params = params(&["--chimSegmentMin", "10"]);
         let index = make_test_index();
         let read_seq = vec![0u8; 50];
 
@@ -1328,8 +1327,7 @@ mod tests {
     #[test]
     fn test_detect_chimeric_old_no_chimera_single_transcript() {
         // Only one transcript → no partner → None
-        let params =
-            Parameters::try_parse_from(vec!["rustar-aligner", "--chimSegmentMin", "20"]).unwrap();
+        let params = params(&["--chimSegmentMin", "20"]);
         let index = make_test_index();
         let read_len = 100usize;
         let t1 = make_clipped_transcript(0, 50, false, read_len, 0, 0);
@@ -1350,8 +1348,7 @@ mod tests {
     fn test_detect_chimeric_old_inter_chr_pair() {
         // Primary: covers read[0..80] on chr0; secondary: covers read[80..100] on chr1.
         // With chimSegmentMin=20, scoreDropMax=20, scoreSeparation=10, this should produce a chimera.
-        let params = Parameters::try_parse_from(vec![
-            "rustar-aligner",
+        let params = params(&[
             "--chimSegmentMin",
             "15",
             "--chimScoreDropMax",
@@ -1360,8 +1357,7 @@ mod tests {
             "10",
             "--chimJunctionOverhangMin",
             "10",
-        ])
-        .unwrap();
+        ]);
         let index = make_test_index();
         let read_len = 100usize;
         // Primary: chr0, read[0..80], right clip = 20
@@ -1386,14 +1382,7 @@ mod tests {
     #[test]
     fn test_detect_chimeric_old_segment_too_short() {
         // Segments are too short after chimSegmentMin filter
-        let params = Parameters::try_parse_from(vec![
-            "rustar-aligner",
-            "--chimSegmentMin",
-            "50",
-            "--chimScoreDropMax",
-            "100",
-        ])
-        .unwrap();
+        let params = params(&["--chimSegmentMin", "50", "--chimScoreDropMax", "100"]);
         let index = make_test_index();
         let read_len = 100usize;
         let t_main = make_clipped_transcript(0, 0, false, read_len, 0, 60); // 40 bp → < 50
@@ -1410,16 +1399,14 @@ mod tests {
         // Score drop is too large: chimScoreDropMax=5 means combined_score + 5 >= read_len=100
         // combined_score = 50 + 50 - 0 = 100, 100 + 5 = 105 >= 100 → should pass
         // But with drop=5, score = 40+40=80, 80+5=85 < 100 → should fail
-        let params = Parameters::try_parse_from(vec![
-            "rustar-aligner",
+        let params = params(&[
             "--chimSegmentMin",
             "20",
             "--chimScoreDropMax",
             "5",
             "--chimScoreSeparation",
             "200", // suppress uniqueness filter
-        ])
-        .unwrap();
+        ]);
         let index = make_test_index();
         let read_len = 100usize;
         let t_main = make_clipped_transcript(0, 0, false, read_len, 0, 40); // 60 bp aligned

--- a/src/genome/mod.rs
+++ b/src/genome/mod.rs
@@ -345,7 +345,6 @@ mod tests {
     use tempfile::NamedTempFile;
 
     fn make_params(fasta_paths: &[std::path::PathBuf], bin_nbits: u32) -> Parameters {
-        use clap::Parser;
         let mut args = vec!["rustar-aligner", "--runMode", "genomeGenerate"];
 
         for path in fasta_paths {

--- a/src/index/io.rs
+++ b/src/index/io.rs
@@ -273,7 +273,6 @@ fn load_sa_index(genome_dir: &Path, gstrand_bit: u32) -> Result<SaIndex, Error> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
     use std::io::Write;
     use tempfile::NamedTempFile;
 

--- a/src/index/sa_index.rs
+++ b/src/index/sa_index.rs
@@ -243,7 +243,6 @@ impl SaIndex {
 mod tests {
     use super::*;
     use crate::params::Parameters;
-    use clap::Parser;
     use std::io::Write;
     use tempfile::NamedTempFile;
 

--- a/src/index/suffix_array.rs
+++ b/src/index/suffix_array.rs
@@ -208,7 +208,6 @@ fn compare_suffixes(
 mod tests {
     use super::*;
     use crate::params::Parameters;
-    use clap::Parser;
     use std::io::Write;
     use tempfile::NamedTempFile;
 

--- a/src/io/bam.rs
+++ b/src/io/bam.rs
@@ -474,14 +474,14 @@ mod tests {
         }
     }
 
-    fn create_test_params() -> Parameters {
-        Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "test.fq"])
+    fn default_params() -> Parameters {
+        Parameters::parse_from(["rustar-aligner", "--readFilesIn", "test.fq"])
     }
 
     #[test]
     fn test_bam_writer_creation() {
         let genome = create_test_genome();
-        let params = create_test_params();
+        let params = default_params();
         let temp_file = NamedTempFile::new().unwrap();
 
         let writer = BamWriter::create(temp_file.path(), &genome, &params);
@@ -491,7 +491,7 @@ mod tests {
     #[test]
     fn test_bam_unmapped_write() {
         let genome = create_test_genome();
-        let params = create_test_params();
+        let params = default_params();
         let temp_file = NamedTempFile::new().unwrap();
 
         let mut writer = BamWriter::create(temp_file.path(), &genome, &params).unwrap();
@@ -519,7 +519,7 @@ mod tests {
         use cigar::op::{Kind, Op};
 
         let genome = create_test_genome();
-        let params = create_test_params();
+        let params = default_params();
         let temp_file = NamedTempFile::new().unwrap();
 
         let mut writer = BamWriter::create(temp_file.path(), &genome, &params).unwrap();
@@ -592,7 +592,7 @@ mod tests {
         let tr_idx = TranscriptomeIndex::from_gtf_exons(&exons, &genome).unwrap();
         assert_eq!(tr_idx.n_transcripts(), 1);
 
-        let params = create_test_params();
+        let params = default_params();
         let temp_file = NamedTempFile::new().unwrap();
         let writer = BamWriter::create_transcriptome(temp_file.path(), &tr_idx, &params);
         assert!(
@@ -608,7 +608,7 @@ mod tests {
     #[test]
     fn test_bam_batch_write() {
         let genome = create_test_genome();
-        let params = create_test_params();
+        let params = default_params();
         let temp_file = NamedTempFile::new().unwrap();
 
         let mut writer = BamWriter::create(temp_file.path(), &genome, &params).unwrap();
@@ -641,7 +641,7 @@ mod tests {
     #[test]
     fn test_bam_compression_level_zero() {
         let genome = create_test_genome();
-        let mut params = create_test_params();
+        let mut params = default_params();
         params.out_bam_compression = 0;
         let temp_file = NamedTempFile::new().unwrap();
         let writer = BamWriter::create(temp_file.path(), &genome, &params);
@@ -654,7 +654,7 @@ mod tests {
     #[test]
     fn test_sorted_bam_limit_ram_unlimited() {
         let genome = create_test_genome();
-        let mut params = create_test_params();
+        let mut params = default_params();
         params.limit_bam_sort_ram = 0; // unlimited
         let temp_file = NamedTempFile::new().unwrap();
         let mut writer = SortedBamWriter::create(temp_file.path(), &genome, &params).unwrap();
@@ -668,7 +668,7 @@ mod tests {
     #[test]
     fn test_sorted_bam_limit_ram_exceeded() {
         let genome = create_test_genome();
-        let mut params = create_test_params();
+        let mut params = default_params();
         params.limit_bam_sort_ram = 1; // 1 byte — will be exceeded by any records
         let temp_file = NamedTempFile::new().unwrap();
         let mut writer = SortedBamWriter::create(temp_file.path(), &genome, &params).unwrap();

--- a/src/io/bam.rs
+++ b/src/io/bam.rs
@@ -460,7 +460,6 @@ impl SortedBamStdoutWriter {
 mod tests {
     use super::*;
     use crate::align::transcript::{Exon, Transcript};
-    use clap::Parser;
     use noodles::sam::alignment::record::cigar;
     use tempfile::NamedTempFile;
 

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1288,7 +1288,6 @@ mod tests {
     use super::*;
     use crate::align::score::SpliceMotif;
     use crate::genome::Genome;
-    use clap::Parser;
     use noodles::sam::alignment::record::cigar;
     use tempfile::NamedTempFile;
 

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1321,7 +1321,7 @@ mod tests {
     #[test]
     fn test_build_sam_header() {
         let genome = make_test_genome();
-        let params = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "test.fq"]);
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "test.fq"]);
 
         let header = build_sam_header(&genome, &params).unwrap();
 
@@ -1335,7 +1335,7 @@ mod tests {
     #[test]
     fn test_build_sam_header_with_rg() {
         let genome = make_test_genome();
-        let params = Parameters::parse_from(vec![
+        let params = Parameters::parse_from([
             "rustar-aligner",
             "--readFilesIn",
             "test.fq",
@@ -1365,7 +1365,7 @@ mod tests {
         use std::io::Read;
 
         let genome = make_test_genome();
-        let params = Parameters::parse_from(vec![
+        let params = Parameters::parse_from([
             "rustar-aligner",
             "--readFilesIn",
             "test.fq",
@@ -1430,7 +1430,7 @@ mod tests {
     #[test]
     fn test_sam_writer_creation() {
         let genome = make_test_genome();
-        let params = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "test.fq"]);
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "test.fq"]);
 
         let tmpfile = NamedTempFile::new().unwrap();
         let writer = SamWriter::create(tmpfile.path(), &genome, &params);
@@ -1491,7 +1491,7 @@ mod tests {
         let mate1_qual = vec![30, 30, 30, 30];
         let mate2_seq = vec![3, 2, 1, 0]; // TGCA
         let mate2_qual = vec![30, 30, 30, 30];
-        let params = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "t.fq"]);
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "t.fq"]);
 
         let records = SamWriter::build_paired_unmapped_records(
             "read1",
@@ -1958,7 +1958,7 @@ mod tests {
     fn test_secondary_flag() {
         use cigar::op::{Kind, Op};
         let genome = make_test_genome();
-        let params = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "test.fq"]);
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "test.fq"]);
 
         let transcripts = vec![
             Transcript {
@@ -2280,7 +2280,7 @@ mod tests {
     fn test_out_sam_mult_nmax() {
         use cigar::op::{Kind, Op};
         let genome = make_test_genome();
-        let params = Parameters::parse_from(vec![
+        let params = Parameters::parse_from([
             "rustar-aligner",
             "--readFilesIn",
             "test.fq",
@@ -3269,7 +3269,7 @@ mod tests {
         use crate::params::Parameters;
 
         // Standard
-        let p = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "r.fq"]);
+        let p = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "r.fq"]);
         let attrs = p.sam_attribute_set();
         assert_eq!(attrs.len(), 5);
         assert!(attrs.contains("NH"));
@@ -3279,7 +3279,7 @@ mod tests {
         assert!(attrs.contains("nM"));
 
         // All
-        let p = Parameters::parse_from(vec![
+        let p = Parameters::parse_from([
             "rustar-aligner",
             "--readFilesIn",
             "r.fq",
@@ -3295,7 +3295,7 @@ mod tests {
         assert!(attrs.contains("jI"));
 
         // None
-        let p = Parameters::parse_from(vec![
+        let p = Parameters::parse_from([
             "rustar-aligner",
             "--readFilesIn",
             "r.fq",
@@ -3306,7 +3306,7 @@ mod tests {
         assert!(attrs.is_empty());
 
         // Explicit subset
-        let p = Parameters::parse_from(vec![
+        let p = Parameters::parse_from([
             "rustar-aligner",
             "--readFilesIn",
             "r.fq",
@@ -3388,8 +3388,7 @@ mod tests {
         use cigar::op::{Kind, Op};
 
         let genome = make_test_genome();
-        let params =
-            Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "r1.fq", "r2.fq"]);
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "r1.fq", "r2.fq"]);
 
         let mapped_transcript = Transcript {
             chr_idx: 0,
@@ -3458,8 +3457,7 @@ mod tests {
         use cigar::op::{Kind, Op};
 
         let genome = make_test_genome();
-        let params =
-            Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "r1.fq", "r2.fq"]);
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "r1.fq", "r2.fq"]);
 
         let mapped_transcript = Transcript {
             chr_idx: 0,
@@ -3541,8 +3539,7 @@ mod tests {
         use cigar::op::{Kind, Op};
 
         let genome = make_test_genome();
-        let params =
-            Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "r1.fq", "r2.fq"]);
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "r1.fq", "r2.fq"]);
 
         let mapped_transcript = Transcript {
             chr_idx: 0,

--- a/src/junction/mod.rs
+++ b/src/junction/mod.rs
@@ -223,7 +223,6 @@ pub fn filter_novel_junctions(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
 
     #[test]
     fn test_junction_db_empty() {
@@ -361,9 +360,7 @@ mod tests {
         // Add an annotated junction (should be excluded from novel list)
         sj_stats.record_junction(0, 500, 600, 1, SpliceMotif::GtAg, true, 20, true);
 
-        // Create minimal params for testing
-        let params = Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
-
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "reads.fq"]);
         let novel_junctions = filter_novel_junctions(&sj_stats, &params);
 
         // Should only get the high-quality novel junction
@@ -390,7 +387,7 @@ mod tests {
             sj_stats.record_junction(0, 300, 400, 1, SpliceMotif::NonCanonical, true, 35, false);
         }
 
-        let params = Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
+        let params = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "reads.fq"]);
         let novel_junctions = filter_novel_junctions(&sj_stats, &params);
 
         // Only the 35-overhang junction should pass (30bp minimum for non-canonical)

--- a/src/junction/sj_output.rs
+++ b/src/junction/sj_output.rs
@@ -370,7 +370,13 @@ pub(crate) fn encode_motif(motif: SpliceMotif) -> u8 {
 
 #[cfg(test)]
 mod tests {
+    use crate::params::Parameters;
+
     use super::*;
+
+    fn default_params() -> Parameters {
+        Parameters::parse_from(["rustar-aligner", "--readFilesIn", "reads.fq"])
+    }
 
     #[test]
     fn test_sj_stats_new() {
@@ -504,7 +510,6 @@ mod tests {
 
     #[test]
     fn test_write_output() {
-        use clap::Parser;
         use tempfile::NamedTempFile;
 
         let stats = SpliceJunctionStats::new();
@@ -522,7 +527,7 @@ mod tests {
             chr_name: vec!["chr1".to_string()],
         };
 
-        let params = crate::params::Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
+        let params = default_params();
 
         let output_file = NamedTempFile::new().unwrap();
         stats
@@ -562,7 +567,6 @@ mod tests {
 
     #[test]
     fn test_sj_filter_noncanonical_needs_high_overhang() {
-        use clap::Parser;
         use tempfile::NamedTempFile;
 
         let stats = SpliceJunctionStats::new();
@@ -583,8 +587,7 @@ mod tests {
             chr_name: vec!["chr1".to_string()],
         };
 
-        let params = crate::params::Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
-
+        let params = default_params();
         let output_file = NamedTempFile::new().unwrap();
         stats
             .write_output(output_file.path(), &genome, &params)
@@ -602,7 +605,6 @@ mod tests {
 
     #[test]
     fn test_sj_filter_annotated_bypasses_filters() {
-        use clap::Parser;
         use tempfile::NamedTempFile;
 
         let stats = SpliceJunctionStats::new();
@@ -619,8 +621,7 @@ mod tests {
             chr_name: vec!["chr1".to_string()],
         };
 
-        let params = crate::params::Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
-
+        let params = default_params();
         let output_file = NamedTempFile::new().unwrap();
         stats
             .write_output(output_file.path(), &genome, &params)
@@ -635,8 +636,6 @@ mod tests {
 
     #[test]
     fn test_compute_surviving_junctions_basic() {
-        use clap::Parser;
-
         let stats = SpliceJunctionStats::new();
 
         // High-quality canonical junction (should survive)
@@ -650,7 +649,7 @@ mod tests {
         // Low-count canonical junction (unique=0 < 1)
         stats.record_junction(0, 500, 600, 1, SpliceMotif::GtAg, false, 20, false);
 
-        let params = crate::params::Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
+        let params = default_params();
         let surviving = stats.compute_surviving_junctions(&params);
 
         // Only the first junction should survive
@@ -666,14 +665,12 @@ mod tests {
 
     #[test]
     fn test_compute_surviving_junctions_annotated_bypass() {
-        use clap::Parser;
-
         let stats = SpliceJunctionStats::new();
 
         // Annotated junction with terrible stats (should still survive)
         stats.record_junction(0, 100, 200, 1, SpliceMotif::NonCanonical, false, 1, true);
 
-        let params = crate::params::Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
+        let params = default_params();
         let surviving = stats.compute_surviving_junctions(&params);
 
         assert_eq!(surviving.len(), 1);
@@ -681,7 +678,6 @@ mod tests {
 
     #[test]
     fn test_compute_surviving_matches_write_output() {
-        use clap::Parser;
         use tempfile::NamedTempFile;
 
         let stats = SpliceJunctionStats::new();
@@ -702,8 +698,7 @@ mod tests {
             chr_name: vec!["chr1".to_string()],
         };
 
-        let params = crate::params::Parameters::try_parse_from(vec!["rustar-aligner"]).unwrap();
-
+        let params = default_params();
         // compute_surviving_junctions should return same set as what write_output writes
         let surviving = stats.compute_surviving_junctions(&params);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,6 @@ use crate::params::{Parameters, RunMode};
 
 /// Top-level dispatcher. Called from `main()` after CLI parsing.
 pub fn run(params: &Parameters) -> anyhow::Result<()> {
-    params.validate()?;
-
     info!("rustar-aligner {}", env!("CARGO_PKG_VERSION"));
     info!("{}", env!("VERSION_BODY"));
     info!("{}", cpu::cpu_detected_line());
@@ -184,9 +182,9 @@ fn align_reads(params: &Parameters) -> anyhow::Result<()> {
     info!("Starting read alignment...");
 
     // Configure Rayon thread pool based on --runThreadN
-    if params.run_thread_n > 1 {
+    if usize::from(params.run_thread_n) > 1 {
         rayon::ThreadPoolBuilder::new()
-            .num_threads(params.run_thread_n)
+            .num_threads(params.run_thread_n.into())
             .build_global()
             .map_err(|e| {
                 error::Error::Parameter(format!("Failed to configure thread pool: {e}"))
@@ -348,9 +346,7 @@ fn run_single_pass(
     // 4. Route to SAM or BAM output based on --outSAMtype / --outStd
     use crate::params::{OutSamSortOrder, OutStd};
 
-    let out_type = params
-        .out_sam_type()
-        .map_err(|e| anyhow::anyhow!("Invalid --outSAMtype: {e}"))?;
+    let out_type = &params.out_sam_type;
 
     // Build boxed writer — stdout takes precedence over file output.
     let mut writer: Box<dyn AlignmentWriter> = match params.out_std {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use clap::Parser;
-
 use rustar_aligner::cpu;
 use rustar_aligner::params::Parameters;
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -1413,7 +1413,8 @@ mod tests {
 
     #[test]
     fn rg_line_missing_id_prefix_errors() {
-        let err = try_parse(&["--readFilesIn", "r.fq", "--outSAMattrRGline", "SM:oops"]).unwrap_err();
+        let err =
+            try_parse(&["--readFilesIn", "r.fq", "--outSAMattrRGline", "SM:oops"]).unwrap_err();
         assert!(err.to_string().contains("ID:"));
     }
 
@@ -1434,7 +1435,8 @@ mod tests {
 
     #[test]
     fn validate_rg_attr_without_line_errors() {
-        let err = try_parse(&["--readFilesIn", "r.fq", "--outSAMattributes", "NH", "RG"]).unwrap_err();
+        let err =
+            try_parse(&["--readFilesIn", "r.fq", "--outSAMattributes", "NH", "RG"]).unwrap_err();
         assert!(err.to_string().contains("RG"));
     }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -106,8 +107,9 @@ impl std::str::FromStr for IntronStrandFilter {
 // ---------------------------------------------------------------------------
 
 /// STAR's `--outSAMtype` format component.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum OutSamFormat {
+    #[default]
     Sam,
     Bam,
     None,
@@ -121,19 +123,10 @@ pub enum OutSamSortOrder {
 }
 
 /// Combined `--outSAMtype` value.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct OutSamType {
     pub format: OutSamFormat,
     pub sort_order: Option<OutSamSortOrder>,
-}
-
-impl Default for OutSamType {
-    fn default() -> Self {
-        Self {
-            format: OutSamFormat::Sam,
-            sort_order: None,
-        }
-    }
 }
 
 impl std::fmt::Display for OutSamType {
@@ -146,6 +139,68 @@ impl std::fmt::Display for OutSamType {
             }
             (OutSamFormat::Bam, _) => write!(f, "BAM Unsorted"),
         }
+    }
+}
+
+impl clap::FromArgMatches for OutSamType {
+    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        let mut s = Self::default();
+        s.update_from_arg_matches(matches)?;
+        Ok(s)
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+        let Some(values) = matches.get_many::<String>("outSAMtype") else {
+            return Ok(());
+        };
+        let tokens: Vec<&str> = values.map(String::as_str).collect();
+        *self = match tokens.as_slice() {
+            ["SAM"] => Self {
+                format: OutSamFormat::Sam,
+                sort_order: None,
+            },
+            ["None"] => Self {
+                format: OutSamFormat::None,
+                sort_order: None,
+            },
+            ["BAM", "Unsorted"] => Self {
+                format: OutSamFormat::Bam,
+                sort_order: Some(OutSamSortOrder::Unsorted),
+            },
+            ["BAM", "SortedByCoordinate"] => Self {
+                format: OutSamFormat::Bam,
+                sort_order: Some(OutSamSortOrder::SortedByCoordinate),
+            },
+            other => {
+                return Err(clap::Error::raw(
+                    clap::error::ErrorKind::InvalidValue,
+                    format!(
+                        "invalid value '{}' for '--outSAMtype': expected 'SAM', 'None', 'BAM Unsorted', or 'BAM SortedByCoordinate'\n",
+                        other.join(" ")
+                    ),
+                ));
+            }
+        };
+        Ok(())
+    }
+}
+
+impl clap::Args for OutSamType {
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        cmd.arg(
+            clap::Arg::new("outSAMtype")
+                .long("outSAMtype")
+                .num_args(1..=2)
+                .default_values(["SAM"])
+                .help(
+                    "Output type: SAM, BAM Unsorted, BAM SortedByCoordinate, None. \
+                     Provide as space-separated tokens, e.g. \"BAM SortedByCoordinate\".",
+                ),
+        )
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        Self::augment_args(cmd)
     }
 }
 
@@ -292,8 +347,8 @@ pub struct Parameters {
     pub run_mode: RunMode,
 
     /// Number of threads
-    #[arg(long = "runThreadN", default_value_t = 1)]
-    pub run_thread_n: usize,
+    #[arg(long = "runThreadN", default_value_t = NonZeroUsize::new(1).unwrap())]
+    pub run_thread_n: NonZeroUsize,
 
     /// Random number generator seed for tie-breaking among equal-scoring alignments
     #[arg(long = "runRNGseed", default_value_t = 777)]
@@ -346,10 +401,8 @@ pub struct Parameters {
     #[arg(long = "outFileNamePrefix", default_value = "./")]
     pub out_file_name_prefix: String,
 
-    /// Output type: SAM, BAM Unsorted, BAM SortedByCoordinate, None.
-    /// Provide as space-separated tokens, e.g. "BAM SortedByCoordinate".
-    #[arg(long = "outSAMtype", num_args = 1..=2, default_values_t = vec!["SAM".to_string()])]
-    pub out_sam_type_raw: Vec<String>,
+    #[command(flatten)]
+    pub out_sam_type: OutSamType,
 
     /// BAM compression level: -1 = uncompressed, 1 (default) to 9 (maximum)
     #[arg(
@@ -709,35 +762,6 @@ impl Parameters {
         PathBuf::from(format!("{}{suffix}", self.out_file_name_prefix))
     }
 
-    /// Parse the raw `--outSAMtype` tokens into a structured `OutSamType`.
-    pub fn out_sam_type(&self) -> Result<OutSamType, String> {
-        match self
-            .out_sam_type_raw
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .as_slice()
-        {
-            ["SAM"] => Ok(OutSamType {
-                format: OutSamFormat::Sam,
-                sort_order: None,
-            }),
-            ["None"] => Ok(OutSamType {
-                format: OutSamFormat::None,
-                sort_order: None,
-            }),
-            ["BAM", "Unsorted"] => Ok(OutSamType {
-                format: OutSamFormat::Bam,
-                sort_order: Some(OutSamSortOrder::Unsorted),
-            }),
-            ["BAM", "SortedByCoordinate"] => Ok(OutSamType {
-                format: OutSamFormat::Bam,
-                sort_order: Some(OutSamSortOrder::SortedByCoordinate),
-            }),
-            other => Err(format!("unknown outSAMtype: {other:?}")),
-        }
-    }
-
     /// Whether `--chimOutType` includes `Junctions` (write Chimeric.out.junction).
     pub fn chim_out_junctions(&self) -> bool {
         self.chim_out_type.iter().any(|s| s == "Junctions")
@@ -910,37 +934,55 @@ impl Parameters {
         );
     }
 
-    /// Validate parameter combinations that clap alone cannot enforce.
-    pub fn validate(&self) -> Result<(), crate::error::Error> {
+    /// Parse and validate parameter combinations.
+    pub fn parse() -> Self {
+        Self::parse_from(std::env::args_os())
+    }
+
+    /// Parse and validate parameter combinations from args.
+    pub fn parse_from<T: Into<std::ffi::OsString> + Clone>(
+        args: impl IntoIterator<Item = T>,
+    ) -> Self {
+        Self::try_parse_from(args)
+            .unwrap_or_else(|e| if cfg!(test) { panic!("{e}") } else { e.exit() })
+    }
+
+    /// Parse and validate parameter combinations.
+    pub fn try_parse() -> Result<Self, clap::Error> {
+        Self::try_parse_from(std::env::args_os())
+    }
+
+    /// Parse and validate parameter combinations from args.
+    pub fn try_parse_from<T: Into<std::ffi::OsString> + Clone>(
+        args: impl IntoIterator<Item = T>,
+    ) -> Result<Self, clap::Error> {
+        use clap::error::ErrorKind;
+
+        let mut command = <Self as clap::CommandFactory>::command();
+        let matches = command.clone().get_matches_from(args);
+        let params = <Self as clap::FromArgMatches>::from_arg_matches(&matches)?;
+
         // genomeGenerate requires FASTA files
-        if self.run_mode == RunMode::GenomeGenerate && self.genome_fasta_files.is_empty() {
-            return Err(crate::error::Error::Parameter(
-                "--genomeFastaFiles is required when --runMode genomeGenerate".into(),
+        if params.run_mode == RunMode::GenomeGenerate && params.genome_fasta_files.is_empty() {
+            return Err(command.error(
+                ErrorKind::MissingRequiredArgument,
+                "--genomeFastaFiles is required when --runMode genomeGenerate",
             ));
         }
 
         // alignReads requires read files
-        if self.run_mode == RunMode::AlignReads && self.read_files_in.is_empty() {
-            return Err(crate::error::Error::Parameter(
-                "--readFilesIn is required when --runMode alignReads".into(),
-            ));
-        }
-
-        // Validate outSAMtype
-        self.out_sam_type()
-            .map_err(crate::error::Error::Parameter)?;
-
-        // Thread count must be at least 1
-        if self.run_thread_n == 0 {
-            return Err(crate::error::Error::Parameter(
-                "--runThreadN must be >= 1".into(),
+        if params.run_mode == RunMode::AlignReads && params.read_files_in.is_empty() {
+            return Err(command.error(
+                ErrorKind::MissingRequiredArgument,
+                "--readFilesIn is required when --runMode alignReads",
             ));
         }
 
         // quantMode GeneCounts requires a GTF file
-        if self.quant_gene_counts() && self.sjdb_gtf_file.is_none() {
-            return Err(crate::error::Error::Parameter(
-                "--quantMode GeneCounts requires --sjdbGTFfile".into(),
+        if params.quant_gene_counts() && params.sjdb_gtf_file.is_none() {
+            return Err(command.error(
+                ErrorKind::MissingRequiredArgument,
+                "--quantMode GeneCounts requires --sjdbGTFfile",
             ));
         }
 
@@ -948,13 +990,16 @@ impl Parameters {
         // error (STAR: Parameters_samAttributes.cpp:206). STAR's "All" preset
         // does NOT include RG, so only match a literal "RG" token here. Also
         // parse the RG line to validate its ID: prefix and per-file RG count.
-        let user_wants_rg_attr = self.out_sam_attributes.iter().any(|a| a == "RG");
-        if !self.rg_line_set() && user_wants_rg_attr {
-            return Err(crate::error::Error::Parameter(
-                "--outSAMattributes contains RG tag, but --outSAMattrRGline is not set".into(),
+        let user_wants_rg_attr = params.out_sam_attributes.iter().any(|a| a == "RG");
+        if !params.rg_line_set() && user_wants_rg_attr {
+            return Err(command.error(
+                ErrorKind::MissingRequiredArgument,
+                "--outSAMattributes contains RG tag, but --outSAMattrRGline is not set",
             ));
         }
-        self.rg_ids()?;
+        params
+            .rg_ids()
+            .map_err(|e| command.error(ErrorKind::InvalidValue, e))?;
 
         // quantMode TranscriptomeSAM requires transcript annotations —
         // either via --sjdbGTFfile or pre-generated transcriptInfo.tab
@@ -962,16 +1007,17 @@ impl Parameters {
         // validation time we can only enforce the genomeGenerate rule;
         // for alignReads, GenomeIndex::load checks for the on-disk files
         // and surfaces a clear error if neither source is available.
-        if self.run_mode == RunMode::GenomeGenerate
-            && self.quant_transcriptome_sam()
-            && self.sjdb_gtf_file.is_none()
+        if params.run_mode == RunMode::GenomeGenerate
+            && params.quant_transcriptome_sam()
+            && params.sjdb_gtf_file.is_none()
         {
-            return Err(crate::error::Error::Parameter(
-                "--quantMode TranscriptomeSAM requires --sjdbGTFfile at genomeGenerate".into(),
+            return Err(command.error(
+                ErrorKind::MissingRequiredArgument,
+                "--quantMode TranscriptomeSAM requires --sjdbGTFfile at genomeGenerate",
             ));
         }
 
-        Ok(())
+        Ok(params)
     }
 
     /// Returns true if `--quantMode GeneCounts` was requested.
@@ -994,17 +1040,17 @@ mod tests {
     use super::*;
 
     /// Helper: parse a STAR-style command line (without program name).
-    fn parse(args: &[&str]) -> Parameters {
+    fn try_parse(args: &[&str]) -> Result<Parameters, clap::Error> {
         let mut full = vec!["rustar-aligner"];
         full.extend_from_slice(args);
-        Parameters::parse_from(full)
+        Parameters::try_parse_from(&full)
     }
 
     #[test]
     fn defaults() {
-        let p = parse(&["--readFilesIn", "reads.fq"]);
+        let p = try_parse(&["--readFilesIn", "reads.fq"]).unwrap();
         assert_eq!(p.run_mode, RunMode::AlignReads);
-        assert_eq!(p.run_thread_n, 1);
+        assert_eq!(p.run_thread_n, NonZeroUsize::new(1).unwrap());
         assert_eq!(p.run_rng_seed, 777);
         assert_eq!(p.genome_dir, PathBuf::from("./GenomeDir"));
         assert_eq!(p.genome_sa_index_nbases, 14);
@@ -1014,7 +1060,7 @@ mod tests {
         assert_eq!(p.clip5p_nbases, 0);
         assert_eq!(p.clip3p_nbases, 0);
         assert_eq!(p.out_file_name_prefix, "./");
-        assert_eq!(p.out_sam_type_raw, vec!["SAM".to_string()]);
+        assert_eq!(p.out_sam_type, OutSamType::default());
         assert_eq!(p.out_sam_strand_field, "None");
         assert_eq!(p.out_sam_attributes, vec!["Standard".to_string()]);
         assert_eq!(p.out_sam_unmapped, OutSamUnmapped::None);
@@ -1081,7 +1127,7 @@ mod tests {
 
     #[test]
     fn genome_generate_mode() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--runMode",
             "genomeGenerate",
             "--genomeDir",
@@ -1093,20 +1139,21 @@ mod tests {
             "8",
             "--genomeSAindexNbases",
             "11",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(p.run_mode, RunMode::GenomeGenerate);
         assert_eq!(p.genome_dir, PathBuf::from("/data/genome"));
         assert_eq!(
             p.genome_fasta_files,
             vec![PathBuf::from("chr1.fa"), PathBuf::from("chr2.fa")]
         );
-        assert_eq!(p.run_thread_n, 8);
+        assert_eq!(p.run_thread_n, NonZeroUsize::new(8).unwrap());
         assert_eq!(p.genome_sa_index_nbases, 11);
     }
 
     #[test]
     fn typical_align_command() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--runMode",
             "alignReads",
             "--genomeDir",
@@ -1131,7 +1178,8 @@ mod tests {
             "gencode.gtf",
             "--twopassMode",
             "Basic",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(p.run_mode, RunMode::AlignReads);
         assert_eq!(p.genome_dir, PathBuf::from("/idx/hg38"));
         assert_eq!(
@@ -1139,15 +1187,10 @@ mod tests {
             vec![PathBuf::from("R1.fq.gz"), PathBuf::from("R2.fq.gz")]
         );
         assert_eq!(p.read_files_command, Some("zcat".to_string()));
-        assert_eq!(p.run_thread_n, 16);
+        assert_eq!(p.run_thread_n, NonZeroUsize::new(16).unwrap());
+        assert_eq!(p.out_sam_type.format, OutSamFormat::Bam);
         assert_eq!(
-            p.out_sam_type_raw,
-            vec!["BAM".to_string(), "SortedByCoordinate".to_string()]
-        );
-        let sam_type = p.out_sam_type().unwrap();
-        assert_eq!(sam_type.format, OutSamFormat::Bam);
-        assert_eq!(
-            sam_type.sort_order,
+            p.out_sam_type.sort_order,
             Some(OutSamSortOrder::SortedByCoordinate)
         );
         assert_eq!(p.out_file_name_prefix, "/out/sample1_");
@@ -1159,7 +1202,7 @@ mod tests {
 
     #[test]
     fn scoring_overrides() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "reads.fq",
             "--scoreGap",
@@ -1178,7 +1221,8 @@ mod tests {
             "-3",
             "--scoreInsBase",
             "-1",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(p.score_gap, 0);
         assert_eq!(p.score_gap_noncan, -12);
         assert_eq!(p.score_gap_gcag, -6);
@@ -1191,38 +1235,36 @@ mod tests {
 
     #[test]
     fn validate_genome_generate_needs_fasta() {
-        let p = parse(&["--runMode", "genomeGenerate"]);
-        let err = p.validate().unwrap_err();
+        let err = try_parse(&["--runMode", "genomeGenerate"]).unwrap_err();
         assert!(err.to_string().contains("genomeFastaFiles"));
     }
 
     #[test]
     fn validate_align_needs_reads() {
-        let p = parse(&["--runMode", "alignReads"]);
-        let err = p.validate().unwrap_err();
+        let err = try_parse(&["--runMode", "alignReads"]).unwrap_err();
         assert!(err.to_string().contains("readFilesIn"));
     }
 
     #[test]
     fn out_sam_type_parsing() {
-        let p = parse(&["--readFilesIn", "r.fq", "--outSAMtype", "SAM"]);
-        let t = p.out_sam_type().unwrap();
-        assert_eq!(t.format, OutSamFormat::Sam);
-        assert_eq!(t.sort_order, None);
+        let p = try_parse(&["--readFilesIn", "r.fq", "--outSAMtype", "SAM"]).unwrap();
+        assert_eq!(p.out_sam_type.format, OutSamFormat::Sam);
+        assert_eq!(p.out_sam_type.sort_order, None);
 
-        let p = parse(&["--readFilesIn", "r.fq", "--outSAMtype", "BAM", "Unsorted"]);
-        let t = p.out_sam_type().unwrap();
-        assert_eq!(t.format, OutSamFormat::Bam);
-        assert_eq!(t.sort_order, Some(OutSamSortOrder::Unsorted));
+        let p = try_parse(&["--readFilesIn", "r.fq", "--outSAMtype", "BAM", "Unsorted"]).unwrap();
+        assert_eq!(p.out_sam_type.format, OutSamFormat::Bam);
+        assert_eq!(p.out_sam_type.sort_order, Some(OutSamSortOrder::Unsorted));
 
-        let p = parse(&["--readFilesIn", "r.fq", "--outSAMtype", "None"]);
-        let t = p.out_sam_type().unwrap();
-        assert_eq!(t.format, OutSamFormat::None);
+        let p = try_parse(&["--readFilesIn", "r.fq", "--outSAMtype", "None"]).unwrap();
+        assert_eq!(p.out_sam_type.format, OutSamFormat::None);
+
+        assert!(try_parse(&["--readFilesIn", "r.fq", "--outSAMtype", "BOGUS"]).is_err());
+        assert!(try_parse(&["--readFilesIn", "r.fq", "--outSAMtype", "BAM"]).is_err());
     }
 
     #[test]
     fn chimeric_params() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--chimSegmentMin",
@@ -1232,7 +1274,8 @@ mod tests {
             "--chimOutType",
             "WithinBAM",
             "SoftClip",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(p.chim_segment_min, 20);
         assert_eq!(p.chim_score_min, 10);
         assert_eq!(
@@ -1243,7 +1286,7 @@ mod tests {
 
     #[test]
     fn chimeric_params_extended() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--chimSegmentMin",
@@ -1260,7 +1303,8 @@ mod tests {
             "12",
             "--chimScoreJunctionNonGTAG",
             "-2",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(p.chim_score_drop_max, 30);
         assert_eq!(p.chim_score_separation, 15);
         assert_eq!(p.chim_main_segment_mult_nmax, 5);
@@ -1271,7 +1315,7 @@ mod tests {
 
     #[test]
     fn chimeric_params_defaults() {
-        let p = parse(&["--readFilesIn", "r.fq"]);
+        let p = try_parse(&["--readFilesIn", "r.fq"]).unwrap();
         assert_eq!(p.chim_score_drop_max, 20);
         assert_eq!(p.chim_score_separation, 10);
         assert_eq!(p.chim_main_segment_mult_nmax, 10);
@@ -1282,26 +1326,27 @@ mod tests {
 
     #[test]
     fn win_bin_window_dist_default() {
-        let p = parse(&["--readFilesIn", "r.fq"]);
+        let p = try_parse(&["--readFilesIn", "r.fq"]).unwrap();
         assert_eq!(p.win_bin_window_dist(), 589_824); // 2^16 * 9
     }
 
     #[test]
     fn win_bin_window_dist_custom() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--winBinNbits",
             "14",
             "--winAnchorDistNbins",
             "5",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(p.win_bin_window_dist(), 81_920); // 2^14 * 5
     }
 
     #[test]
     fn rg_line_default_unset() {
-        let p = parse(&["--readFilesIn", "r.fq"]);
+        let p = try_parse(&["--readFilesIn", "r.fq"]).unwrap();
         assert!(!p.rg_line_set());
         assert_eq!(p.parsed_rg_lines().unwrap(), Vec::<String>::new());
         assert_eq!(p.rg_ids().unwrap(), Vec::<String>::new());
@@ -1310,14 +1355,15 @@ mod tests {
 
     #[test]
     fn rg_line_single() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--outSAMattrRGline",
             "ID:foo",
             "SM:bar",
             "LB:lib1",
-        ]);
+        ])
+        .unwrap();
         assert!(p.rg_line_set());
         assert_eq!(
             p.parsed_rg_lines().unwrap(),
@@ -1329,7 +1375,7 @@ mod tests {
 
     #[test]
     fn rg_line_multi() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r1.fq",
             "r2.fq",
@@ -1339,7 +1385,8 @@ mod tests {
             ",",
             "ID:b",
             "LB:x",
-        ]);
+        ])
+        .unwrap();
         let lines = p.parsed_rg_lines().unwrap();
         assert_eq!(
             lines,
@@ -1350,13 +1397,14 @@ mod tests {
 
     #[test]
     fn rg_line_single_replicates_for_multi_file() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r1.fq",
             "r2.fq",
             "--outSAMattrRGline",
             "ID:foo",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             p.rg_ids().unwrap(),
             vec!["foo".to_string(), "foo".to_string()]
@@ -1365,43 +1413,41 @@ mod tests {
 
     #[test]
     fn rg_line_missing_id_prefix_errors() {
-        let p = parse(&["--readFilesIn", "r.fq", "--outSAMattrRGline", "SM:oops"]);
-        let err = p.parsed_rg_lines().unwrap_err();
+        let err = try_parse(&["--readFilesIn", "r.fq", "--outSAMattrRGline", "SM:oops"]).unwrap_err();
         assert!(err.to_string().contains("ID:"));
     }
 
     #[test]
     fn rg_line_count_mismatch_errors() {
         // 1 input file, 2 RG entries — mismatch (ids.len()>1 && != n_files).
-        let p = parse(&[
+        let err = try_parse(&[
             "--readFilesIn",
             "r1.fq",
             "--outSAMattrRGline",
             "ID:a",
             ",",
             "ID:b",
-        ]);
-        let err = p.rg_ids().unwrap_err();
+        ])
+        .unwrap_err();
         assert!(err.to_string().contains("does not match"));
     }
 
     #[test]
     fn validate_rg_attr_without_line_errors() {
-        let p = parse(&["--readFilesIn", "r.fq", "--outSAMattributes", "NH", "RG"]);
-        let err = p.validate().unwrap_err();
+        let err = try_parse(&["--readFilesIn", "r.fq", "--outSAMattributes", "NH", "RG"]).unwrap_err();
         assert!(err.to_string().contains("RG"));
     }
 
     #[test]
     fn run_rng_seed_override() {
-        let p = parse(&["--readFilesIn", "r.fq", "--runRNGseed", "42"]);
+        let p = try_parse(&["--readFilesIn", "r.fq", "--runRNGseed", "42"]).unwrap();
         assert_eq!(p.run_rng_seed, 42);
     }
 
     #[test]
     fn quant_transcriptome_sam_default() {
         use crate::quant::transcriptome::QuantTranscriptomeSAMoutput;
-        let p = parse(&["--readFilesIn", "r.fq"]);
+        let p = try_parse(&["--readFilesIn", "r.fq"]).unwrap();
         assert!(!p.quant_transcriptome_sam());
         assert_eq!(
             p.quant_transcriptome_sam_output,
@@ -1411,7 +1457,7 @@ mod tests {
 
     #[test]
     fn quant_transcriptome_sam_enabled() {
-        let p = parse(&["--readFilesIn", "r.fq", "--quantMode", "TranscriptomeSAM"]);
+        let p = try_parse(&["--readFilesIn", "r.fq", "--quantMode", "TranscriptomeSAM"]).unwrap();
         assert!(p.quant_transcriptome_sam());
         assert!(!p.quant_gene_counts());
     }
@@ -1419,23 +1465,25 @@ mod tests {
     #[test]
     fn quant_transcriptome_sam_output_override() {
         use crate::quant::transcriptome::QuantTranscriptomeSAMoutput;
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--quantTranscriptomeSAMoutput",
             "BanSingleEnd",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             p.quant_transcriptome_sam_output,
             QuantTranscriptomeSAMoutput::BanSingleEnd
         );
 
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--quantTranscriptomeSAMoutput",
             "BanSingleEnd_ExtendSoftclip",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             p.quant_transcriptome_sam_output,
             QuantTranscriptomeSAMoutput::BanSingleEndExtendSoftclip
@@ -1444,15 +1492,15 @@ mod tests {
 
     #[test]
     fn validate_transcriptome_sam_at_genome_generate_needs_gtf() {
-        let p = parse(&[
+        let err = try_parse(&[
             "--runMode",
             "genomeGenerate",
             "--genomeFastaFiles",
             "g.fa",
             "--quantMode",
             "TranscriptomeSAM",
-        ]);
-        let err = p.validate().unwrap_err();
+        ])
+        .unwrap_err();
         assert!(err.to_string().contains("TranscriptomeSAM"));
         assert!(err.to_string().contains("sjdbGTFfile"));
     }
@@ -1462,26 +1510,25 @@ mod tests {
         // alignReads: if --sjdbGTFfile is absent, the check is deferred to
         // GenomeIndex::load which will either find transcriptInfo.tab in
         // --genomeDir or surface a clear error at load time.
-        let p = parse(&["--readFilesIn", "r.fq", "--quantMode", "TranscriptomeSAM"]);
-        assert!(p.validate().is_ok());
+        try_parse(&["--readFilesIn", "r.fq", "--quantMode", "TranscriptomeSAM"]).unwrap();
     }
 
     #[test]
     fn validate_transcriptome_sam_with_gtf_ok() {
-        let p = parse(&[
+        try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--quantMode",
             "TranscriptomeSAM",
             "--sjdbGTFfile",
             "genes.gtf",
-        ]);
-        assert!(p.validate().is_ok());
+        ])
+        .unwrap();
     }
 
     #[test]
     fn sj_stitch_mismatch() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--alignSJstitchMismatchNmax",
@@ -1489,13 +1536,14 @@ mod tests {
             "-1",
             "2",
             "3",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(p.align_sj_stitch_mismatch_nmax, vec![1, -1, 2, 3]);
     }
 
     #[test]
     fn output_path_bare_dot_prefix() {
-        let p = parse(&["--readFilesIn", "r.fq", "--outFileNamePrefix", "SAMPLE."]);
+        let p = try_parse(&["--readFilesIn", "r.fq", "--outFileNamePrefix", "SAMPLE."]).unwrap();
         assert_eq!(p.out_file_name_prefix, "SAMPLE.");
         assert_eq!(
             p.output_path("Aligned.out.bam"),
@@ -1509,7 +1557,7 @@ mod tests {
 
     #[test]
     fn output_path_trailing_slash_prefix() {
-        let p = parse(&["--readFilesIn", "r.fq", "--outFileNamePrefix", "out/"]);
+        let p = try_parse(&["--readFilesIn", "r.fq", "--outFileNamePrefix", "out/"]).unwrap();
         assert_eq!(
             p.output_path("Aligned.out.bam"),
             PathBuf::from("out/Aligned.out.bam")
@@ -1518,7 +1566,7 @@ mod tests {
 
     #[test]
     fn output_path_default_prefix() {
-        let p = parse(&["--readFilesIn", "r.fq"]);
+        let p = try_parse(&["--readFilesIn", "r.fq"]).unwrap();
         assert_eq!(
             p.output_path("Aligned.out.bam"),
             PathBuf::from("./Aligned.out.bam")
@@ -1527,12 +1575,13 @@ mod tests {
 
     #[test]
     fn output_path_path_with_underscore() {
-        let p = parse(&[
+        let p = try_parse(&[
             "--readFilesIn",
             "r.fq",
             "--outFileNamePrefix",
             "/out/sample1_",
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             p.output_path("Aligned.out.bam"),
             PathBuf::from("/out/sample1_Aligned.out.bam")

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -2199,8 +2199,7 @@ mod tests {
     // ---- Subtask 3: filter-mode tests ----
 
     fn default_params() -> Parameters {
-        use clap::Parser;
-        Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "r.fq"])
+        Parameters::parse_from(["rustar-aligner", "--readFilesIn", "r.fq"])
     }
 
     #[test]


### PR DESCRIPTION
shadow `clap::Parser`’s methods by our own that also validate.