### PR TITLE
fix(ci): resolve clippy 1.97 lints and RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "assert_cmd"
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -639,9 +639,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/src/index/suffix_array.rs
+++ b/src/index/suffix_array.rs
@@ -275,7 +275,7 @@ mod tests {
         let first_base = genome.sequence[first_pos as usize];
 
         // In "AAB", the first suffix lexicographically is "A" (from pos 0 or 1)
-        assert!(first_base == 0); // A
+        assert_eq!(first_base, 0); // A
     }
 
     /// Differential: the caps-sa-backed builder must produce a `PackedArray`

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1516,8 +1516,8 @@ mod tests {
         assert!(rgs.contains_key(&b"rg0"[..]));
         let map = rgs.get(&b"rg0"[..]).unwrap();
         // SM and LB should be present as other_fields
-        let sm_tag = HeaderOtherTag::<_>::try_from([b'S', b'M']).unwrap();
-        let lb_tag = HeaderOtherTag::<_>::try_from([b'L', b'B']).unwrap();
+        let sm_tag = HeaderOtherTag::<_>::try_from(*b"SM").unwrap();
+        let lb_tag = HeaderOtherTag::<_>::try_from(*b"LB").unwrap();
         let sm: &[u8] = map.other_fields().get(&sm_tag).unwrap().as_ref();
         let lb: &[u8] = map.other_fields().get(&lb_tag).unwrap().as_ref();
         assert_eq!(sm, b"sample0");

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -1036,13 +1036,10 @@ fn align_to_one_transcript(
         } else {
             // Coalesce: extend the last projected exon by this block's length
             // (STAR adds block EX_L directly — does NOT update start position).
-            if let Some(last) = proj_exons.last_mut() {
-                let len = block_end - block_start;
-                last.genome_end += len;
-                last.read_end = block.read_end;
-            } else {
-                return None;
-            }
+            let last = proj_exons.last_mut()?;
+            let len = block_end - block_start;
+            last.genome_end += len;
+            last.read_end = block.read_end;
         }
 
         // Advance `ex` across any splice boundary BEFORE the next block,

--- a/tests/alignment_features.rs
+++ b/tests/alignment_features.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 
 /// LCG pseudo-random sequence generator (identical LCG to existing tests).
 fn lcg_seq(seed: u32, length: usize) -> Vec<u8> {
-    let bases: [u8; 4] = [b'A', b'C', b'G', b'T'];
+    let bases: [u8; 4] = *b"ACGT";
     let mut state = seed;
     let mut seq = Vec::with_capacity(length);
     for _ in 0..length {


### PR DESCRIPTION
CI is currently red on `main` for reasons unrelated to any single change, which blocks all PRs. This fixes both the lint and audit gates.

## Clippy (`-D warnings`)
CI's clippy advanced to **1.97**, adding lints that now fail on existing code:
- `src/index/suffix_array.rs` — `assert!(x == 0)` → `assert_eq!` (`manual_assert_eq`)
- `src/io/sam.rs`, `tests/alignment_features.rs` — byte-slice literals → byte strings, e.g. `[b'S', b'M']` → `*b"SM"` (`byte_char_slices`)
- `src/quant/transcriptome.rs` — `if let … else { return None }` → `?` (`question_mark`)

## Security audit (Cargo.lock only, no manifest change)
- `memmap2` 0.9.10 → **0.9.11** — RUSTSEC-2026-0186 (out-of-bounds pointer offset to `madvise`/`msync`)
- `crossbeam-epoch` 0.9.18 → **0.9.20** — RUSTSEC-2026-0204 (invalid pointer deref in `fmt::Pointer`)
- `anyhow` 1.0.102 → **1.0.104** — RUSTSEC-2026-0190 (unsound `downcast_mut`)

The memmap2/anyhow bumps overlap with dependabot #100/#101; this PR additionally fixes the clippy 1.97 breakage and the crossbeam-epoch advisory, so the whole gate goes green in one shot. Happy to close in favour of the dependabot PRs + a clippy-only PR if the team prefers.

No behavioural change. Verified locally with `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)