### PR TITLE
feat: --sjdbFileChrStartEnd explicit junction TSV files

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -273,11 +273,12 @@ impl GenomeIndex {
         // preparation + Gsj append must happen BEFORE the suffix array is
         // built, because STAR indexes the flanking-sequence buffer alongside
         // the real genome in a single SA (`sjdbBuildIndex.cpp:293`).
-        let (junction_db, transcriptome, prepared_junctions) = if let Some(ref gtf_path) =
-            params.sjdb_gtf_file
-        {
-            let n_genome_real = genome.n_genome;
+        let n_genome_real = genome.n_genome;
 
+        let mut raw: Vec<(usize, u64, u64, u8)> = Vec::new();
+        let mut transcriptome = None;
+
+        if let Some(ref gtf_path) = params.sjdb_gtf_file {
             let exons = crate::junction::gtf::parse_gtf_configured(
                 gtf_path,
                 &params.sjdb_gtf_feature_exon,
@@ -297,12 +298,29 @@ impl GenomeIndex {
                 tr.gene_ids.len()
             );
 
-            let raw = crate::junction::gtf::extract_junctions_configured(
+            let gtf_raw = crate::junction::gtf::extract_junctions_configured(
                 exons,
                 &genome,
                 &params.sjdb_gtf_tag_exon_parent_transcript,
             )?;
-            log::info!("Extracted {} annotated junctions from GTF", raw.len());
+            log::info!("Extracted {} annotated junctions from GTF", gtf_raw.len());
+            raw.extend(gtf_raw);
+            transcriptome = Some(tr);
+        }
+
+        if !params.sjdb_file_chr_start_end.is_empty() {
+            let extra = crate::junction::chr_start_end::parse_sjdb_chr_start_end(
+                &params.sjdb_file_chr_start_end,
+                &genome,
+            )?;
+            log::info!(
+                "Parsed {} junctions from --sjdbFileChrStartEnd",
+                extra.len()
+            );
+            raw.extend(extra);
+        }
+
+        let (junction_db, prepared_junctions) = if !raw.is_empty() {
             let jdb = SpliceJunctionDb::from_raw_junctions(&raw);
 
             let prepared: Vec<PreparedJunction> = raw
@@ -335,10 +353,10 @@ impl GenomeIndex {
                 n_genome_real
             );
 
-            (jdb, Some(tr), prepared)
+            (jdb, prepared)
         } else {
-            log::info!("No GTF file provided, all junctions will be novel");
-            (SpliceJunctionDb::empty(), None, Vec::new())
+            log::info!("No GTF or --sjdbFileChrStartEnd provided, all junctions will be novel");
+            (SpliceJunctionDb::empty(), Vec::new())
         };
 
         log::info!(

--- a/src/junction/chr_start_end.rs
+++ b/src/junction/chr_start_end.rs
@@ -1,0 +1,131 @@
+//! `--sjdbFileChrStartEnd`: explicit splice junctions given as TSV files, unioned with any
+//! `--sjdbGTFfile`-derived junctions before sjdb insertion (STAR's `sjdbFileChrStartEnd`).
+//!
+//! Each line is `chr  start  end  [strand]`, whitespace-delimited, with `start`/`end` the 1-based
+//! coordinates of the intron's first and last base. The strand column is optional; `.` or absent
+//! means unknown (the motif is derived from the genome at sjdb-insertion time). Lines with fewer
+//! than 3 fields, or a non-integer `start`/`end`, are skipped (STAR's `istringstream >>` silently
+//! stops parsing a malformed line). An unresolvable chromosome name is a hard error, matching
+//! STAR's fatal exit on the same condition.
+
+use std::path::Path;
+
+use crate::error::Error;
+use crate::genome::Genome;
+
+/// Parse `--sjdbFileChrStartEnd` TSV files into raw junction tuples
+/// `(chr_idx, intron_start, intron_end, strand)`, in the same genome-absolute 0-based /
+/// `0=unknown,1=+,2=-` convention as [`crate::junction::gtf::extract_junctions_configured`].
+pub fn parse_sjdb_chr_start_end(
+    paths: &[std::path::PathBuf],
+    genome: &Genome,
+) -> Result<Vec<(usize, u64, u64, u8)>, Error> {
+    let mut out = Vec::new();
+    for path in paths {
+        let text = std::fs::read_to_string(path).map_err(|e| Error::io(e, path.clone()))?;
+        for line in text.lines() {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() < 3 {
+                continue;
+            }
+            let (Ok(start), Ok(end)) = (fields[1].parse::<u64>(), fields[2].parse::<u64>()) else {
+                continue;
+            };
+            let strand = match fields.get(3).and_then(|s| s.chars().next()) {
+                Some('+') => 1u8,
+                Some('-') => 2u8,
+                _ => 0u8,
+            };
+            let chr_idx = chr_index(genome, fields[0], path)?;
+            let base = genome.chr_start[chr_idx];
+            out.push((chr_idx, base + start - 1, base + end - 1, strand));
+        }
+    }
+    Ok(out)
+}
+
+fn chr_index(genome: &Genome, name: &str, path: &Path) -> Result<usize, Error> {
+    genome
+        .chr_name
+        .iter()
+        .position(|n| n == name)
+        .ok_or_else(|| {
+            Error::Parameter(format!(
+                "{}: chromosome '{name}' not found in the genome (--sjdbFileChrStartEnd)",
+                path.display()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_genome() -> Genome {
+        Genome {
+            sequence: vec![0u8; 2000],
+            n_genome: 2000,
+            n_genome_real: 2000,
+            n_chr_real: 2,
+            chr_name: vec!["chr1".to_string(), "chr2".to_string()],
+            chr_length: vec![1000, 1000],
+            chr_start: vec![0, 1000, 2000],
+        }
+    }
+
+    #[test]
+    fn parses_chr_start_end_strand() {
+        let genome = tiny_genome();
+        let dir =
+            std::env::temp_dir().join(format!("sjdb-chr-start-end-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("junctions.tsv");
+        std::fs::write(&path, "chr1\t101\t200\t+\nchr2\t51\t150\t-\n").unwrap();
+
+        let raw = parse_sjdb_chr_start_end(std::slice::from_ref(&path), &genome).unwrap();
+        assert_eq!(raw, vec![(0, 100, 199, 1), (1, 1050, 1149, 2)]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn missing_strand_defaults_to_unknown() {
+        let genome = tiny_genome();
+        let dir =
+            std::env::temp_dir().join(format!("sjdb-chr-start-end-test2-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("junctions.tsv");
+        std::fs::write(&path, "chr1\t101\t200\n").unwrap();
+
+        let raw = parse_sjdb_chr_start_end(std::slice::from_ref(&path), &genome).unwrap();
+        assert_eq!(raw, vec![(0, 100, 199, 0)]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn short_lines_are_skipped() {
+        let genome = tiny_genome();
+        let dir =
+            std::env::temp_dir().join(format!("sjdb-chr-start-end-test3-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("junctions.tsv");
+        std::fs::write(&path, "chr1\t101\n# comment too short\nchr1\t101\t200\t+\n").unwrap();
+
+        let raw = parse_sjdb_chr_start_end(std::slice::from_ref(&path), &genome).unwrap();
+        assert_eq!(raw, vec![(0, 100, 199, 1)]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn unknown_chromosome_errors() {
+        let genome = tiny_genome();
+        let dir =
+            std::env::temp_dir().join(format!("sjdb-chr-start-end-test4-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("junctions.tsv");
+        std::fs::write(&path, "chrZ\t101\t200\t+\n").unwrap();
+
+        let err = parse_sjdb_chr_start_end(std::slice::from_ref(&path), &genome).unwrap_err();
+        assert!(err.to_string().contains("chrZ"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/junction/mod.rs
+++ b/src/junction/mod.rs
@@ -5,6 +5,7 @@
 /// - Building a junction database from annotated exons
 /// - Junction lookup during alignment (annotated vs novel)
 /// - Junction statistics collection for SJ.out.tab output
+pub(crate) mod chr_start_end;
 pub(crate) mod gtf;
 mod sj_output;
 pub mod sjdb_insert;

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -609,6 +609,11 @@ pub struct Parameters {
     #[arg(long = "sjdbGTFfile")]
     pub sjdb_gtf_file: Option<PathBuf>,
 
+    /// TSV file(s) of `chr start end [strand]` junctions (1-based intron first/last base) to
+    /// insert into the sjdb, unioned with any `--sjdbGTFfile` junctions
+    #[arg(long = "sjdbFileChrStartEnd", num_args = 1..)]
+    pub sjdb_file_chr_start_end: Vec<PathBuf>,
+
     /// Prefix to add to chromosome names from GTF file (e.g. "chr" when GTF uses bare numbers)
     #[arg(long = "sjdbGTFchrPrefix", default_value = "")]
     pub sjdb_gtf_chr_prefix: String,


### PR DESCRIPTION
## Summary
- Parses `chr  start  end  [strand]` TSV files (1-based intron first/last base, sister project STAR-rs's convention) into the same raw junction shape (`chr_idx, intron_start, intron_end, strand`) `--sjdbGTFfile` parsing already produces
- Unions both sources before sjdb insertion into the genome/SA (`genomeGenerate`'s `build_prep`, shared by both the in-memory and streaming index-build paths)
- Works standalone with no GTF: junction DB + sjdb files are built whenever the union is non-empty; only the transcriptome index still requires a GTF
- Unknown chromosome name in the TSV is a hard error (matches STAR's fatal exit on the same condition)

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` (0 warnings)
- [x] `cargo test` (459 passed, 4 new)
- [x] manual smoke test: `genomeGenerate` with only `--sjdbFileChrStartEnd` (no GTF) on a synthetic genome — junction round-trips correctly through `sjdbList.out.tab`, `sjdbInfo.txt` populated, no transcriptome files written