### PR TITLE
feat: adapter-aware read clipping (Hamming)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ src/
     segment.rs     -- ChimericSegment and ChimericAlignment data structures
     score.rs       -- Junction type classification, repeat length calculation
     output.rs      -- Chimeric.out.junction writer (14-column format)
+  clip/
+    mod.rs         -- Adapter-aware clipping (--clip{5,3}pNbases + Hamming --clip3pAdapterSeq/*MMp/*AfterAdapterNbases)
+  wasp/
+    mod.rs         -- WASP allele-specific-mapping filter (--waspOutputMode SAMtag, --varVCFfile), SE + PE
 ```
 
 ## Development Philosophy — Match STAR Exactly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "assert_cmd"
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -639,9 +639,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,3 +1,9 @@
 The original MIT STAR license is included here for attribution to the original author Alexander Dobin
 
 The LICENSE of this repo has been chosen to also be MIT to match that of the STAR repo https://github.com/alexdobin/STAR
+
+`STAR_RS_LICENSE` is the MIT license of [STAR-rs](https://github.com/BenjaminDEMAILLE/STAR-rs)
+(Copyright (c) 2026 Benjamin Demaille), included for attribution of modules ported
+from STAR-rs into rustar-aligner. STAR-rs is dual-licensed `MIT OR Apache-2.0`; the
+ported code is taken under its MIT option, which is compatible with this repo's MIT
+license. See `docs-old/dev/porting-from-star-rs.md` for the porting conventions.

--- a/LICENSES/STAR_RS_LICENSE
+++ b/LICENSES/STAR_RS_LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benjamin Demaille
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs-old/dev/porting-from-star-rs.md
+++ b/docs-old/dev/porting-from-star-rs.md
@@ -1,0 +1,75 @@
+# Porting features from STAR-rs into rustar-aligner
+
+This note records the conventions for bringing features over from
+[STAR-rs](https://github.com/BenjaminDEMAILLE/STAR-rs) (a clean-room Rust re-port of
+STAR 2.7.11b, validated byte-identical against native STAR) into rustar-aligner.
+It is the shared reference for the themed, dependency-stacked porting PRs.
+
+## Why
+
+rustar-aligner and STAR-rs are two independent Rust reimplementations of STAR.
+rustar-aligner already covers single/paired-end alignment, splice junctions,
+two-pass, 4-tier chimeric, GeneCounts, TranscriptomeSAM and sorted BAM. STAR-rs
+additionally implements STARsolo, STARlong, WASP, genome transforms, signal tracks,
+adapter clipping, PE mate-overlap, SuperTranscriptome, liftOver and more. These
+notes cover moving that surface over, one theme per PR.
+
+## Licensing
+
+STAR-rs is dual-licensed `MIT OR Apache-2.0` (Copyright (c) 2026 Benjamin Demaille).
+Ported code is taken under the **MIT** option, compatible with this repo's MIT
+license. `LICENSES/STAR_RS_LICENSE` preserves the STAR-rs MIT notice for attribution.
+
+**Never copy `vendor/cellranger-upstream` code from STAR-rs.** It is 10x Genomics
+source-available (non-OSI) and kept in STAR-rs as algorithm *reference only*. When
+porting STARsolo, reimplement the algorithms from the STAR C++ source, as STAR-rs did.
+
+## Type / module mapping
+
+STAR-rs is a 10-crate workspace (`star_core`, `star_index`, `star_seed`,
+`star_align`, `star_cli`, ...); rustar-aligner is a single crate (`rustar_aligner`)
+with a flat module tree. A ported file's `use star_*::...` header is repointed to
+`crate::...`, and the core types are adapted field-by-field:
+
+| STAR-rs | rustar-aligner (`src/align/transcript.rs`) |
+| --- | --- |
+| `star_align::star_model::Transcript` | `crate::align::transcript::Transcript` |
+| `Exon { r, g, len, i_frag }` | `Exon { read_start, genome_start, genome_end, i_frag }` (start+end, not start+len) |
+| `tr.str_: u8` (0 fwd / 1 rev) | `tr.is_reverse: bool` |
+| `tr.chr` | `tr.chr_idx` |
+| `tr.n_exons()` | `tr.exons.len()` |
+| `star_core::Cigar` (derived from exons late) | `Vec<noodles ...::cigar::Op>` (materialized in `Transcript`) |
+| `star_index::load::StarGenome` (unified) | split `genome::Genome` + `index::GenomeIndex` + `index::suffix_array::SuffixArray` |
+
+Base encoding is identical in both: `A=0, C=1, G=2, T=3, N=4`, reverse complement in
+the second half of the genome array.
+
+## Determinism
+
+rustar-aligner currently uses `rand` (`StdRng`, seeded by `--runRNGseed`) for
+multimapper-order / tie-break randomness. STAR-rs instead uses a hand-rolled,
+per-read-seeded `splitmix64` shuffle so output is **byte-identical regardless of
+thread count** (a stronger correctness property than STAR's per-thread `mt19937`).
+
+**Decision for the porting effort:** adopt STAR-rs's thread-invariant model. Ported
+code should not introduce new `rand` usage; the migration of the existing tie-break
+path lands in its own PR before STARsolo (whose UMI dedup depends on deterministic
+order). This is a behavioural change from STAR's per-thread RNG and is flagged here
+for team discussion.
+
+## Validation
+
+STAR-rs's `DIVERGENCES.md` (entries D1-D24) enumerates every intentional difference
+from the native-STAR oracle, each locked by a named test. Treat it as the acceptance
+spec: a ported feature should match native STAR except where DIVERGENCES.md documents
+an intentional difference.
+
+rustar-aligner already has a differential harness under `test/` (`compare_sam.py`,
+`compare_pe.py`, `assess_faithfulness.py`, `compare_junctions.py`,
+`compare_chimeric.py`, driven by `test/ci.sh`) that runs native STAR and diffs
+outputs. Use it to validate each port against `STAR` on the yeast test set; it is a
+local/manual harness and is not part of the GitHub `alls-green` CI gate.
+
+Every PR must still pass the standard gate: `cargo build`, `cargo test`,
+`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and MSRV
+`cargo +1.89 check`.

--- a/src/clip/mod.rs
+++ b/src/clip/mod.rs
@@ -1,0 +1,234 @@
+//! Adapter-aware read clipping (STAR `ClipMate` / `ParametersClip`, Hamming mode).
+//!
+//! Ported from STAR-rs `crates/star-align/src/star_clip.rs`. Extends the plain
+//! `--clip5pNbases`/`--clip3pNbases` fixed clip with a 3' adapter Hamming scan
+//! (`--clip3pAdapterSeq`/`--clip3pAdapterMMp`) and the after-adapter trim
+//! (`--clip{5,3}pAfterAdapterNbases`).
+//!
+//! STAR removes the clipped bases from the read before mapping (the mapped read
+//! is the clipped one); this module reproduces the clip amounts. rustar-aligner
+//! feeds the clipped read straight to the aligner and to SAM output (matching its
+//! existing `--clip5pNbases`/`--clip3pNbases` convention), so clipped bases are
+//! dropped rather than reinserted as soft-clips.
+//!
+//! STAR clips a mate as two passes in order: 5' first (`clip5pNbases`, then
+//! `clip5pAfterAdapterNbases`), then 3' on the 5'-clipped read (`clip3pNbases`,
+//! then the 3' adapter Hamming scan, then `clip3pAfterAdapterNbases`).
+//!
+//! Only `--clipAdapterType Hamming` (STAR's default) is supported; a 5' Hamming
+//! adapter is not a thing STAR itself supports either (only `CellRanger4` mode
+//! clips a 5' adapter, the 10x TSO) — that mode is out of scope here.
+
+use crate::io::fastq::encode_base;
+use crate::params::Parameters;
+
+/// One end's clipping parameters (STAR `ClipMate`). `n` = fixed clip, `adapter` =
+/// the adapter sequence (ASCII; empty = none), `ad_mmp` = max mismatch fraction,
+/// `n_after` = extra clip after the adapter.
+#[derive(Debug, Clone, Default)]
+pub struct ClipEnd {
+    /// `--clip{5,3}pNbases` for this end.
+    pub n: usize,
+    /// `--clip3pAdapterSeq` (ASCII), empty when none. Only meaningful for the 3' end.
+    pub adapter: Vec<u8>,
+    /// `--clip3pAdapterMMp` (default 0.1).
+    pub ad_mmp: f64,
+    /// `--clip{5,3}pAfterAdapterNbases`.
+    pub n_after: usize,
+}
+
+/// One mate's clipping parameters: the 5' and 3' ends.
+#[derive(Debug, Clone, Default)]
+pub struct ClipParams {
+    /// 5' end (STAR `ClipMate` type 0).
+    pub five: ClipEnd,
+    /// 3' end (STAR `ClipMate` type 1).
+    pub three: ClipEnd,
+}
+
+/// Build [`ClipParams`] from the run's `--clip{5,3}pNbases` / `--clip3pAdapterSeq`
+/// / `--clip3pAdapterMMp` / `--clip{5,3}pAfterAdapterNbases`. `-` (STAR's sentinel)
+/// means no adapter. Built once per run and reused for every read.
+pub fn clip_params_from(params: &Parameters) -> ClipParams {
+    let adapter = if params.clip3p_adapter_seq == "-" {
+        Vec::new()
+    } else {
+        params.clip3p_adapter_seq.as_bytes().to_vec()
+    };
+    ClipParams {
+        five: ClipEnd {
+            n: params.clip5p_nbases as usize,
+            adapter: Vec::new(),
+            ad_mmp: 0.0,
+            n_after: params.clip5p_after_adapter_nbases as usize,
+        },
+        three: ClipEnd {
+            n: params.clip3p_nbases as usize,
+            adapter,
+            ad_mmp: params.clip3p_adapter_mmp,
+            n_after: params.clip3p_after_adapter_nbases as usize,
+        },
+    }
+}
+
+/// STAR `localSearch`: the offset `ixBest` in `x` where `y` best matches (max
+/// matches, then min mismatches, subject to `nMM/nMatch <= p_mm`); `nx` when no
+/// acceptable match (so nothing clips).
+fn local_search(x: &[u8], y: &[u8], p_mm: f64) -> usize {
+    let nx = x.len();
+    let ny = y.len();
+    let (mut best_ix, mut best_match, mut best_mm) = (nx, 0usize, 0usize);
+    for ix in 0..nx {
+        let (mut n_match, mut n_mm) = (0usize, 0usize);
+        for iy in 0..ny.min(nx - ix) {
+            if x[ix + iy] > 3 {
+                continue;
+            }
+            if x[ix + iy] == y[iy] {
+                n_match += 1;
+            } else {
+                n_mm += 1;
+            }
+        }
+        if (n_match > best_match || (n_match == best_match && n_mm < best_mm))
+            && (n_match == 0 || n_mm as f64 / n_match as f64 <= p_mm)
+        {
+            best_ix = ix;
+            best_match = n_match;
+            best_mm = n_mm;
+        }
+    }
+    best_ix
+}
+
+/// Clip one mate (STAR's two `ClipMate::clip` passes: 5' then 3'). Returns
+/// `(clip5p_total, clip3p_total)`; the clipped region is
+/// `read[clip5p_total .. len-clip3p_total]`.
+///
+/// STAR marks a `ClipMate` inactive (no clip at all) when it has no fixed clip
+/// AND no adapter: an end's `n_after` alone is a no-op, matching the oracle.
+pub fn clip_mate(read: &[u8], p: &ClipParams) -> (usize, usize) {
+    let len = read.len();
+
+    // ---- 5' end (STAR ClipMate type 0) ----
+    let five_active = p.five.n > 0;
+    let mut c5 = 0;
+    if five_active {
+        c5 = p.five.n.min(len);
+        if p.five.n_after > 0 {
+            c5 += p.five.n_after.min(len - c5);
+        }
+    }
+
+    // ---- 3' end (STAR ClipMate type 1), on the 5'-clipped read ----
+    let three_active = p.three.n > 0 || !p.three.adapter.is_empty();
+    let s = &read[c5..];
+    let sl = s.len();
+    let mut c3 = 0;
+    if three_active {
+        c3 = p.three.n.min(sl);
+        if !p.three.adapter.is_empty() {
+            // Hamming 3' adapter scan on the read after the fixed 3' clip.
+            let x_num: Vec<u8> = s[..sl - c3].iter().map(|&b| encode_base(b)).collect();
+            let y_num: Vec<u8> = p.three.adapter.iter().map(|&b| encode_base(b)).collect();
+            let nx = x_num.len();
+            let ix_best = local_search(&x_num, &y_num, p.three.ad_mmp);
+            c3 += nx - ix_best;
+        }
+        if p.three.n_after > 0 {
+            let remaining = sl.saturating_sub(c3);
+            c3 += p.three.n_after.min(remaining);
+        }
+    }
+
+    (c5, c3)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hamming_3p(adapter: &[u8], mmp: f64) -> ClipParams {
+        ClipParams {
+            three: ClipEnd {
+                adapter: adapter.to_vec(),
+                ad_mmp: mmp,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fixed_5p_3p() {
+        let p = ClipParams {
+            five: ClipEnd {
+                n: 3,
+                ..Default::default()
+            },
+            three: ClipEnd {
+                n: 2,
+                ..Default::default()
+            },
+        };
+        assert_eq!(clip_mate(b"AAACCCGGGTT", &p), (3, 2));
+    }
+
+    #[test]
+    fn adapter_3p_hamming() {
+        // Adapter "AGATCGGAAGAGC"; read = insert + adapter tail -> the 13-base tail is clipped.
+        let p = hamming_3p(b"AGATCGGAAGAGC", 0.1);
+        let (c5, c3) = clip_mate(b"CCCCGGGGAGATCGGAAGAGC", &p);
+        assert_eq!((c5, c3), (0, 13));
+    }
+
+    #[test]
+    fn adapter_3p_mmp_rejects_when_strict() {
+        // One mismatch in a 13-base adapter: allowed at 0.1 (1/12<=0.1), rejected at 0.0.
+        let read = b"CCCCGGGGAGATCGGAtGAGC"; // 't' lowercase -> code T, a mismatch vs adapter G
+        let read = &read.to_ascii_uppercase();
+        let (_, c3_loose) = clip_mate(read, &hamming_3p(b"AGATCGGAAGAGC", 0.1));
+        assert_eq!(c3_loose, 13);
+        let (_, c3_strict) = clip_mate(read, &hamming_3p(b"AGATCGGAAGAGC", 0.0));
+        assert_eq!(c3_strict, 0);
+    }
+
+    #[test]
+    fn after_adapter_alone_is_noop() {
+        // STAR's inactive-end short-circuit: n_after with no fixed clip and no adapter clips nothing.
+        let p = ClipParams {
+            five: ClipEnd {
+                n_after: 4,
+                ..Default::default()
+            },
+            three: ClipEnd {
+                n_after: 4,
+                ..Default::default()
+            },
+        };
+        assert_eq!(clip_mate(b"ACGTACGTACGTACGTACGT", &p), (0, 0));
+    }
+
+    #[test]
+    fn after_adapter_nbases_3p() {
+        let mut p = hamming_3p(b"AGATCGGAAGAGC", 0.1);
+        p.three.n_after = 3;
+        let (_, c3) = clip_mate(b"CCCCGGGGAGATCGGAAGAGC", &p);
+        assert_eq!(c3, 16); // 13 adapter + 3 after
+    }
+
+    #[test]
+    fn no_adapter_configured_only_fixed_clips() {
+        let p = ClipParams {
+            five: ClipEnd {
+                n: 2,
+                ..Default::default()
+            },
+            three: ClipEnd {
+                n: 1,
+                ..Default::default()
+            },
+        };
+        assert_eq!(clip_mate(b"AAACCCGGGTT", &p), (2, 1));
+    }
+}

--- a/src/index/suffix_array.rs
+++ b/src/index/suffix_array.rs
@@ -275,7 +275,7 @@ mod tests {
         let first_base = genome.sequence[first_pos as usize];
 
         // In "AAB", the first suffix lexicographically is "A" (from pos 0 or 1)
-        assert!(first_base == 0); // A
+        assert_eq!(first_base, 0); // A
     }
 
     /// Differential: the caps-sa-backed builder must produce a `PackedArray`

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1516,8 +1516,8 @@ mod tests {
         assert!(rgs.contains_key(&b"rg0"[..]));
         let map = rgs.get(&b"rg0"[..]).unwrap();
         // SM and LB should be present as other_fields
-        let sm_tag = HeaderOtherTag::<_>::try_from([b'S', b'M']).unwrap();
-        let lb_tag = HeaderOtherTag::<_>::try_from([b'L', b'B']).unwrap();
+        let sm_tag = HeaderOtherTag::<_>::try_from(*b"SM").unwrap();
+        let lb_tag = HeaderOtherTag::<_>::try_from(*b"LB").unwrap();
         let sm: &[u8] = map.other_fields().get(&sm_tag).unwrap().as_ref();
         let lb: &[u8] = map.other_fields().get(&lb_tag).unwrap().as_ref();
         assert_eq!(sm, b"sample0");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod params;
 
 pub mod align;
 pub mod chimeric;
+pub mod clip;
 pub mod cpu;
 pub mod genome;
 pub mod index;
@@ -934,8 +935,7 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
     };
 
     let batch_size = 10000;
-    let clip5p = params.clip5p_nbases as usize;
-    let clip3p = params.clip3p_nbases as usize;
+    let clip_params = crate::clip::clip_params_from(params);
     let max_multimaps = params.out_filter_multimap_nmax as usize;
     let output_unmapped = params.out_sam_unmapped != params::OutSamUnmapped::None;
     let write_unmapped_fastq = params.out_reads_unmapped == params::OutReadsUnmapped::Fastx;
@@ -992,6 +992,7 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                 let quant = quant.as_ref().map(Arc::clone);
 
                 // Apply clipping
+                let (clip5p, clip3p) = crate::clip::clip_mate(&read.sequence, &clip_params);
                 let (clipped_seq, clipped_qual) =
                     clip_read(&read.sequence, &read.quality, clip5p, clip3p);
 
@@ -1365,8 +1366,7 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
     };
 
     let batch_size = 10000;
-    let clip5p = params.clip5p_nbases as usize;
-    let clip3p = params.clip3p_nbases as usize;
+    let clip_params = crate::clip::clip_params_from(params);
     let max_multimaps = params.out_filter_multimap_nmax as usize;
     let output_unmapped = params.out_sam_unmapped != params::OutSamUnmapped::None;
     let write_unmapped_fastq = params.out_reads_unmapped == params::OutReadsUnmapped::Fastx;
@@ -1421,18 +1421,23 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                 let sj_stats = Arc::clone(&sj_stats);
                 let quant = quant.as_ref().map(Arc::clone);
 
-                // Apply clipping to both mates
+                // Apply clipping to both mates (each mate's adapter position is
+                // scanned independently, so clip_mate runs once per mate).
+                let (m1_clip5p, m1_clip3p) =
+                    crate::clip::clip_mate(&paired_read.mate1.sequence, &clip_params);
+                let (m2_clip5p, m2_clip3p) =
+                    crate::clip::clip_mate(&paired_read.mate2.sequence, &clip_params);
                 let (m1_seq, m1_qual) = clip_read(
                     &paired_read.mate1.sequence,
                     &paired_read.mate1.quality,
-                    clip5p,
-                    clip3p,
+                    m1_clip5p,
+                    m1_clip3p,
                 );
                 let (m2_seq, m2_qual) = clip_read(
                     &paired_read.mate2.sequence,
                     &paired_read.mate2.quality,
-                    clip5p,
-                    clip3p,
+                    m2_clip5p,
+                    m2_clip3p,
                 );
 
                 let mut buffer = BufferedSamRecords::new();

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -296,6 +296,22 @@ pub struct Parameters {
     #[arg(long = "clip3pNbases", default_value_t = 0)]
     pub clip3p_nbases: u32,
 
+    /// 3' adapter sequence to clip (Hamming scan), `-` = none
+    #[arg(long = "clip3pAdapterSeq", default_value = "-")]
+    pub clip3p_adapter_seq: String,
+
+    /// Max mismatch proportion for the 3' adapter clip
+    #[arg(long = "clip3pAdapterMMp", default_value_t = 0.1)]
+    pub clip3p_adapter_mmp: f64,
+
+    /// Extra bases to clip from the 3' end after the adapter
+    #[arg(long = "clip3pAfterAdapterNbases", default_value_t = 0)]
+    pub clip3p_after_adapter_nbases: u32,
+
+    /// Extra bases to clip from the 5' end after `clip5pNbases`
+    #[arg(long = "clip5pAfterAdapterNbases", default_value_t = 0)]
+    pub clip5p_after_adapter_nbases: u32,
+
     // ── Output ──────────────────────────────────────────────────────────
     /// Output file name prefix (including path)
     #[arg(long = "outFileNamePrefix", default_value = "./")]

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -1036,13 +1036,10 @@ fn align_to_one_transcript(
         } else {
             // Coalesce: extend the last projected exon by this block's length
             // (STAR adds block EX_L directly — does NOT update start position).
-            if let Some(last) = proj_exons.last_mut() {
-                let len = block_end - block_start;
-                last.genome_end += len;
-                last.read_end = block.read_end;
-            } else {
-                return None;
-            }
+            let last = proj_exons.last_mut()?;
+            let len = block_end - block_start;
+            last.genome_end += len;
+            last.read_end = block.read_end;
         }
 
         // Advance `ex` across any splice boundary BEFORE the next block,

--- a/tests/alignment_features.rs
+++ b/tests/alignment_features.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 
 /// LCG pseudo-random sequence generator (identical LCG to existing tests).
 fn lcg_seq(seed: u32, length: usize) -> Vec<u8> {
-    let bases: [u8; 4] = [b'A', b'C', b'G', b'T'];
+    let bases: [u8; 4] = *b"ACGT";
     let mut state = seed;
     let mut seq = Vec::with_capacity(length);
     for _ in 0..length {


### PR DESCRIPTION
## Summary
- Port STAR-rs's Hamming-mode adapter clipping (`crates/star-align/src/star_clip.rs`), extending rustar-aligner's existing fixed-count `--clip5pNbases`/`--clip3pNbases` with a 3' adapter scan and after-adapter trim.
- `src/clip/mod.rs`: `ClipEnd`/`ClipParams` + `clip_mate` (STAR's two ClipMate passes) + `local_search` (STAR's `localSearch` Hamming scan).
- Themed split of the original bundled WASP+everything PR, per `docs-old/dev/porting-from-star-rs.md`.

## Test plan
- [x] cargo build / test / clippy -D warnings / fmt --check all green