### PR TITLE
feat: genomeGenerate VCF genome transform (--genomeTransformType Haploid)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ src/
   genome/
     mod.rs         -- Genome struct, padding logic, reverse complement, file writing
     fasta.rs       -- FASTA parser, base encoding (A=0,C=1,G=2,T=3,N=4)
+    transform.rs   -- --genomeTransformType Haploid VCF-allele substitution (genomeGenerate-time only)
   index/
     mod.rs         -- GenomeIndex (build + load + write)
     packed_array.rs-- Variable-width bit packing (1-64 bits per element)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "assert_cmd"
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -639,9 +639,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,3 +1,9 @@
 The original MIT STAR license is included here for attribution to the original author Alexander Dobin
 
 The LICENSE of this repo has been chosen to also be MIT to match that of the STAR repo https://github.com/alexdobin/STAR
+
+`STAR_RS_LICENSE` is the MIT license of [STAR-rs](https://github.com/BenjaminDEMAILLE/STAR-rs)
+(Copyright (c) 2026 Benjamin Demaille), included for attribution of modules ported
+from STAR-rs into rustar-aligner. STAR-rs is dual-licensed `MIT OR Apache-2.0`; the
+ported code is taken under its MIT option, which is compatible with this repo's MIT
+license. See `docs-old/dev/porting-from-star-rs.md` for the porting conventions.

--- a/LICENSES/STAR_RS_LICENSE
+++ b/LICENSES/STAR_RS_LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Benjamin Demaille
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs-old/dev/porting-from-star-rs.md
+++ b/docs-old/dev/porting-from-star-rs.md
@@ -1,0 +1,75 @@
+# Porting features from STAR-rs into rustar-aligner
+
+This note records the conventions for bringing features over from
+[STAR-rs](https://github.com/BenjaminDEMAILLE/STAR-rs) (a clean-room Rust re-port of
+STAR 2.7.11b, validated byte-identical against native STAR) into rustar-aligner.
+It is the shared reference for the themed, dependency-stacked porting PRs.
+
+## Why
+
+rustar-aligner and STAR-rs are two independent Rust reimplementations of STAR.
+rustar-aligner already covers single/paired-end alignment, splice junctions,
+two-pass, 4-tier chimeric, GeneCounts, TranscriptomeSAM and sorted BAM. STAR-rs
+additionally implements STARsolo, STARlong, WASP, genome transforms, signal tracks,
+adapter clipping, PE mate-overlap, SuperTranscriptome, liftOver and more. These
+notes cover moving that surface over, one theme per PR.
+
+## Licensing
+
+STAR-rs is dual-licensed `MIT OR Apache-2.0` (Copyright (c) 2026 Benjamin Demaille).
+Ported code is taken under the **MIT** option, compatible with this repo's MIT
+license. `LICENSES/STAR_RS_LICENSE` preserves the STAR-rs MIT notice for attribution.
+
+**Never copy `vendor/cellranger-upstream` code from STAR-rs.** It is 10x Genomics
+source-available (non-OSI) and kept in STAR-rs as algorithm *reference only*. When
+porting STARsolo, reimplement the algorithms from the STAR C++ source, as STAR-rs did.
+
+## Type / module mapping
+
+STAR-rs is a 10-crate workspace (`star_core`, `star_index`, `star_seed`,
+`star_align`, `star_cli`, ...); rustar-aligner is a single crate (`rustar_aligner`)
+with a flat module tree. A ported file's `use star_*::...` header is repointed to
+`crate::...`, and the core types are adapted field-by-field:
+
+| STAR-rs | rustar-aligner (`src/align/transcript.rs`) |
+| --- | --- |
+| `star_align::star_model::Transcript` | `crate::align::transcript::Transcript` |
+| `Exon { r, g, len, i_frag }` | `Exon { read_start, genome_start, genome_end, i_frag }` (start+end, not start+len) |
+| `tr.str_: u8` (0 fwd / 1 rev) | `tr.is_reverse: bool` |
+| `tr.chr` | `tr.chr_idx` |
+| `tr.n_exons()` | `tr.exons.len()` |
+| `star_core::Cigar` (derived from exons late) | `Vec<noodles ...::cigar::Op>` (materialized in `Transcript`) |
+| `star_index::load::StarGenome` (unified) | split `genome::Genome` + `index::GenomeIndex` + `index::suffix_array::SuffixArray` |
+
+Base encoding is identical in both: `A=0, C=1, G=2, T=3, N=4`, reverse complement in
+the second half of the genome array.
+
+## Determinism
+
+rustar-aligner currently uses `rand` (`StdRng`, seeded by `--runRNGseed`) for
+multimapper-order / tie-break randomness. STAR-rs instead uses a hand-rolled,
+per-read-seeded `splitmix64` shuffle so output is **byte-identical regardless of
+thread count** (a stronger correctness property than STAR's per-thread `mt19937`).
+
+**Decision for the porting effort:** adopt STAR-rs's thread-invariant model. Ported
+code should not introduce new `rand` usage; the migration of the existing tie-break
+path lands in its own PR before STARsolo (whose UMI dedup depends on deterministic
+order). This is a behavioural change from STAR's per-thread RNG and is flagged here
+for team discussion.
+
+## Validation
+
+STAR-rs's `DIVERGENCES.md` (entries D1-D24) enumerates every intentional difference
+from the native-STAR oracle, each locked by a named test. Treat it as the acceptance
+spec: a ported feature should match native STAR except where DIVERGENCES.md documents
+an intentional difference.
+
+rustar-aligner already has a differential harness under `test/` (`compare_sam.py`,
+`compare_pe.py`, `assess_faithfulness.py`, `compare_junctions.py`,
+`compare_chimeric.py`, driven by `test/ci.sh`) that runs native STAR and diffs
+outputs. Use it to validate each port against `STAR` on the yeast test set; it is a
+local/manual harness and is not part of the GitHub `alls-green` CI gate.
+
+Every PR must still pass the standard gate: `cargo build`, `cargo test`,
+`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and MSRV
+`cargo +1.89 check`.

--- a/src/align/read_align.rs
+++ b/src/align/read_align.rs
@@ -1505,6 +1505,7 @@ mod tests {
         }
 
         let genome = Genome {
+            transform_blocks: None,
             sequence,
             n_genome,
             n_genome_real: n_genome,

--- a/src/align/score.rs
+++ b/src/align/score.rs
@@ -634,6 +634,7 @@ mod tests {
         }
 
         Genome {
+            transform_blocks: None,
             sequence,
             n_genome,
             n_genome_real: n_genome,

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -3019,6 +3019,7 @@ mod tests {
         }
 
         let genome = Genome {
+            transform_blocks: None,
             sequence,
             n_genome,
             n_genome_real: n_genome,
@@ -3141,6 +3142,7 @@ mod tests {
         }
 
         let genome = Genome {
+            transform_blocks: None,
             sequence,
             n_genome,
             n_genome_real: n_genome,

--- a/src/chimeric/detect.rs
+++ b/src/chimeric/detect.rs
@@ -993,6 +993,7 @@ mod tests {
         let n_genome = chr_pad * 2;
         let sequence = vec![0u8; 2 * n_genome as usize];
         Genome {
+            transform_blocks: None,
             sequence,
             n_genome,
             n_genome_real: n_genome,

--- a/src/chimeric/output.rs
+++ b/src/chimeric/output.rs
@@ -434,6 +434,7 @@ mod tests {
     fn make_genome_2chr() -> crate::genome::Genome {
         use crate::genome::Genome;
         Genome {
+            transform_blocks: None,
             sequence: vec![0u8; 2048],
             n_genome: 1024,
             n_genome_real: 1024,

--- a/src/chimeric/score.rs
+++ b/src/chimeric/score.rs
@@ -171,6 +171,7 @@ mod tests {
 
     fn mock_genome_with_sequence(seq: Vec<u8>) -> Genome {
         Genome {
+            transform_blocks: None,
             sequence: seq,
             n_genome: 100,
             n_genome_real: 100,

--- a/src/genome/mod.rs
+++ b/src/genome/mod.rs
@@ -1,4 +1,5 @@
 pub mod fasta;
+pub mod transform;
 
 use std::path::Path;
 
@@ -43,6 +44,32 @@ pub struct Genome {
     /// Padded start positions of each chromosome in the genome.
     /// Length = n_chr_real + 1; the last entry is n_genome (total size).
     pub chr_start: Vec<u64>,
+
+    /// `--genomeTransformType Haploid` block map (`[orig_start, length, new_start]`,
+    /// forward-genome coordinates), `None` unless a transform was applied. Written
+    /// to `transformGenomeBlocks.tsv` by [`write_index_files`](Self::write_index_files).
+    pub transform_blocks: Option<Vec<[u64; 3]>>,
+}
+
+/// Compute STAR's bin-padded chromosome start offsets: `chr_start[i]` is chromosome
+/// `i`'s 0-based start in the padded forward genome; the trailing `chr_start[n]` is
+/// the total padded (forward) genome size. Shared by [`Genome::from_fasta`] and
+/// [`transform`] (which must reproduce the same padding independently, once over
+/// the original chromosome lengths and once over the transformed ones).
+pub(crate) fn compute_chr_starts(chr_lengths: &[u64], chr_bin_nbits: u32) -> Vec<u64> {
+    let bin_size = 1u64 << chr_bin_nbits;
+    let mut chr_start = Vec::with_capacity(chr_lengths.len() + 1);
+    let mut n: u64 = 0;
+    for &len in chr_lengths {
+        if n > 0 {
+            n = ((n + 1) / bin_size + 1) * bin_size;
+        }
+        chr_start.push(n);
+        n += len;
+    }
+    n = ((n + 1) / bin_size + 1) * bin_size;
+    chr_start.push(n);
+    chr_start
 }
 
 impl Genome {
@@ -54,46 +81,46 @@ impl Genome {
     /// # Returns
     /// A `Genome` with forward + reverse complement sequences and metadata.
     pub fn from_fasta(params: &Parameters) -> Result<Self, Error> {
-        let chromosomes = parse_fasta_files(&params.genome_fasta_files)?;
-
-        // Compute padding bin size
+        let mut chromosomes = parse_fasta_files(&params.genome_fasta_files)?;
         let bin_nbits = params.genome_chr_bin_nbits;
-        let bin_size = 1u64 << bin_nbits;
 
-        // First pass: compute padded positions and total genome size
+        // --genomeTransformType Haploid: substitute the VCF alleles into the
+        // chromosome sequences before padding/SA build. Indels shift lengths;
+        // Genome::from_fasta's own padding pass (below) re-derives chr_start
+        // from the (now transformed) chromosome lengths, so it automatically
+        // matches the block map's `new_start` globalization in `transform`.
+        let transform_blocks = if params.genome_transform_type.eq_ignore_ascii_case("Haploid") {
+            let vcf_path = params
+                .genome_transform_vcf
+                .as_ref()
+                .expect("validated: Haploid requires --genomeTransformVCF");
+            let vcf_text = std::fs::read_to_string(vcf_path).map_err(|e| Error::io(e, vcf_path))?;
+            let chr_name: Vec<String> = chromosomes.iter().map(|c| c.name.clone()).collect();
+            let variants = transform::parse_vcf_haploid(&vcf_text, &chr_name);
+            let transformed = transform::transform_chromosomes(&chromosomes, &variants, bin_nbits);
+            chromosomes = transformed.chromosomes;
+            Some(transformed.blocks)
+        } else {
+            None
+        };
+
+        // First pass: chromosome names/lengths, validating non-zero length.
         let mut chr_name = Vec::new();
         let mut chr_length = Vec::new();
-        let mut chr_start = Vec::new();
-
-        let mut n: u64 = 0; // current position in the padded genome
-
         for chrom in &chromosomes {
             let len = chrom.sequence.len() as u64;
-
             if len == 0 {
                 return Err(Error::Fasta(format!(
                     "chromosome '{}' has zero length",
                     chrom.name
                 )));
             }
-
-            // Apply STAR's padding formula before this chromosome (except for the first)
-            if n > 0 {
-                n = ((n + 1) / bin_size + 1) * bin_size;
-            }
-
             chr_name.push(chrom.name.clone());
             chr_length.push(len);
-            chr_start.push(n);
-
-            n += len;
         }
 
-        // Final padding after the last chromosome
-        n = ((n + 1) / bin_size + 1) * bin_size;
-        let n_genome = n;
-        chr_start.push(n_genome); // STAR adds this extra entry
-
+        let chr_start = compute_chr_starts(&chr_length, bin_nbits);
+        let n_genome = *chr_start.last().unwrap();
         let n_chr_real = chromosomes.len();
 
         // Allocate buffer: forward (0..n_genome) + reverse (n_genome..2*n_genome)
@@ -122,6 +149,7 @@ impl Genome {
             chr_name,
             chr_length,
             chr_start,
+            transform_blocks,
         })
     }
 
@@ -249,6 +277,13 @@ impl Genome {
         // keys via `<<` streaming; the leading `###` comment lines are
         // skipped.
         self.write_genome_parameters_txt(dir, params)?;
+
+        // --genomeTransformType Haploid: the block map for reverse conversion.
+        if let Some(blocks) = &self.transform_blocks {
+            let blocks_path = dir.join("transformGenomeBlocks.tsv");
+            fs::write(&blocks_path, transform::blocks_to_tsv(blocks))
+                .map_err(|e| Error::io(e, &blocks_path))?;
+        }
 
         Ok(())
     }

--- a/src/genome/transform.rs
+++ b/src/genome/transform.rs
@@ -1,0 +1,310 @@
+//! `--genomeTransformType Haploid` (STAR `Genome_transformGenome.cpp`): substitute VCF alleles into
+//! the genome before the suffix array is built, so reads carrying the alternate allele align with
+//! fewer mismatches.
+//!
+//! Ported from STAR-rs `crates/star-index/src/transform.rs`. Only **Haploid** (one allele per site,
+//! including indels that shift coordinates and split the `transformGenomeBlocks.tsv` block map) is
+//! implemented; **Diploid** (the genome duplicated into `_h1`/`_h2` haplotypes) is a follow-up. With
+//! the only supported `--genomeTransformOutput` (`None`, the default) this is a pure `genomeGenerate`
+//! transform: the aligner reports transformed-genome coordinates directly, so no align-time
+//! back-transform is implemented either (that's a separate follow-up, gated in `Parameters::validate`).
+//!
+//! Unlike STAR-rs, which transforms an already-laid-out, bin-padded genome buffer, this operates on
+//! rustar-aligner's `Vec<Chromosome>` (name + unpadded base-code sequence) directly, before
+//! [`Genome::from_fasta`](super::Genome::from_fasta)'s own padding pass runs. Blocks are computed in
+//! two stages: substitution happens in chromosome-local coordinates (no padding involved), then
+//! globalized using [`compute_chr_starts`](super::compute_chr_starts) run once over the original
+//! chromosome lengths and once over the transformed lengths — the same deterministic function
+//! `Genome::from_fasta` itself uses, so the geometry is guaranteed to match the final on-disk index.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use crate::io::fastq::encode_base;
+
+use super::compute_chr_starts;
+use super::fasta::Chromosome;
+
+/// One VCF variant applied to a chromosome: 0-based chr-local `pos`, the reference length, and the
+/// alternate allele bytes (raw ASCII letters; [`encode_base`] is applied at substitution time).
+#[derive(Debug, Clone)]
+pub struct Variant {
+    pub pos: u64,
+    pub ref_len: usize,
+    pub alt: Vec<u8>,
+}
+
+impl Variant {
+    /// STAR's `len = alt.size() - ref.size()` (0 for a SNV, `>0` insertion, `<0` deletion).
+    fn len_delta(&self) -> i64 {
+        self.alt.len() as i64 - self.ref_len as i64
+    }
+}
+
+/// Parse a VCF for the Haploid transform (`Genome_transformGenome.cpp:41-107`): every record on a
+/// known chromosome contributes its **first** alternate allele (no genotype filtering); `#` lines and
+/// records on unknown chromosomes are skipped. Returns per-chromosome-index variants, each list sorted
+/// by position with STAR's overlap filter applied (keep a variant only if it starts at or after the
+/// end of the last kept one).
+pub fn parse_vcf_haploid(text: &str, chr_name: &[String]) -> BTreeMap<usize, Vec<Variant>> {
+    let index: BTreeMap<&str, usize> = chr_name
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.as_str(), i))
+        .collect();
+
+    let mut per_chr: BTreeMap<usize, Vec<Variant>> = BTreeMap::new();
+    for line in text.lines() {
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        let f: Vec<&str> = line.split_whitespace().collect();
+        if f.len() < 5 {
+            continue;
+        }
+        let Some(&ci) = index.get(f[0]) else {
+            continue;
+        };
+        let Ok(pos1): Result<u64, _> = f[1].parse() else {
+            continue;
+        };
+        if pos1 == 0 {
+            continue;
+        }
+        let ref_allele = f[3].as_bytes();
+        // STAR takes the FIRST alternate allele for Haploid (`altV[0]`).
+        let alt = f[4].split(',').next().unwrap_or(f[4]).as_bytes().to_vec();
+        per_chr.entry(ci).or_default().push(Variant {
+            pos: pos1 - 1,
+            ref_len: ref_allele.len(),
+            alt,
+        });
+    }
+
+    for variants in per_chr.values_mut() {
+        *variants = filter_sort_variants(std::mem::take(variants));
+    }
+    per_chr
+}
+
+/// Sort variants by position and apply STAR's overlap filter: keep a variant only if it starts at or
+/// after the end of the previously kept variant's reference span.
+fn filter_sort_variants(mut variants: Vec<Variant>) -> Vec<Variant> {
+    variants.sort_by_key(|v| v.pos);
+    let mut kept: Vec<Variant> = Vec::with_capacity(variants.len());
+    let mut g0: u64 = 0;
+    for v in variants {
+        if v.pos >= g0 {
+            g0 = v.pos + v.ref_len as u64;
+            kept.push(v);
+        }
+    }
+    kept
+}
+
+/// One chromosome's Haploid substitution, in chromosome-LOCAL coordinates (no padding): the
+/// transformed sequence, and its blocks `[orig_local_start, len, new_local_start]` (globalized by the
+/// caller). A chromosome with no variants yields one identity block spanning the whole sequence.
+fn transform_one_chromosome(seq: &[u8], variants: &[Variant]) -> (Vec<u8>, Vec<[u64; 3]>) {
+    if variants.is_empty() {
+        return (seq.to_vec(), vec![[0, seq.len() as u64, 0]]);
+    }
+
+    let cl0 = seq.len() as u64;
+    let mut gnew: Vec<u8> = Vec::with_capacity(seq.len());
+    let mut blocks: Vec<[u64; 3]> = Vec::new();
+    let mut iv = 0usize;
+    let mut g0: u64 = 0;
+    let mut g1: u64 = 0;
+    blocks.push([g0, 0, g1]); // first block
+
+    while g0 < cl0 {
+        if g0 == variants[iv].pos {
+            let v = &variants[iv];
+            for &b in &v.alt {
+                gnew.push(encode_base(b));
+            }
+            g0 += v.ref_len as u64;
+            g1 += v.alt.len() as u64;
+            if v.len_delta() != 0 {
+                // Close the previous block; STAR's length formula, then open a new one.
+                let last = blocks.last_mut().unwrap();
+                last[1] = g0 - v.ref_len as u64 + v.ref_len.min(v.alt.len()) as u64 - last[0];
+                blocks.push([g0, 0, g1]);
+            }
+            if iv < variants.len() - 1 {
+                iv += 1;
+            }
+        } else {
+            gnew.push(seq[g0 as usize]);
+            g0 += 1;
+            g1 += 1;
+        }
+    }
+    if blocks.last().unwrap()[1] == 0 {
+        let last = blocks.last_mut().unwrap();
+        last[1] = g0 - last[0];
+    }
+    (gnew, blocks)
+}
+
+/// The result of transforming a genome's chromosome list: the substituted chromosomes, and the global
+/// `[orig_start, length, new_start]` block map (STAR's `array<uint64,3>`), in chromosome order.
+pub struct TransformedGenome {
+    pub chromosomes: Vec<Chromosome>,
+    pub blocks: Vec<[u64; 3]>,
+}
+
+/// Apply the Haploid VCF transform to a genome's chromosome list. `variants` maps a chromosome index
+/// (matching `chromosomes`' order) to its filtered, sorted variants (from [`parse_vcf_haploid`]);
+/// `chr_bin_nbits` is `--genomeChrBinNbits`, used only to globalize the block coordinates the same way
+/// [`Genome::from_fasta`](super::Genome::from_fasta) will pad the transformed chromosomes.
+pub fn transform_chromosomes(
+    chromosomes: &[Chromosome],
+    variants: &BTreeMap<usize, Vec<Variant>>,
+    chr_bin_nbits: u32,
+) -> TransformedGenome {
+    let orig_lengths: Vec<u64> = chromosomes
+        .iter()
+        .map(|c| c.sequence.len() as u64)
+        .collect();
+
+    let empty: Vec<Variant> = Vec::new();
+    let mut new_chromosomes = Vec::with_capacity(chromosomes.len());
+    let mut local_blocks_per_chr: Vec<Vec<[u64; 3]>> = Vec::with_capacity(chromosomes.len());
+    for (ci, chrom) in chromosomes.iter().enumerate() {
+        let vs = variants.get(&ci).unwrap_or(&empty);
+        let (seq, blocks) = transform_one_chromosome(&chrom.sequence, vs);
+        new_chromosomes.push(Chromosome {
+            name: chrom.name.clone(),
+            sequence: seq,
+        });
+        local_blocks_per_chr.push(blocks);
+    }
+
+    let new_lengths: Vec<u64> = new_chromosomes
+        .iter()
+        .map(|c| c.sequence.len() as u64)
+        .collect();
+    let orig_chr_start = compute_chr_starts(&orig_lengths, chr_bin_nbits);
+    let new_chr_start = compute_chr_starts(&new_lengths, chr_bin_nbits);
+
+    let mut blocks = Vec::new();
+    for (ci, local) in local_blocks_per_chr.into_iter().enumerate() {
+        for [lo, len, ln] in local {
+            blocks.push([orig_chr_start[ci] + lo, len, new_chr_start[ci] + ln]);
+        }
+    }
+
+    TransformedGenome {
+        chromosomes: new_chromosomes,
+        blocks,
+    }
+}
+
+/// Render `transformGenomeBlocks.tsv` (STAR's `transformBlocksWrite`): header `<nBlocks>\t-1`, then
+/// one `new_start\tlength\torig_start` line per block (reverting the stored
+/// `[orig_start, length, new_start]` order, for reverse conversion).
+pub fn blocks_to_tsv(blocks: &[[u64; 3]]) -> String {
+    let mut s = format!("{}\t-1\n", blocks.len());
+    for b in blocks {
+        let _ = writeln!(s, "{}\t{}\t{}", b[2], b[1], b[0]);
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_first_alt_and_filters_overlaps() {
+        let chr = vec!["chr1".to_string(), "chr2".to_string()];
+        let vcf = "\
+##fileformat=VCFv4.2
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+chr1\t10\t.\tG\tA,T\t.\t.\t.
+chrX\t5\t.\tG\tA\t.\t.\t.
+chr2\t3\t.\tC\tT\t.\t.\t.
+";
+        let v = parse_vcf_haploid(vcf, &chr);
+        assert_eq!(v[&0].len(), 1);
+        assert_eq!(v[&0][0].pos, 9); // 0-based
+        assert_eq!(v[&0][0].alt, b"A"); // first alt only
+        assert_eq!(v[&1][0].pos, 2);
+        assert_eq!(v[&1][0].alt, b"T");
+        assert!(!v.contains_key(&2)); // chrX not in index; only 2 contigs
+    }
+
+    #[test]
+    fn snv_substitution_and_identity_blocks() {
+        let chromosomes = vec![
+            Chromosome {
+                name: "chr1".to_string(),
+                sequence: vec![2, 2, 2, 2, 2], // GGGGG
+            },
+            Chromosome {
+                name: "chr2".to_string(),
+                sequence: vec![2, 2, 2, 2], // GGGG
+            },
+        ];
+        let mut variants = BTreeMap::new();
+        variants.insert(
+            0usize,
+            vec![Variant {
+                pos: 2,
+                ref_len: 1,
+                alt: b"A".to_vec(),
+            }],
+        );
+        let t = transform_chromosomes(&chromosomes, &variants, 18);
+        assert_eq!(t.chromosomes[0].sequence[2], 0); // A code
+        assert_eq!(t.chromosomes[0].sequence.len(), 5);
+        assert_eq!(t.chromosomes[1].sequence.len(), 4);
+        // One identity block per chromosome; lengths unchanged.
+        let cs = compute_chr_starts(&[5, 4], 18);
+        assert_eq!(t.blocks, vec![[cs[0], 5, cs[0]], [cs[1], 4, cs[1]]]);
+    }
+
+    #[test]
+    fn indel_shifts_coordinates_and_splits_blocks() {
+        // chr1 = 6 bases; a 1-base insertion at pos 2 (ref C -> alt CTT, +2) then a deletion at pos 4
+        // (ref GA -> alt G, -1). Net length 6 + 2 - 1 = 7.
+        let chromosomes = vec![Chromosome {
+            name: "chr1".to_string(),
+            sequence: vec![0, 0, 1, 2, 2, 0], // AACGGA
+        }];
+        let mut variants = BTreeMap::new();
+        variants.insert(
+            0usize,
+            vec![
+                Variant {
+                    pos: 2,
+                    ref_len: 1,
+                    alt: b"CTT".to_vec(),
+                },
+                Variant {
+                    pos: 4,
+                    ref_len: 2,
+                    alt: b"G".to_vec(),
+                },
+            ],
+        );
+        let t = transform_chromosomes(&chromosomes, &variants, 18);
+        assert_eq!(t.chromosomes[0].sequence.len(), 7);
+        let seq: Vec<u8> = t.chromosomes[0]
+            .sequence
+            .iter()
+            .map(|&c| b"ACGT"[c as usize])
+            .collect();
+        assert_eq!(&seq, b"AACTTGG");
+        // Blocks split at each indel: [orig_start, length, new_start] (global, chr1 starts at 0).
+        assert_eq!(t.blocks[0], [0, 3, 0]);
+    }
+
+    #[test]
+    fn blocks_to_tsv_reverts_column_order() {
+        let tsv = blocks_to_tsv(&[[0, 5, 0], [5, 2, 7]]);
+        assert_eq!(tsv, "2\t-1\n0\t5\t0\n7\t2\t5\n");
+    }
+}

--- a/src/index/io.rs
+++ b/src/index/io.rs
@@ -218,6 +218,9 @@ fn load_genome(genome_dir: &Path, _params: &Parameters) -> Result<Genome, Error>
         chr_name,
         chr_length,
         chr_start,
+        // Loading transformGenomeBlocks.tsv back is only needed for the
+        // (not yet implemented) align-time back-transform.
+        transform_blocks: None,
     })
 }
 

--- a/src/index/suffix_array.rs
+++ b/src/index/suffix_array.rs
@@ -275,7 +275,7 @@ mod tests {
         let first_base = genome.sequence[first_pos as usize];
 
         // In "AAB", the first suffix lexicographically is "A" (from pos 0 or 1)
-        assert!(first_base == 0); // A
+        assert_eq!(first_base, 0); // A
     }
 
     /// Differential: the caps-sa-backed builder must produce a `PackedArray`

--- a/src/io/bam.rs
+++ b/src/io/bam.rs
@@ -465,6 +465,7 @@ mod tests {
 
     fn create_test_genome() -> Genome {
         Genome {
+            transform_blocks: None,
             sequence: vec![0, 1, 2, 3, 0, 1, 2, 3], // ACGTACGT
             n_genome: 8,
             n_genome_real: 8,

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1516,8 +1516,8 @@ mod tests {
         assert!(rgs.contains_key(&b"rg0"[..]));
         let map = rgs.get(&b"rg0"[..]).unwrap();
         // SM and LB should be present as other_fields
-        let sm_tag = HeaderOtherTag::<_>::try_from([b'S', b'M']).unwrap();
-        let lb_tag = HeaderOtherTag::<_>::try_from([b'L', b'B']).unwrap();
+        let sm_tag = HeaderOtherTag::<_>::try_from(*b"SM").unwrap();
+        let lb_tag = HeaderOtherTag::<_>::try_from(*b"LB").unwrap();
         let sm: &[u8] = map.other_fields().get(&sm_tag).unwrap().as_ref();
         let lb: &[u8] = map.other_fields().get(&lb_tag).unwrap().as_ref();
         assert_eq!(sm, b"sample0");

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1404,6 +1404,7 @@ mod tests {
 
     fn make_test_genome() -> Genome {
         Genome {
+            transform_blocks: None,
             sequence: vec![0, 1, 2, 3, 0, 1, 2, 3], // ACGTACGT
             n_genome: 8,
             n_genome_real: 8,

--- a/src/junction/gtf.rs
+++ b/src/junction/gtf.rs
@@ -310,6 +310,7 @@ mod tests {
     fn test_extract_junctions_single_transcript() {
         // Create a simple genome
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,
@@ -362,6 +363,7 @@ mod tests {
     #[test]
     fn test_extract_junctions_multiple_transcripts() {
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,
@@ -438,6 +440,7 @@ mod tests {
     #[test]
     fn test_extract_junctions_single_exon_transcript() {
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,
@@ -470,6 +473,7 @@ mod tests {
     #[test]
     fn test_extract_junctions_unknown_chromosome() {
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,
@@ -517,6 +521,7 @@ mod tests {
     #[test]
     fn test_junction_coordinate_calculation() {
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,
@@ -601,6 +606,7 @@ mod tests {
     #[test]
     fn test_extract_junctions_configured_custom_transcript_tag() {
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,

--- a/src/junction/mod.rs
+++ b/src/junction/mod.rs
@@ -407,6 +407,7 @@ mod tests {
 
         // Two-chromosome toy genome so chr_start[1] != 0.
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 4000],
             n_genome: 2000,
             n_genome_real: 2000,

--- a/src/junction/sj_output.rs
+++ b/src/junction/sj_output.rs
@@ -523,6 +523,7 @@ mod tests {
         stats.record_junction(0, 300, 400, 2, SpliceMotif::GcAg, false, 15, true);
 
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,
@@ -584,6 +585,7 @@ mod tests {
         stats.record_junction(0, 300, 400, 1, SpliceMotif::GtAg, true, 20, false);
 
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,
@@ -619,6 +621,7 @@ mod tests {
         stats.record_junction(0, 100, 200, 1, SpliceMotif::NonCanonical, true, 2, true);
 
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,
@@ -697,6 +700,7 @@ mod tests {
         }
 
         let genome = Genome {
+            transform_blocks: None,
             sequence: vec![0; 1000],
             n_genome: 1000,
             n_genome_real: 1000,

--- a/src/junction/sjdb_insert.rs
+++ b/src/junction/sjdb_insert.rs
@@ -569,6 +569,7 @@ mod tests {
         let mut seq = forward;
         seq.extend(std::iter::repeat_n(5u8, n));
         Genome {
+            transform_blocks: None,
             sequence: seq,
             n_genome: n as u64,
             n_genome_real: n as u64,
@@ -974,6 +975,7 @@ mod tests {
         let mut seq = vec![5u8; 4000];
         seq[..2000].copy_from_slice(&vec![0u8; 2000]);
         let genome = Genome {
+            transform_blocks: None,
             sequence: seq,
             n_genome: 2000,
             n_genome_real: 2000,
@@ -1113,6 +1115,7 @@ mod tests {
         let mut seq = vec![5u8; 4000];
         seq[..2000].copy_from_slice(&vec![0u8; 2000]);
         let genome = Genome {
+            transform_blocks: None,
             sequence: seq,
             n_genome: 2000,
             n_genome_real: 2000,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,24 @@ fn genome_generate(params: &Parameters) -> anyhow::Result<()> {
     // + `write` remains for tests / random-access callers.
     GenomeIndex::generate_streaming(params)?;
 
+    // --genomeTransformType Haploid: also write the untransformed index to
+    // `<genomeDir>/OriginalGenome/` (STAR's own layout), by re-running the same
+    // build with the transform disabled and the output directory redirected.
+    // `transformGenomeBlocks.tsv` (the reverse-conversion block map) was already
+    // written into `genomeDir` above, as part of the transformed Genome's own
+    // `write_index_files` call.
+    if params.genome_transform_type.eq_ignore_ascii_case("Haploid") {
+        let mut orig_params = params.clone();
+        orig_params.genome_transform_type = "None".to_string();
+        orig_params.genome_transform_vcf = None;
+        orig_params.genome_dir = params.genome_dir.join("OriginalGenome");
+        info!(
+            "genomeTransformType Haploid: writing untransformed index to {}",
+            orig_params.genome_dir.display()
+        );
+        GenomeIndex::generate_streaming(&orig_params)?;
+    }
+
     info!("Genome generation complete!");
     Ok(())
 }

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -275,6 +275,16 @@ pub struct Parameters {
     #[arg(long = "genomeSAsparseD", default_value_t = 1)]
     pub genome_sa_sparse_d: u32,
 
+    /// Substitute VCF alleles into the genome at genomeGenerate (`None` or
+    /// `Haploid`). Requires `--genomeTransformVCF`; incompatible with
+    /// `--sjdbGTFfile`. `Diploid` is not implemented (see `Parameters::validate`)
+    #[arg(long = "genomeTransformType", default_value = "None")]
+    pub genome_transform_type: String,
+
+    /// VCF of variants for `--genomeTransformType`
+    #[arg(long = "genomeTransformVCF")]
+    pub genome_transform_vcf: Option<PathBuf>,
+
     // ── Read files ──────────────────────────────────────────────────────
     /// Input read file(s); second file is mate 2 for paired-end
     #[arg(long = "readFilesIn", num_args = 1..=2)]
@@ -862,6 +872,37 @@ impl Parameters {
                 ErrorKind::MissingRequiredArgument,
                 "--readFilesIn is required when --runMode alignReads",
             ));
+        }
+
+        // --genomeTransformType: only Haploid is implemented (Diploid substitutes
+        // and duplicates the genome into two haplotypes; not yet ported). Requires
+        // a VCF, and is incompatible with a GTF (STAR itself doesn't combine
+        // genomeTransform with sjdb annotation at genomeGenerate).
+        if !params.genome_transform_type.eq_ignore_ascii_case("None") {
+            if params.genome_transform_type.eq_ignore_ascii_case("Diploid") {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "--genomeTransformType Diploid is not implemented; use --genomeTransformType Haploid",
+                ));
+            }
+            if !params.genome_transform_type.eq_ignore_ascii_case("Haploid") {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "--genomeTransformType must be None or Haploid",
+                ));
+            }
+            if params.genome_transform_vcf.is_none() {
+                return Err(command.error(
+                    ErrorKind::MissingRequiredArgument,
+                    "--genomeTransformType Haploid requires --genomeTransformVCF",
+                ));
+            }
+            if params.sjdb_gtf_file.is_some() {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "--genomeTransformType is incompatible with --sjdbGTFfile",
+                ));
+            }
         }
 
         // quantMode GeneCounts requires a GTF file

--- a/src/quant/mod.rs
+++ b/src/quant/mod.rs
@@ -381,6 +381,7 @@ mod tests {
 
     fn make_genome() -> Genome {
         Genome {
+            transform_blocks: None,
             sequence: vec![0u8; 2000],
             n_genome: 2000,
             n_genome_real: 2000,

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -1036,13 +1036,10 @@ fn align_to_one_transcript(
         } else {
             // Coalesce: extend the last projected exon by this block's length
             // (STAR adds block EX_L directly — does NOT update start position).
-            if let Some(last) = proj_exons.last_mut() {
-                let len = block_end - block_start;
-                last.genome_end += len;
-                last.read_end = block.read_end;
-            } else {
-                return None;
-            }
+            let last = proj_exons.last_mut()?;
+            let len = block_end - block_start;
+            last.genome_end += len;
+            last.read_end = block.read_end;
         }
 
         // Advance `ex` across any splice boundary BEFORE the next block,

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -1378,6 +1378,7 @@ mod tests {
 
     fn make_genome() -> Genome {
         Genome {
+            transform_blocks: None,
             sequence: vec![0u8; 3000],
             n_genome: 3000,
             n_genome_real: 3000,
@@ -2293,6 +2294,7 @@ mod tests {
         // Aligned region [104, 144) — fill with zeros (A) so read bases match
         seq[104..144].fill(0);
         let genome = Genome {
+            transform_blocks: None,
             sequence: seq,
             n_genome: 1000,
             n_genome_real: 1000,
@@ -2346,6 +2348,7 @@ mod tests {
         // Aligned region [104, 144): all zeros
         seq[104..144].fill(0);
         let genome = Genome {
+            transform_blocks: None,
             sequence: seq,
             n_genome: 1000,
             n_genome_real: 1000,

--- a/tests/alignment_features.rs
+++ b/tests/alignment_features.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 
 /// LCG pseudo-random sequence generator (identical LCG to existing tests).
 fn lcg_seq(seed: u32, length: usize) -> Vec<u8> {
-    let bases: [u8; 4] = [b'A', b'C', b'G', b'T'];
+    let bases: [u8; 4] = *b"ACGT";
     let mut state = seed;
     let mut seq = Vec::with_capacity(length);
     for _ in 0..length {


### PR DESCRIPTION
## Summary
- Port STAR-rs's genomeGenerate-time genome transform (`crates/star-index/src/transform.rs`, itself a port of STAR's `Genome_transformGenome.cpp`): substitute a VCF's alleles into the reference genome before the suffix array is built.
- Scoped to Haploid only and to genomeGenerate only (align-time back-transform isn't needed with the only supported `--genomeTransformOutput` = `None`).
- `src/genome/transform.rs`: `parse_vcf_haploid`, `transform_one_chromosome`, `transform_chromosomes`, `blocks_to_tsv`.
- `src/genome/mod.rs`: extracted `compute_chr_starts` helper; hooks the transform into `from_fasta`; adds `Genome::transform_blocks`.
- `src/lib.rs`: `genome_generate()` also writes the untransformed index to `<genomeDir>/OriginalGenome/`.
- Themed split of the original bundled WASP+everything PR, per `docs-old/dev/porting-from-star-rs.md`. Diploid (next PR) stacks on this one.

## Test plan
- [x] cargo build / test / clippy -D warnings / fmt --check all green
- [x] Verified end-to-end: genomeGenerate with `--genomeTransformType Haploid` produces correct transformed Genome + untouched OriginalGenome/ + transformGenomeBlocks.tsv