### PR TITLE
fix: quote command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -938,6 +938,7 @@ dependencies = [
  "predicates",
  "rand",
  "rayon",
+ "shlex",
  "tempfile",
  "thiserror",
 ]
@@ -1018,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ chrono = "0.4"
 rand = "0.10"
 tempfile = "3"
 bitflags = { version = "2.11.1", features = ["std"] }
+shlex = "2.0.1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1422,9 +1422,26 @@ mod tests {
     }
 
     #[test]
+    fn test_build_sam_header_pg_line_cl_quoted() {
+        let genome = make_test_genome();
+        let params =
+            Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "some words.fq"]);
+
+        let header = build_sam_header(&genome, &params).unwrap();
+        let programs = header.programs().as_ref();
+        let pg = programs.get(&b"rustar-aligner"[..]).unwrap();
+        let cl = pg
+            .other_fields()
+            .get(&program_tag::COMMAND_LINE)
+            .expect("CL field must be present");
+        assert_eq!(cl, "rustar-aligner --readFilesIn 'some words.fq'");
+    }
+
+    #[test]
     fn test_build_sam_header_pg_line_default_cl_when_unset() {
         let genome = make_test_genome();
-        let params = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "test.fq"]);
+        let params = Parameters::parse_from(vec!["rustar-aligner", "--readFilesIn", "test.fq\0"]);
+        // when there are null bytes in the args, `command_line` is set to None
         assert!(params.command_line.is_none());
 
         let header = build_sam_header(&genome, &params).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,5 @@ fn main() -> anyhow::Result<()> {
 
     cpu::check_cpu_compat()?;
 
-    let command_line = std::env::args().collect::<Vec<_>>().join(" ");
-    let mut params = Parameters::parse();
-    params.command_line = Some(command_line);
-    rustar_aligner::run(&params)
+    rustar_aligner::run(&Parameters::parse())
 }

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -833,9 +833,16 @@ impl Parameters {
     ) -> Result<Self, clap::Error> {
         use clap::error::ErrorKind;
 
+        let args: Vec<_> = args.into_iter().map(Into::into).collect();
+
         let mut command = <Self as clap::CommandFactory>::command();
-        let matches = command.clone().get_matches_from(args);
+        let matches = command.clone().get_matches_from(args.iter());
         let mut params = <Self as clap::FromArgMatches>::from_arg_matches(&matches)?;
+
+        params.command_line = {
+            let args: Vec<_> = args.iter().map(|s| s.to_string_lossy()).collect();
+            shlex::try_join(args.iter().map(AsRef::as_ref)).ok()
+        };
 
         // genomeGenerate requires FASTA files
         if params.run_mode == RunMode::GenomeGenerate && params.genome_fasta_files.is_empty() {


### PR DESCRIPTION
we’re no longer in the 90s, file names can contain spaces.