### PR TITLE
Fix/sj filter count or

### DIFF
--- a/src/index/io.rs
+++ b/src/index/io.rs
@@ -42,7 +42,34 @@ impl GenomeIndex {
             sa_index.data.len()
         );
 
-        // Load GTF annotations if provided
+        // Load prepared junctions from the index (sjdbInfo.txt) if present.
+        // STAR appends a Gsj flanking-sequence buffer to the genome at build
+        // time; align-time code needs the parsed junctions to (a) decode SA hits
+        // that land inside that buffer back to real (donor, acceptor) positions,
+        // and (b) recognise annotated junctions when aligning against a
+        // pre-built annotated index.
+        let sjdb_info_path = genome_dir.join("sjdbInfo.txt");
+        let (prepared_junctions, sjdb_overhang) = if sjdb_info_path.exists() {
+            let tab = sjdb_insert::read_sjdb_info_tab(&sjdb_info_path, &genome)?;
+            log::info!(
+                "Loaded sjdbInfo.txt: {} junctions, sjdbOverhang={}",
+                tab.junctions.len(),
+                tab.sjdb_overhang,
+            );
+            (tab.junctions, tab.sjdb_overhang)
+        } else {
+            (Vec::new(), 0)
+        };
+
+        // Build the annotated-junction database consulted at stitch time.
+        //   - If a GTF is supplied at align time, parse it (STAR's on-the-fly path).
+        //   - Otherwise fall back to the junctions stored in the index
+        //     (sjdbInfo.txt). Without this fallback, the standard workflow —
+        //     build the index once with `--sjdbGTFfile`, then align with only
+        //     `--genomeDir` — would treat every junction as novel (the runtime
+        //     db would be empty), losing all `sjdbScore` bonuses and annotated
+        //     junction recognition. Keyed on the stored (post-sjdbPrepare) donor/
+        //     acceptor coordinates, matching what the stitch scan produces.
         let junction_db = if let Some(ref gtf_path) = params.sjdb_gtf_file {
             SpliceJunctionDb::from_gtf_configured(
                 gtf_path,
@@ -51,6 +78,16 @@ impl GenomeIndex {
                 &params.sjdb_gtf_chr_prefix,
                 &params.sjdb_gtf_tag_exon_parent_transcript,
             )?
+        } else if !prepared_junctions.is_empty() {
+            let raw: Vec<(usize, u64, u64, u8)> = prepared_junctions
+                .iter()
+                .map(|j| (j.chr_idx, j.stored_start(), j.stored_end(), j.strand))
+                .collect();
+            log::info!(
+                "No GTF at align time; loaded {} annotated junctions from index sjdbInfo.txt",
+                raw.len()
+            );
+            SpliceJunctionDb::from_raw_junctions(&raw)
         } else {
             log::info!("No GTF file provided, all junctions will be novel");
             SpliceJunctionDb::empty()
@@ -99,24 +136,6 @@ impl GenomeIndex {
                 tr.gene_ids.len()
             );
         }
-
-        // Reload prepared junctions + sjdbOverhang from sjdbInfo.txt when
-        // present. STAR appends a Gsj flanking-sequence buffer to the
-        // genome at build time; align-time code needs the parsed junctions
-        // to decode SA hits that land inside that buffer back to real
-        // `(donor, acceptor)` genome positions.
-        let sjdb_info_path = genome_dir.join("sjdbInfo.txt");
-        let (prepared_junctions, sjdb_overhang) = if sjdb_info_path.exists() {
-            let tab = sjdb_insert::read_sjdb_info_tab(&sjdb_info_path, &genome)?;
-            log::info!(
-                "Loaded sjdbInfo.txt: {} junctions, sjdbOverhang={}",
-                tab.junctions.len(),
-                tab.sjdb_overhang,
-            );
-            (tab.junctions, tab.sjdb_overhang)
-        } else {
-            (Vec::new(), 0)
-        };
 
         Ok(GenomeIndex {
             genome,

--- a/src/junction/mod.rs
+++ b/src/junction/mod.rs
@@ -197,11 +197,18 @@ pub fn filter_novel_junctions(
             let min_overhang = params.out_sj_filter_overhang_min[cat] as u32;
             let has_overhang = max_overhang >= min_overhang;
 
-            // Coverage threshold (motif-specific)
+            // Coverage threshold (motif-specific). STAR keeps a junction if EITHER
+            // the unique-read count OR the total (unique+multi) count meets its
+            // threshold — an OR, not an AND (STAR manual: "Junctions are output if
+            // one of outSJfilterCountUniqueMin OR outSJfilterCountTotalMin
+            // conditions are satisfied"; confirmed against STAR's source and the
+            // byte-faithful STAR-rs `star_sj.rs`). Using AND here dropped every
+            // junction supported only by multi-mapping reads (unique==0), which is
+            // why rustar-aligner reported far fewer novel junctions than STAR.
             let min_unique = params.out_sj_filter_count_unique_min[cat] as u32;
             let min_total = params.out_sj_filter_count_total_min[cat] as u32;
             let total = unique + multi;
-            let has_coverage = unique >= min_unique && total >= min_total;
+            let has_coverage = unique >= min_unique || total >= min_total;
 
             // Intron length threshold
             let intron_len = key.intron_end.saturating_sub(key.intron_start) + 1;

--- a/src/junction/sj_output.rs
+++ b/src/junction/sj_output.rs
@@ -189,11 +189,16 @@ impl SpliceJunctionStats {
                 if (*max_overhang as i32) < overhang_min[cat] {
                     continue;
                 }
-                if (*unique as i32) < unique_min[cat] {
-                    continue;
-                }
+                // STAR keeps a junction if EITHER the unique count OR the total
+                // (unique+multi) count meets its threshold — an OR, not an AND
+                // (STAR manual; confirmed against STAR source and STAR-rs
+                // `star_sj.rs`). Testing them as two independent drop-guards was
+                // an AND, which discarded every junction supported only by
+                // multi-mapping reads (unique==0) — the cause of rustar-aligner
+                // reporting far fewer novel junctions than STAR. Drop only when
+                // BOTH thresholds fail.
                 let total = unique + multi;
-                if (total as i32) < total_min[cat] {
+                if (*unique as i32) < unique_min[cat] && (total as i32) < total_min[cat] {
                     continue;
                 }
                 if dist_min[cat] > 0 && min_dist_to_neighbor[idx] < dist_min[cat] as u64 {
@@ -645,7 +650,7 @@ mod tests {
     fn test_compute_surviving_junctions_basic() {
         let stats = SpliceJunctionStats::new();
 
-        // High-quality canonical junction (should survive)
+        // High-quality canonical junction, unique read (should survive)
         stats.record_junction(0, 100, 200, 1, SpliceMotif::GtAg, true, 50, false);
 
         // Low-overhang non-canonical junction (should be filtered: 10 < 30)
@@ -653,18 +658,32 @@ mod tests {
             stats.record_junction(0, 300, 400, 1, SpliceMotif::NonCanonical, true, 10, false);
         }
 
-        // Low-count canonical junction (unique=0 < 1)
+        // Canonical junction supported ONLY by a multi-mapper (unique=0, total=1).
+        // STAR keeps it via the OR count filter: total(1) >= CountTotalMin[canonical](1).
         stats.record_junction(0, 500, 600, 1, SpliceMotif::GtAg, false, 20, false);
+
+        // Non-canonical junction with too few reads (unique=0 and total=1, both
+        // below CountUniqueMin/CountTotalMin[non-canonical]=3) but good overhang:
+        // fails the OR count filter on BOTH branches -> filtered.
+        stats.record_junction(0, 700, 800, 1, SpliceMotif::NonCanonical, false, 40, false);
 
         let params = default_params();
         let surviving = stats.compute_surviving_junctions(&params);
 
-        // Only the first junction should survive
-        assert_eq!(surviving.len(), 1);
+        // The unique canonical and the multi-only canonical survive; the
+        // low-overhang and low-count non-canonical junctions are filtered.
+        assert_eq!(surviving.len(), 2);
         assert!(surviving.contains(&SjKey {
             chr_idx: 0,
             intron_start: 100,
             intron_end: 200,
+            strand: 1,
+            motif: 1,
+        }));
+        assert!(surviving.contains(&SjKey {
+            chr_idx: 0,
+            intron_start: 500,
+            intron_end: 600,
             strand: 1,
             motif: 1,
         }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1069,11 +1069,9 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                         .count_se_read(&transcripts, n_for_mapq, &q.gene_ann);
                 }
 
-                // Record junction statistics
+                // Record junction statistics (deduped per read across all loci)
                 let is_unique = transcripts.len() == 1;
-                for transcript in &transcripts {
-                    record_transcript_junctions(transcript, &index, &sj_stats, is_unique);
-                }
+                record_read_junctions(&transcripts, &index, &sj_stats, is_unique);
 
                 // Extract junction keys from primary alignment for BySJout filtering
                 let primary_junction_keys =
@@ -1551,36 +1549,24 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     );
                 }
 
-                // Record junction statistics
+                // Record junction statistics (deduped per read across both mates
+                // and all loci — a junction crossed by both mates counts once).
                 let is_unique = both_mapped.len() == 1 || (has_half_mapped && results.len() == 1);
+                let mut read_trs: Vec<&crate::align::transcript::Transcript> = Vec::new();
                 for result in &results {
                     match result {
                         PairedAlignmentResult::BothMapped(pair) => {
-                            record_transcript_junctions(
-                                &pair.mate1_transcript,
-                                &index,
-                                &sj_stats,
-                                is_unique,
-                            );
-                            record_transcript_junctions(
-                                &pair.mate2_transcript,
-                                &index,
-                                &sj_stats,
-                                is_unique,
-                            );
+                            read_trs.push(&pair.mate1_transcript);
+                            read_trs.push(&pair.mate2_transcript);
                         }
                         PairedAlignmentResult::HalfMapped {
                             mapped_transcript, ..
                         } => {
-                            record_transcript_junctions(
-                                mapped_transcript,
-                                &index,
-                                &sj_stats,
-                                is_unique,
-                            );
+                            read_trs.push(mapped_transcript);
                         }
                     }
                 }
+                record_read_junctions(read_trs, &index, &sj_stats, is_unique);
 
                 // Extract junction keys from primary alignment for BySJout
                 let primary_junction_keys = if by_sjout && !results.is_empty() {
@@ -1869,14 +1855,69 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
 }
 
 /// Record junctions from a transcript into SJ statistics
-fn record_transcript_junctions(
-    transcript: &crate::align::transcript::Transcript,
+/// One splice junction extracted from a transcript's CIGAR (before per-read
+/// deduplication / recording).
+struct ReadJunction {
+    chr_idx: usize,
+    intron_start: u64,
+    intron_end: u64,
+    strand: u8,
+    motif: crate::align::score::SpliceMotif,
+    overhang: u32,
+    annotated: bool,
+}
+
+/// Record a read's splice junctions into `sj_stats`, **deduplicated per read**:
+/// a junction crossed by several of the read's alignments/mates counts ONCE,
+/// taking the max overhang across occurrences (STAR `outputTranscriptSJ`;
+/// confirmed against the byte-faithful STAR-rs `star_sj.rs::record_read`).
+/// `is_unique` reflects the read's overall mapping multiplicity (n_loci == 1),
+/// not per-locus. Recording per-locus/per-mate instead double-counts junctions
+/// crossed by both mates of a pair, inflating the SJ.out.tab multi counts.
+fn record_read_junctions<'a>(
+    transcripts: impl IntoIterator<Item = &'a crate::align::transcript::Transcript>,
     index: &crate::index::GenomeIndex,
     sj_stats: &crate::junction::SpliceJunctionStats,
     is_unique: bool,
 ) {
+    use std::collections::HashMap;
+    let mut per_read: HashMap<(usize, u64, u64), ReadJunction> = HashMap::new();
+    for t in transcripts {
+        for j in extract_transcript_junctions(t, index) {
+            per_read
+                .entry((j.chr_idx, j.intron_start, j.intron_end))
+                .and_modify(|e| {
+                    e.overhang = e.overhang.max(j.overhang);
+                    e.annotated |= j.annotated;
+                })
+                .or_insert(j);
+        }
+    }
+    for j in per_read.values() {
+        sj_stats.record_junction(
+            j.chr_idx,
+            j.intron_start,
+            j.intron_end,
+            j.strand,
+            j.motif,
+            is_unique,
+            j.overhang,
+            j.annotated,
+        );
+    }
+}
+
+/// Extract all splice junctions (`N` / Skip ops) from one transcript's CIGAR,
+/// with per-junction overhang, motif, strand and annotation — without recording
+/// them (recording is done per-read by `record_read_junctions`).
+fn extract_transcript_junctions(
+    transcript: &crate::align::transcript::Transcript,
+    index: &crate::index::GenomeIndex,
+) -> Vec<ReadJunction> {
     use crate::align::score::AlignmentScorer;
     use cigar::op::Kind;
+
+    let mut out: Vec<ReadJunction> = Vec::new();
 
     // First pass: compute exon segment lengths (query-consuming bases between N operations)
     // An "exon segment" is the query bases on each side of a splice junction.
@@ -1935,17 +1976,15 @@ fn record_transcript_junctions(
                     strand,
                 );
 
-                // Record junction
-                sj_stats.record_junction(
-                    transcript.chr_idx,
+                out.push(ReadJunction {
+                    chr_idx: transcript.chr_idx,
                     intron_start,
                     intron_end,
                     strand,
                     motif,
-                    is_unique,
                     overhang,
                     annotated,
-                );
+                });
 
                 // Advance genome position past the intron
                 genome_pos += intron_len as u64;
@@ -1957,4 +1996,6 @@ fn record_transcript_junctions(
             Kind::Insertion | Kind::SoftClip | Kind::HardClip | Kind::Pad => {}
         }
     }
+
+    out
 }


### PR DESCRIPTION
fix: dedup splice junctions per read (STAR-faithful SJ counting)

STAR counts a junction crossed by several of a read's alignments/mates once (outputTranscriptSJ; STAR-rs star_sj.rs::record_read). rustar recorded per-locus/per-mate, double-counting PE overlapping-mate junctions and inflating SJ.out.tab multi counts — which also pushed some non-canonical junctions (threshold >=3) over the filter. Gather each
read's junctions into a per-read set and record once.

Human chr21 2M PE: multi-only junctions 1836 -> 1582 (STAR 1584), sumMulti 3959 -> 2618 (STAR 2652), total 3377 -> 3118 (STAR 3071). Yeast unchanged (SE 8790, SJ-output-only).