### PR TITLE
feat: coverage signal / Signal.*.out.bg bedGraph tracks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ src/
     segment.rs     -- ChimericSegment and ChimericAlignment data structures
     score.rs       -- Junction type classification, repeat length calculation
     output.rs      -- Chimeric.out.junction writer (14-column format)
+  signal/
+    mod.rs         -- Coverage signal / Signal.*.out.bg bedGraph tracks (--outWigType bedGraph, stranded)
 ```
 
 ## Development Philosophy — Match STAR Exactly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "assert_cmd"
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -639,9 +639,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,3 +1,9 @@
 The original MIT STAR license is included here for attribution to the original author Alexander Dobin
 
 The LICENSE of this repo has been chosen to also be MIT to match that of the STAR repo https://github.com/alexdobin/STAR
+
+`STAR_RS_LICENSE` is the MIT license of [STAR-rs](https://github.com/BenjaminDEMAILLE/STAR-rs)
+(Copyright (c) 2026 Benjamin Demaille), included for attribution of modules ported
+from STAR-rs into rustar-aligner. STAR-rs is dual-licensed `MIT OR Apache-2.0`; the
+ported code is taken under its MIT option, which is compatible with this repo's MIT
+license. See `docs-old/dev/porting-from-star-rs.md` for the porting conventions.

--- a/LICENSES/STAR_RS_LICENSE
+++ b/LICENSES/STAR_RS_LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benjamin Demaille
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs-old/dev/porting-from-star-rs.md
+++ b/docs-old/dev/porting-from-star-rs.md
@@ -1,0 +1,75 @@
+# Porting features from STAR-rs into rustar-aligner
+
+This note records the conventions for bringing features over from
+[STAR-rs](https://github.com/BenjaminDEMAILLE/STAR-rs) (a clean-room Rust re-port of
+STAR 2.7.11b, validated byte-identical against native STAR) into rustar-aligner.
+It is the shared reference for the themed, dependency-stacked porting PRs.
+
+## Why
+
+rustar-aligner and STAR-rs are two independent Rust reimplementations of STAR.
+rustar-aligner already covers single/paired-end alignment, splice junctions,
+two-pass, 4-tier chimeric, GeneCounts, TranscriptomeSAM and sorted BAM. STAR-rs
+additionally implements STARsolo, STARlong, WASP, genome transforms, signal tracks,
+adapter clipping, PE mate-overlap, SuperTranscriptome, liftOver and more. These
+notes cover moving that surface over, one theme per PR.
+
+## Licensing
+
+STAR-rs is dual-licensed `MIT OR Apache-2.0` (Copyright (c) 2026 Benjamin Demaille).
+Ported code is taken under the **MIT** option, compatible with this repo's MIT
+license. `LICENSES/STAR_RS_LICENSE` preserves the STAR-rs MIT notice for attribution.
+
+**Never copy `vendor/cellranger-upstream` code from STAR-rs.** It is 10x Genomics
+source-available (non-OSI) and kept in STAR-rs as algorithm *reference only*. When
+porting STARsolo, reimplement the algorithms from the STAR C++ source, as STAR-rs did.
+
+## Type / module mapping
+
+STAR-rs is a 10-crate workspace (`star_core`, `star_index`, `star_seed`,
+`star_align`, `star_cli`, ...); rustar-aligner is a single crate (`rustar_aligner`)
+with a flat module tree. A ported file's `use star_*::...` header is repointed to
+`crate::...`, and the core types are adapted field-by-field:
+
+| STAR-rs | rustar-aligner (`src/align/transcript.rs`) |
+| --- | --- |
+| `star_align::star_model::Transcript` | `crate::align::transcript::Transcript` |
+| `Exon { r, g, len, i_frag }` | `Exon { read_start, genome_start, genome_end, i_frag }` (start+end, not start+len) |
+| `tr.str_: u8` (0 fwd / 1 rev) | `tr.is_reverse: bool` |
+| `tr.chr` | `tr.chr_idx` |
+| `tr.n_exons()` | `tr.exons.len()` |
+| `star_core::Cigar` (derived from exons late) | `Vec<noodles ...::cigar::Op>` (materialized in `Transcript`) |
+| `star_index::load::StarGenome` (unified) | split `genome::Genome` + `index::GenomeIndex` + `index::suffix_array::SuffixArray` |
+
+Base encoding is identical in both: `A=0, C=1, G=2, T=3, N=4`, reverse complement in
+the second half of the genome array.
+
+## Determinism
+
+rustar-aligner currently uses `rand` (`StdRng`, seeded by `--runRNGseed`) for
+multimapper-order / tie-break randomness. STAR-rs instead uses a hand-rolled,
+per-read-seeded `splitmix64` shuffle so output is **byte-identical regardless of
+thread count** (a stronger correctness property than STAR's per-thread `mt19937`).
+
+**Decision for the porting effort:** adopt STAR-rs's thread-invariant model. Ported
+code should not introduce new `rand` usage; the migration of the existing tie-break
+path lands in its own PR before STARsolo (whose UMI dedup depends on deterministic
+order). This is a behavioural change from STAR's per-thread RNG and is flagged here
+for team discussion.
+
+## Validation
+
+STAR-rs's `DIVERGENCES.md` (entries D1-D24) enumerates every intentional difference
+from the native-STAR oracle, each locked by a named test. Treat it as the acceptance
+spec: a ported feature should match native STAR except where DIVERGENCES.md documents
+an intentional difference.
+
+rustar-aligner already has a differential harness under `test/` (`compare_sam.py`,
+`compare_pe.py`, `assess_faithfulness.py`, `compare_junctions.py`,
+`compare_chimeric.py`, driven by `test/ci.sh`) that runs native STAR and diffs
+outputs. Use it to validate each port against `STAR` on the yeast test set; it is a
+local/manual harness and is not part of the GitHub `alls-green` CI gate.
+
+Every PR must still pass the standard gate: `cargo build`, `cargo test`,
+`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and MSRV
+`cargo +1.89 check`.

--- a/src/index/suffix_array.rs
+++ b/src/index/suffix_array.rs
@@ -275,7 +275,7 @@ mod tests {
         let first_base = genome.sequence[first_pos as usize];
 
         // In "AAB", the first suffix lexicographically is "A" (from pos 0 or 1)
-        assert!(first_base == 0); // A
+        assert_eq!(first_base, 0); // A
     }
 
     /// Differential: the caps-sa-backed builder must produce a `PackedArray`

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1516,8 +1516,8 @@ mod tests {
         assert!(rgs.contains_key(&b"rg0"[..]));
         let map = rgs.get(&b"rg0"[..]).unwrap();
         // SM and LB should be present as other_fields
-        let sm_tag = HeaderOtherTag::<_>::try_from([b'S', b'M']).unwrap();
-        let lb_tag = HeaderOtherTag::<_>::try_from([b'L', b'B']).unwrap();
+        let sm_tag = HeaderOtherTag::<_>::try_from(*b"SM").unwrap();
+        let lb_tag = HeaderOtherTag::<_>::try_from(*b"LB").unwrap();
         let sm: &[u8] = map.other_fields().get(&sm_tag).unwrap().as_ref();
         let lb: &[u8] = map.other_fields().get(&lb_tag).unwrap().as_ref();
         assert_eq!(sm, b"sample0");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod io;
 pub mod junction;
 pub mod mapq;
 pub mod quant;
+pub mod signal;
 pub mod stats;
 
 use log::info;
@@ -661,6 +662,12 @@ struct AlignmentBatchResults {
     unmapped_mate1: Vec<(String, Vec<u8>, Vec<u8>)>,
     /// Unmapped mate2 reads (PE only). Empty unless outReadsUnmapped=Fastx.
     unmapped_mate2: Vec<(String, Vec<u8>, Vec<u8>)>,
+    /// `--outWigType bedGraph` signal contributions: (transcript, is_second_mate)
+    /// per reported alignment. Empty unless enabled and the read/pair mapped
+    /// within the multimap limit. `signal_n_tr` is the shared NH for all of them
+    /// (transcripts.len() for SE, both_mapped.len() for PE).
+    signal_contrib: Vec<(crate::align::transcript::Transcript, bool)>,
+    signal_n_tr: usize,
 }
 
 /// Build transcriptome-space records for a single-end read.  Projects every
@@ -884,6 +891,47 @@ fn extract_junction_keys(
     keys
 }
 
+/// Write the four `--outWigType bedGraph` stranded tracks (STAR's `Signal.{Unique,
+/// UniqueMultiple}.str{1,2}.out.bg`). No-op if `signal` is `None` (feature disabled).
+/// RPM scales the `Unique` tracks by `1e6/nUniq` and `UniqueMultiple` by
+/// `1e6/(nUniq+nMult)` (STAR `signalFromBAM` `normFactor[0]` vs `[1]`); one norm
+/// for both would double `UniqueMultiple` when multimappers exist.
+fn write_signal_tracks(
+    signal: Option<&crate::signal::Signal>,
+    sig_n_uniq: u64,
+    sig_n_mult: u64,
+    params: &Parameters,
+) -> anyhow::Result<()> {
+    let Some(sig) = signal else {
+        return Ok(());
+    };
+    let norm_unique = if sig_n_uniq > 0 {
+        1.0e6 / sig_n_uniq as f64
+    } else {
+        0.0
+    };
+    let norm_mult = if sig_n_uniq + sig_n_mult > 0 {
+        1.0e6 / (sig_n_uniq + sig_n_mult) as f64
+    } else {
+        0.0
+    };
+    for (unique, strand, file) in [
+        (true, 0, "Signal.Unique.str1.out.bg"),
+        (false, 0, "Signal.UniqueMultiple.str1.out.bg"),
+        (true, 1, "Signal.Unique.str2.out.bg"),
+        (false, 1, "Signal.UniqueMultiple.str2.out.bg"),
+    ] {
+        let body = if params.out_wig_rpm() {
+            let norm = if unique { norm_unique } else { norm_mult };
+            sig.bedgraph_rpm(unique, strand, norm)
+        } else {
+            sig.bedgraph(unique, strand)
+        };
+        std::fs::write(params.output_path(file), body)?;
+    }
+    Ok(())
+}
+
 /// Align single-end reads
 #[allow(clippy::too_many_arguments)]
 fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
@@ -940,6 +988,17 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
     let output_unmapped = params.out_sam_unmapped != params::OutSamUnmapped::None;
     let write_unmapped_fastq = params.out_reads_unmapped == params::OutReadsUnmapped::Fastx;
     let by_sjout = params.out_filter_type == OutFilterType::BySJout;
+
+    // --outWigType bedGraph: accumulate the stranded coverage signal over every
+    // reported alignment. Folded sequentially (not thread-safe across the
+    // parallel per-read closures), matching how sam/transcriptome records are
+    // already merged in chunk order below.
+    let out_wig_bedgraph = params.out_wig_bedgraph();
+    let mut signal = out_wig_bedgraph
+        .then(|| crate::signal::Signal::new(&index.genome.chr_name, &index.genome.chr_length));
+    // RPM normalization counters (STAR signalFromBAM `nUniq`/`nMult`): a mapped
+    // read contributes to `nUniq` when uniquely mapped (NH==1), else 1 to `nMult`.
+    let (mut sig_n_uniq, mut sig_n_mult) = (0u64, 0u64);
 
     // BySJout disk buffer: SAM records written to a temp file; only compact metadata kept in RAM.
     // For 100M reads this avoids ~60 GB of Vec<RecordBuf> in memory.
@@ -1031,6 +1090,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                         transcriptome_records: Vec::new(),
                         unmapped_mate1: unmapped_m1,
                         unmapped_mate2: Vec::new(),
+                        signal_contrib: Vec::new(),
+                        signal_n_tr: 0,
                     });
                 }
 
@@ -1084,6 +1145,11 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                     };
 
                 // Build SAM records (no I/O, just construction)
+                // --outWigType bedGraph: gathered below only when mapped within the
+                // multimap limit (the same set that gets written to SAM/BAM).
+                let mut signal_contrib = Vec::new();
+                let signal_n_tr = transcripts.len();
+
                 let is_unmapped_se = transcripts.is_empty();
                 if is_unmapped_se {
                     // Unmapped
@@ -1110,6 +1176,9 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                     )?;
                     for record in records {
                         buffer.push(record);
+                    }
+                    if out_wig_bedgraph {
+                        signal_contrib = transcripts.iter().cloned().map(|t| (t, false)).collect();
                     }
                 }
                 // else: too many loci, skip output
@@ -1144,6 +1213,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                     transcriptome_records,
                     unmapped_mate1: unmapped_m1,
                     unmapped_mate2: Vec::new(),
+                    signal_contrib,
+                    signal_n_tr,
                 })
             })
             .collect();
@@ -1151,6 +1222,19 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
         if by_sjout {
             for result in batch_results {
                 let batch = result?;
+                // --outWigType bedGraph: fold this read's contribution into the signal.
+                if let Some(sig) = signal.as_mut()
+                    && !batch.signal_contrib.is_empty()
+                {
+                    if batch.signal_n_tr == 1 {
+                        sig_n_uniq += 1;
+                    } else {
+                        sig_n_mult += 1;
+                    }
+                    for (tr, second_mate) in &batch.signal_contrib {
+                        sig.add_transcript(&index.genome, tr, batch.signal_n_tr, *second_mate);
+                    }
+                }
                 // Write SAM records to temp file (disk, not RAM)
                 let n_sam_records = batch.sam_records.records.len() as u32;
                 if let (Some(tw), Some(hdr)) = (&mut bysj_temp_writer, &bysj_sam_header) {
@@ -1174,6 +1258,20 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
             // Normal mode: sequential writing (merge buffers in chunk order)
             for result in batch_results {
                 let batch = result?;
+
+                // --outWigType bedGraph: fold this read's contribution into the signal.
+                if let Some(sig) = signal.as_mut()
+                    && !batch.signal_contrib.is_empty()
+                {
+                    if batch.signal_n_tr == 1 {
+                        sig_n_uniq += 1;
+                    } else {
+                        sig_n_mult += 1;
+                    }
+                    for (tr, second_mate) in &batch.signal_contrib {
+                        sig.add_transcript(&index.genome, tr, batch.signal_n_tr, *second_mate);
+                    }
+                }
 
                 // Write SAM/BAM records
                 writer.write_batch(&batch.sam_records.records)?;
@@ -1304,6 +1402,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
         uw.flush()?;
     }
 
+    write_signal_tracks(signal.as_ref(), sig_n_uniq, sig_n_mult, params)?;
+
     Ok(())
 }
 
@@ -1371,6 +1471,13 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
     let output_unmapped = params.out_sam_unmapped != params::OutSamUnmapped::None;
     let write_unmapped_fastq = params.out_reads_unmapped == params::OutReadsUnmapped::Fastx;
     let by_sjout = params.out_filter_type == OutFilterType::BySJout;
+
+    // --outWigType bedGraph: accumulate the stranded coverage signal over every
+    // reported alignment (both mates), folded sequentially per pair.
+    let out_wig_bedgraph = params.out_wig_bedgraph();
+    let mut signal = out_wig_bedgraph
+        .then(|| crate::signal::Signal::new(&index.genome.chr_name, &index.genome.chr_length));
+    let (mut sig_n_uniq, mut sig_n_mult) = (0u64, 0u64);
 
     // BySJout disk buffer: SAM records to temp file, compact metadata in RAM.
     let bysj_temp = if by_sjout {
@@ -1485,6 +1592,8 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                         transcriptome_records: Vec::new(),
                         unmapped_mate1: um1,
                         unmapped_mate2: um2,
+                        signal_contrib: Vec::new(),
+                        signal_n_tr: 0,
                     });
                 }
 
@@ -1506,6 +1615,11 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                         }
                     })
                     .collect();
+
+                // --outWigType bedGraph: gathered below only for both-mapped pairs
+                // within the multimap limit (the same set written to SAM/BAM).
+                let mut signal_contrib = Vec::new();
+                let signal_n_tr = both_mapped.len();
 
                 if results.is_empty() {
                     stats.record_alignment(n_for_mapq, max_multimaps);
@@ -1668,6 +1782,17 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     for record in records {
                         buffer.push(record);
                     }
+                    if out_wig_bedgraph {
+                        signal_contrib = paired_alns
+                            .iter()
+                            .flat_map(|pa| {
+                                [
+                                    (pa.mate1_transcript.clone(), false),
+                                    (pa.mate2_transcript.clone(), true),
+                                ]
+                            })
+                            .collect();
+                    }
                 }
                 // else: too many loci, skip output
 
@@ -1722,6 +1847,8 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     transcriptome_records,
                     unmapped_mate1,
                     unmapped_mate2,
+                    signal_contrib,
+                    signal_n_tr,
                 })
             })
             .collect();
@@ -1729,6 +1856,19 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
         if by_sjout {
             for result in batch_results {
                 let batch = result?;
+                // --outWigType bedGraph: fold this pair's contribution into the signal.
+                if let Some(sig) = signal.as_mut()
+                    && !batch.signal_contrib.is_empty()
+                {
+                    if batch.signal_n_tr == 1 {
+                        sig_n_uniq += 1;
+                    } else {
+                        sig_n_mult += 1;
+                    }
+                    for (tr, second_mate) in &batch.signal_contrib {
+                        sig.add_transcript(&index.genome, tr, batch.signal_n_tr, *second_mate);
+                    }
+                }
                 let n_sam_records = batch.sam_records.records.len() as u32;
                 if let (Some(tw), Some(hdr)) = (&mut bysj_temp_writer, &bysj_sam_header) {
                     crate::io::sam::bysj_write_records(tw, hdr, &batch.sam_records.records)?;
@@ -1755,6 +1895,19 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
             // Normal mode: sequential SAM writing
             for result in batch_results {
                 let batch = result?;
+                // --outWigType bedGraph: fold this pair's contribution into the signal.
+                if let Some(sig) = signal.as_mut()
+                    && !batch.signal_contrib.is_empty()
+                {
+                    if batch.signal_n_tr == 1 {
+                        sig_n_uniq += 1;
+                    } else {
+                        sig_n_mult += 1;
+                    }
+                    for (tr, second_mate) in &batch.signal_contrib {
+                        sig.add_transcript(&index.genome, tr, batch.signal_n_tr, *second_mate);
+                    }
+                }
                 writer.write_batch(&batch.sam_records.records)?;
                 if let Some(ref mut tw) = tr_writer {
                     tw.write_batch(&batch.transcriptome_records)?;
@@ -1864,6 +2017,8 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
     if let Some(ref mut uw2) = unmapped_writer2 {
         uw2.flush()?;
     }
+
+    write_signal_tracks(signal.as_ref(), sig_n_uniq, sig_n_mult, params)?;
 
     Ok(())
 }

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -296,6 +296,20 @@ pub struct Parameters {
     #[arg(long = "clip3pNbases", default_value_t = 0)]
     pub clip3p_nbases: u32,
 
+    /// Coverage signal output: `None` (default) or `bedGraph`. `wiggle` and a 2nd
+    /// word (`read1_5p`/`read2`) are rejected (see `Parameters::validate`)
+    #[arg(long = "outWigType", num_args = 1.., default_values_t = vec![String::from("None")])]
+    pub out_wig_type: Vec<String>,
+
+    /// Coverage-signal normalization: `RPM` (default) or `None` (raw counts)
+    #[arg(long = "outWigNorm", default_value = "RPM")]
+    pub out_wig_norm: String,
+
+    /// Coverage-signal strandedness: `Stranded` (default). `Unstranded` is
+    /// rejected (see `Parameters::validate`)
+    #[arg(long = "outWigStrand", default_value = "Stranded")]
+    pub out_wig_strand: String,
+
     // ── Output ──────────────────────────────────────────────────────────
     /// Output file name prefix (including path)
     #[arg(long = "outFileNamePrefix", default_value = "./")]
@@ -917,6 +931,41 @@ impl Parameters {
             ));
         }
 
+        // --outWigType at alignReads: only `bedGraph` (stranded, full-length) is
+        // implemented. `wiggle`, `--outWigStrand Unstranded`, and the 2nd word
+        // (`read1_5p`/`read2`) are STAR features of `--runMode
+        // inputAlignmentsFromBAM`, which rustar-aligner doesn't have; reject them
+        // loudly rather than silently emitting bedGraph / stranded / full-length
+        // tracks instead.
+        if params
+            .out_wig_type
+            .iter()
+            .any(|t| !t.eq_ignore_ascii_case("None"))
+        {
+            if params
+                .out_wig_type
+                .iter()
+                .any(|t| t.eq_ignore_ascii_case("wiggle"))
+            {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "--outWigType wiggle is not implemented; use --outWigType bedGraph",
+                ));
+            }
+            if params.out_wig_strand.eq_ignore_ascii_case("Unstranded") {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "--outWigStrand Unstranded is not implemented; use --outWigStrand Stranded",
+                ));
+            }
+            if params.out_wig_type.len() > 1 {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "the --outWigType 2nd word (read1_5p / read2) is not implemented; omit it",
+                ));
+            }
+        }
+
         Ok(params)
     }
 
@@ -928,6 +977,18 @@ impl Parameters {
     /// Returns true if `--quantMode TranscriptomeSAM` was requested.
     pub fn quant_transcriptome_sam(&self) -> bool {
         self.quant_mode.iter().any(|m| m == "TranscriptomeSAM")
+    }
+
+    /// Returns true if `--outWigType bedGraph` was requested.
+    pub fn out_wig_bedgraph(&self) -> bool {
+        self.out_wig_type
+            .iter()
+            .any(|t| t.eq_ignore_ascii_case("bedGraph"))
+    }
+
+    /// Returns true unless `--outWigNorm None` was requested (RPM is the default).
+    pub fn out_wig_rpm(&self) -> bool {
+        !self.out_wig_norm.eq_ignore_ascii_case("None")
     }
 }
 

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -1036,13 +1036,10 @@ fn align_to_one_transcript(
         } else {
             // Coalesce: extend the last projected exon by this block's length
             // (STAR adds block EX_L directly — does NOT update start position).
-            if let Some(last) = proj_exons.last_mut() {
-                let len = block_end - block_start;
-                last.genome_end += len;
-                last.read_end = block.read_end;
-            } else {
-                return None;
-            }
+            let last = proj_exons.last_mut()?;
+            let len = block_end - block_start;
+            last.genome_end += len;
+            last.read_end = block.read_end;
         }
 
         // Advance `ex` across any splice boundary BEFORE the next block,

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -1,0 +1,258 @@
+//! Coverage signal / `Signal.*.out.bg` bedGraph output (STAR `signalFromBAM.cpp`,
+//! `--outWigType bedGraph`, stranded).
+//!
+//! Ported from STAR-rs `crates/star-align/src/star_wig.rs`. Per strand (str1 =
+//! forward, str2 = reverse) two tracks accumulate: `Unique` (only `NH == 1`
+//! reads, +1 per covered base) and `UniqueMultiple` (every reported alignment,
+//! `+1/NH`). bedGraph intervals are emitted wherever the coverage changes.
+//!
+//! Only `--outWigType bedGraph` (stranded, full-length) is implemented, matching
+//! STAR-rs's own align-time scope: `wiggle`, `--outWigStrand Unstranded`, and the
+//! `--outWigType` 2nd word (`read1_5p`/`read2`) selector are only available via
+//! STAR's `--runMode inputAlignmentsFromBAM`, which neither STAR-rs nor
+//! rustar-aligner implement at align time. `Parameters::validate` rejects them
+//! loudly rather than silently emitting the wrong tracks.
+
+use crate::align::transcript::Transcript;
+use crate::genome::Genome;
+
+/// Per-chromosome coverage for the two strands, `Unique` and `UniqueMultiple` tracks.
+pub struct Signal {
+    /// `[chr][strand] = (unique, unique_multiple)`, each `chr_len + 1` bases (STAR's trailing zero).
+    per_chr: Vec<[(Vec<f64>, Vec<f64>); 2]>,
+    chr_len: Vec<usize>,
+    chr_name: Vec<String>,
+}
+
+impl Signal {
+    pub fn new(chr_name: &[String], chr_length: &[u64]) -> Self {
+        let chr_len: Vec<usize> = chr_length.iter().map(|&l| l as usize).collect();
+        let per_chr = chr_len
+            .iter()
+            .map(|&l| {
+                [
+                    (vec![0.0; l + 1], vec![0.0; l + 1]),
+                    (vec![0.0; l + 1], vec![0.0; l + 1]),
+                ]
+            })
+            .collect();
+        Self {
+            per_chr,
+            chr_len,
+            chr_name: chr_name.to_vec(),
+        }
+    }
+
+    /// Accumulate covered genomic `M`-blocks (chr-local `(start, len)`) on one strand
+    /// with `NH = n_tr`: `+1` to `Unique` iff `n_tr == 1`, always `+1/n_tr` to
+    /// `UniqueMultiple`. Introns and deletions are simply the gaps between blocks.
+    pub fn add_blocks(
+        &mut self,
+        chr: usize,
+        strand: usize,
+        blocks: &[(usize, usize)],
+        n_tr: usize,
+    ) {
+        let (uniq, umult) = {
+            let s = &mut self.per_chr[chr][strand];
+            (&mut s.0, &mut s.1)
+        };
+        let w = 1.0 / n_tr as f64;
+        for &(g0, len) in blocks {
+            for p in g0..g0 + len {
+                if n_tr == 1 {
+                    uniq[p] += 1.0;
+                }
+                umult[p] += w;
+            }
+        }
+    }
+
+    /// Accumulate one reported alignment (`tr`) with `NH = n_tr`. Only exon blocks
+    /// are covered; introns/deletions between exons are skipped by the block's
+    /// genomic jump. `second_mate` selects STAR's `iStrand` rule (`signalFromBAM.cpp`):
+    /// `iStrand = is_reverse == is_not_second_mate` — mate1 (and SE) use the
+    /// alignment's own strand directly, mate2's is flipped.
+    pub fn add_transcript(
+        &mut self,
+        genome: &Genome,
+        tr: &Transcript,
+        n_tr: usize,
+        second_mate: bool,
+    ) {
+        let cs = genome.chr_start[tr.chr_idx];
+        let blocks: Vec<(usize, usize)> = tr
+            .exons
+            .iter()
+            .map(|ex| {
+                (
+                    (ex.genome_start - cs) as usize,
+                    (ex.genome_end - ex.genome_start) as usize,
+                )
+            })
+            .collect();
+        let strand = usize::from(tr.is_reverse != second_mate);
+        self.add_blocks(tr.chr_idx, strand, &blocks, n_tr);
+    }
+
+    /// bedGraph text for one track (`unique = true` for the `Unique` track, else
+    /// `UniqueMultiple`) on one strand (0 = str1, 1 = str2), un-normalized
+    /// (`--outWigNorm None`). STAR emits `chr start end value` per constant-coverage run.
+    pub fn bedgraph(&self, unique: bool, strand: usize) -> String {
+        self.bedgraph_fmt(unique, strand, fmt_g6)
+    }
+
+    /// bedGraph text normalized to reads-per-million (`--outWigNorm RPM`): each
+    /// coverage value is scaled by `norm` (`1e6 / nReadsUnique`) and printed with 5
+    /// decimals, matching STAR.
+    pub fn bedgraph_rpm(&self, unique: bool, strand: usize, norm: f64) -> String {
+        self.bedgraph_fmt(unique, strand, |v| format!("{:.5}", v * norm))
+    }
+
+    /// The shared bedGraph run-length emitter; `fmt` renders one coverage value.
+    fn bedgraph_fmt(&self, unique: bool, strand: usize, fmt: impl Fn(f64) -> String) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        for chr in 0..self.chr_len.len() {
+            let track = if unique {
+                &self.per_chr[chr][strand].0
+            } else {
+                &self.per_chr[chr][strand].1
+            };
+            let mut prev = 0.0f64;
+            for ig in 0..=self.chr_len[chr] {
+                let new = if ig < track.len() { track[ig] } else { 0.0 };
+                // Exact comparison is intentional: `new`/`prev` are read back
+                // unmodified from the accumulator, so a run boundary is a real
+                // change, not float noise (clippy::float_cmp).
+                #[allow(clippy::float_cmp)]
+                let changed = new != prev;
+                if changed {
+                    if prev != 0.0 {
+                        let _ = writeln!(out, "{}\t{}", ig, fmt(prev));
+                    }
+                    if new != 0.0 {
+                        let _ = write!(out, "{}\t{}\t", self.chr_name[chr], ig);
+                    }
+                    prev = new;
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Format a coverage value like C++'s default `ostream` for `--outWigNorm None`:
+/// `%g` with 6 significant digits (NOT 6 decimal places). Integers print without a
+/// decimal point; for `|v| >= 1` the number of fractional digits is
+/// `5 - floor(log10|v|)` (so a total of 6 significant digits), then trailing zeros
+/// and a trailing `.` are stripped. Values `|v| < 1` keep 6 fractional digits (the
+/// leading `0.` does not count toward significant digits at these magnitudes).
+/// Coverage sums are small and positive, so the scientific branch of `%g` never
+/// triggers here.
+pub(crate) fn fmt_g6(v: f64) -> String {
+    // Exact comparison is intentional: this checks whether `v` is a whole number
+    // (to print it without a decimal point), not an approximate-equality test
+    // (clippy::float_cmp).
+    #[allow(clippy::float_cmp)]
+    let is_integer = v == v.trunc();
+    if is_integer && v.abs() < 1e15 {
+        return format!("{}", v as i64);
+    }
+    let decimals = if v.abs() >= 1.0 {
+        (5 - v.abs().log10().floor() as i64).max(0) as usize
+    } else {
+        6
+    };
+    let mut s = format!("{v:.decimals$}");
+    while s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::align::transcript::Exon;
+    use noodles::sam::alignment::record::cigar::{Op, op::Kind};
+
+    fn tr_fwd(chr_idx: usize, genome_start: u64, len: u64) -> Transcript {
+        Transcript {
+            chr_idx,
+            genome_start,
+            genome_end: genome_start + len,
+            is_reverse: false,
+            exons: vec![Exon {
+                genome_start,
+                genome_end: genome_start + len,
+                read_start: 0,
+                read_end: len as usize,
+                i_frag: 0,
+            }],
+            cigar: vec![Op::new(Kind::Match, len as usize)],
+            score: len as i32 - 1,
+            n_mismatch: 0,
+            n_gap: 0,
+            n_junction: 0,
+            junction_motifs: vec![],
+            junction_annotated: vec![],
+            read_seq: vec![],
+        }
+    }
+
+    #[test]
+    fn fmt_g6_matches_cpp_percent_g() {
+        assert_eq!(fmt_g6(1.0), "1");
+        assert_eq!(fmt_g6(5.0), "5");
+        assert_eq!(fmt_g6(0.5), "0.5");
+        assert_eq!(fmt_g6(1.0 + 1.0 / 3.0), "1.33333");
+        assert_eq!(fmt_g6(1.0 / 3.0), "0.333333");
+        assert_eq!(fmt_g6(12.0 + 5.0 / 6.0), "12.8333");
+        assert_eq!(fmt_g6(100.0 + 1.0 / 3.0), "100.333");
+    }
+
+    #[test]
+    fn add_blocks_unique_and_multi() {
+        let mut sig = Signal::new(&["chrI".to_string()], &[100]);
+        sig.add_blocks(0, 0, &[(10, 5)], 1);
+        assert_eq!(sig.bedgraph(true, 0), "chrI\t10\t15\t1\n");
+        assert_eq!(sig.bedgraph(false, 0), "chrI\t10\t15\t1\n");
+    }
+
+    #[test]
+    fn add_blocks_multimapper_splits_weight() {
+        let mut sig = Signal::new(&["chrI".to_string()], &[100]);
+        sig.add_blocks(0, 0, &[(10, 2)], 2);
+        // Not unique -> no Unique track contribution, UniqueMultiple gets 1/2.
+        assert_eq!(sig.bedgraph(true, 0), "");
+        assert_eq!(sig.bedgraph(false, 0), "chrI\t10\t12\t0.5\n");
+    }
+
+    #[test]
+    fn add_transcript_mate2_strand_is_flipped() {
+        let mut sig = Signal::new(&["chrI".to_string()], &[100]);
+        let genome = crate::genome::Genome {
+            sequence: vec![],
+            n_genome: 100,
+            n_genome_real: 100,
+            n_chr_real: 1,
+            chr_name: vec!["chrI".to_string()],
+            chr_length: vec![100],
+            chr_start: vec![0],
+        };
+        let tr = tr_fwd(0, 10, 5); // forward alignment
+        // SE / mate1: forward alignment -> str1 (strand 0).
+        sig.add_transcript(&genome, &tr, 1, false);
+        assert_eq!(sig.bedgraph(true, 0), "chrI\t10\t15\t1\n");
+        assert_eq!(sig.bedgraph(true, 1), "");
+        // mate2: forward alignment -> flipped to str2 (strand 1).
+        let mut sig2 = Signal::new(&["chrI".to_string()], &[100]);
+        sig2.add_transcript(&genome, &tr, 1, true);
+        assert_eq!(sig2.bedgraph(true, 0), "");
+        assert_eq!(sig2.bedgraph(true, 1), "chrI\t10\t15\t1\n");
+    }
+}

--- a/tests/alignment_features.rs
+++ b/tests/alignment_features.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 
 /// LCG pseudo-random sequence generator (identical LCG to existing tests).
 fn lcg_seq(seed: u32, length: usize) -> Vec<u8> {
-    let bases: [u8; 4] = [b'A', b'C', b'G', b'T'];
+    let bases: [u8; 4] = *b"ACGT";
     let mut state = seed;
     let mut seq = Vec::with_capacity(length);
     for _ in 0..length {


### PR DESCRIPTION
## Summary
- Port STAR-rs's align-time coverage signal (`crates/star-align/src/star_wig.rs`, itself a port of STAR's `signalFromBAM.cpp`).
- `src/signal/mod.rs`: `Signal` (per-chromosome, per-strand Unique/UniqueMultiple f64 tracks), `add_blocks`, `add_transcript`, `bedgraph`/`bedgraph_rpm`, `fmt_g6`.
- `--outWigType bedGraph` (stranded, full-length); `wiggle`/`Unstranded`/2nd-word variants rejected loudly (not implemented).
- Themed split of the original bundled WASP+everything PR, per `docs-old/dev/porting-from-star-rs.md`.

## Test plan
- [x] cargo build / test / clippy -D warnings / fmt --check all green