### PR TITLE
feat: SAM output record-level tweaks (IHstart, flagOR/AND, primaryFlag, readID, tlen)

### DIFF
--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -136,6 +136,11 @@ impl SamWriter {
         let rg_id_owned = params.primary_rg_id()?;
         let rg_id = rg_id_owned.as_deref();
 
+        let best_score = transcripts
+            .iter()
+            .map(|t| t.score)
+            .max()
+            .unwrap_or(i32::MIN);
         for (hit_index, transcript) in transcripts.iter().take(max_output).enumerate() {
             let mut record = transcript_to_record(
                 transcript,
@@ -150,6 +155,7 @@ impl SamWriter {
             )?;
             maybe_insert_rg_tag(&mut record, rg_id);
             apply_sam_flag_or_and(&mut record, params);
+            apply_primary_flag(&mut record, transcript.score, best_score, params);
 
             self.writer.write_alignment_record(&self.header, &record)?;
         }
@@ -262,6 +268,11 @@ impl SamWriter {
         let rg_id = rg_id_owned.as_deref();
 
         let mut records = Vec::with_capacity(max_output);
+        let best_score = transcripts
+            .iter()
+            .map(|t| t.score)
+            .max()
+            .unwrap_or(i32::MIN);
         for (hit_index, transcript) in transcripts.iter().take(max_output).enumerate() {
             let mut record = transcript_to_record(
                 transcript,
@@ -276,6 +287,7 @@ impl SamWriter {
             )?;
             maybe_insert_rg_tag(&mut record, rg_id);
             apply_sam_flag_or_and(&mut record, params);
+            apply_primary_flag(&mut record, transcript.score, best_score, params);
             records.push(record);
         }
 
@@ -333,6 +345,11 @@ impl SamWriter {
         let rg_id = rg_id_owned.as_deref();
 
         let mut records = Vec::with_capacity(max_output * 2);
+        let best_score = paired_alignments
+            .iter()
+            .map(|p| p.combined_wt_score)
+            .max()
+            .unwrap_or(i32::MIN);
 
         for (pair_idx, paired_aln) in paired_alignments.iter().take(max_output).enumerate() {
             let hit_index = pair_idx + 1; // 1-based
@@ -359,6 +376,7 @@ impl SamWriter {
             )?;
             maybe_insert_rg_tag(&mut rec1, rg_id);
             apply_sam_flag_or_and(&mut rec1, params);
+            apply_primary_flag(&mut rec1, combined_score, best_score, params);
             records.push(rec1);
 
             // Create record for mate2 (this=mate2, mate=mate1)
@@ -380,6 +398,7 @@ impl SamWriter {
             )?;
             maybe_insert_rg_tag(&mut rec2, rg_id);
             apply_sam_flag_or_and(&mut rec2, params);
+            apply_primary_flag(&mut rec2, combined_score, best_score, params);
             records.push(rec2);
         }
 
@@ -928,6 +947,19 @@ fn apply_sam_flag_or_and(record: &mut RecordBuf, params: &Parameters) {
     let and_bits = params.out_sam_flag_and.min(u16::MAX as u32) as u16;
     let bits = u16::from(record.flags());
     *record.flags_mut() = sam::alignment::record::Flags::from((bits & and_bits) | or_bits);
+}
+
+/// `--outSAMprimaryFlag AllBestScore`: clear the SECONDARY bit on every alignment tied for the
+/// best score, instead of only the single (already-sorted) best alignment (`OneBestScore`,
+/// the default, which the caller's existing hit-index-based SECONDARY assignment already gives).
+fn apply_primary_flag(record: &mut RecordBuf, score: i32, best_score: i32, params: &Parameters) {
+    if params.out_sam_primary_flag == crate::params::OutSamPrimaryFlag::AllBestScore
+        && score == best_score
+    {
+        let mut flags = record.flags();
+        flags.remove(sam::alignment::record::Flags::SECONDARY);
+        *record.flags_mut() = flags;
+    }
 }
 
 /// Convert FASTQ ASCII quality bytes (Phred+33) to raw Phred values (0-93) for
@@ -2557,6 +2589,62 @@ mod tests {
         // QC_FAIL (0x200) was OR-ed in.
         assert!(!records[0].flags().is_reverse_complemented());
         assert!(records[0].flags().is_qc_fail());
+    }
+
+    #[test]
+    fn test_out_sam_primary_flag_all_best_score() {
+        use cigar::op::{Kind, Op};
+        let genome = make_test_genome();
+        let params = Parameters::parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "test.fq",
+            "--outSAMprimaryFlag",
+            "AllBestScore",
+        ]);
+
+        let mk = |genome_start: u64, score: i32| Transcript {
+            chr_idx: 0,
+            genome_start,
+            genome_end: genome_start + 50,
+            is_reverse: false,
+            exons: vec![],
+            cigar: vec![Op::new(Kind::Match, 50)],
+            score,
+            n_mismatch: 0,
+            n_gap: 0,
+            n_junction: 0,
+            junction_motifs: vec![],
+            junction_annotated: vec![],
+            read_seq: vec![0; 4],
+        };
+        // Two alignments tied for the best score (100), one strictly worse (98).
+        let transcripts = vec![mk(0, 100), mk(2, 98), mk(4, 100)];
+
+        let read_seq = vec![0, 1, 2, 3];
+        let read_qual = vec![30, 30, 30, 30];
+
+        let records = SamWriter::build_alignment_records(
+            "read1",
+            &read_seq,
+            &read_qual,
+            &transcripts,
+            &genome,
+            &params,
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(records.len(), 3);
+        assert!(!records[0].flags().is_secondary(), "best-score #1 primary");
+        assert!(
+            records[1].flags().is_secondary(),
+            "worse-score stays secondary"
+        );
+        assert!(
+            !records[2].flags().is_secondary(),
+            "best-score #2 also primary"
+        );
     }
 
     #[test]

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -149,6 +149,7 @@ impl SamWriter {
                 attrs,
             )?;
             maybe_insert_rg_tag(&mut record, rg_id);
+            apply_sam_flag_or_and(&mut record, params);
 
             self.writer.write_alignment_record(&self.header, &record)?;
         }
@@ -274,6 +275,7 @@ impl SamWriter {
                 attrs,
             )?;
             maybe_insert_rg_tag(&mut record, rg_id);
+            apply_sam_flag_or_and(&mut record, params);
             records.push(record);
         }
 
@@ -356,6 +358,7 @@ impl SamWriter {
                 attrs,
             )?;
             maybe_insert_rg_tag(&mut rec1, rg_id);
+            apply_sam_flag_or_and(&mut rec1, params);
             records.push(rec1);
 
             // Create record for mate2 (this=mate2, mate=mate1)
@@ -376,6 +379,7 @@ impl SamWriter {
                 attrs,
             )?;
             maybe_insert_rg_tag(&mut rec2, rg_id);
+            apply_sam_flag_or_and(&mut rec2, params);
             records.push(rec2);
         }
 
@@ -524,6 +528,7 @@ impl SamWriter {
             data.insert(Tag::new(b'M', b'D'), Value::String(BString::from(md)));
         }
         maybe_insert_rg_tag(&mut mapped_rec, rg_id);
+        apply_sam_flag_or_and(&mut mapped_rec, params);
 
         // --- Build unmapped mate record ---
         let mut unmapped_rec = RecordBuf::default();
@@ -913,6 +918,16 @@ fn maybe_insert_rg_tag(record: &mut RecordBuf, rg_id: Option<&str>) {
             .data_mut()
             .insert(Tag::READ_GROUP, Value::String(BString::from(id)));
     }
+}
+
+/// Apply `--outSAMflagOR` / `--outSAMflagAND` to a mapped record's FLAG:
+/// `(FLAG & flagAND) | flagOR`. Matches STAR/STAR-rs, which apply this only to
+/// mapped-mate records; unmapped and transcriptome-BAM records are untouched.
+fn apply_sam_flag_or_and(record: &mut RecordBuf, params: &Parameters) {
+    let or_bits = params.out_sam_flag_or as u16;
+    let and_bits = params.out_sam_flag_and.min(u16::MAX as u32) as u16;
+    let bits = u16::from(record.flags());
+    *record.flags_mut() = sam::alignment::record::Flags::from((bits & and_bits) | or_bits);
 }
 
 /// Convert FASTQ ASCII quality bytes (Phred+33) to raw Phred values (0-93) for
@@ -2490,6 +2505,58 @@ mod tests {
         // Record 2 (HI=3): IS secondary + reverse complemented
         assert!(records[2].flags().is_secondary());
         assert!(records[2].flags().is_reverse_complemented());
+    }
+
+    #[test]
+    fn test_out_sam_flag_or_and_applied_to_mapped_record() {
+        use cigar::op::{Kind, Op};
+        let genome = make_test_genome();
+        // OR in 0x200 (QC-fail); AND out 0x10 (reverse) via 65535 & !16 = 65519.
+        let params = Parameters::parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "test.fq",
+            "--outSAMflagOR",
+            "512",
+            "--outSAMflagAND",
+            "65519",
+        ]);
+
+        let transcript = Transcript {
+            chr_idx: 0,
+            genome_start: 0,
+            genome_end: 50,
+            is_reverse: true,
+            exons: vec![],
+            cigar: vec![Op::new(Kind::Match, 50)],
+            score: 100,
+            n_mismatch: 0,
+            n_gap: 0,
+            n_junction: 0,
+            junction_motifs: vec![],
+            junction_annotated: vec![],
+            read_seq: vec![0; 4],
+        };
+
+        let read_seq = vec![0, 1, 2, 3];
+        let read_qual = vec![30, 30, 30, 30];
+
+        let records = SamWriter::build_alignment_records(
+            "read1",
+            &read_seq,
+            &read_qual,
+            std::slice::from_ref(&transcript),
+            &genome,
+            &params,
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(records.len(), 1);
+        // REVERSE_COMPLEMENTED (0x10) was set by the transcript but AND-ed out;
+        // QC_FAIL (0x200) was OR-ed in.
+        assert!(!records[0].flags().is_reverse_complemented());
+        assert!(records[0].flags().is_qc_fail());
     }
 
     #[test]

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -370,7 +370,13 @@ impl SamWriter {
                 mapq,
                 true, // is_first_mate
                 paired_aln.is_proper_pair,
-                paired_aln.insert_size,
+                paired_tlen(
+                    &paired_aln.mate1_transcript,
+                    &paired_aln.mate2_transcript,
+                    true,
+                    paired_aln.insert_size,
+                    params,
+                ),
                 max_output, // NH = number of reported alignments
                 hit_index,
                 params.out_sam_attr_ih_start,
@@ -393,8 +399,14 @@ impl SamWriter {
                 mapq,
                 false, // is_first_mate
                 paired_aln.is_proper_pair,
-                -paired_aln.insert_size, // Negative for mate2
-                max_output,              // NH = number of reported alignments
+                paired_tlen(
+                    &paired_aln.mate1_transcript,
+                    &paired_aln.mate2_transcript,
+                    false,
+                    -paired_aln.insert_size, // Negative for mate2 (mode 1 default)
+                    params,
+                ),
+                max_output, // NH = number of reported alignments
                 hit_index,
                 params.out_sam_attr_ih_start,
                 combined_score,
@@ -971,6 +983,28 @@ fn apply_primary_flag(record: &mut RecordBuf, score: i32, best_score: i32, param
         flags.remove(sam::alignment::record::Flags::SECONDARY);
         *record.flags_mut() = flags;
     }
+}
+
+/// `--outSAMtlen 2`: per-mate span, signed by whichever mate is genomically leftmost (ties go to
+/// mate1). Differs from the default (mode 1, `default_signed`) only for contained/dovetailed
+/// pairs, where mode 1's whole-combined-transcript span and mode 2's per-mate max/min span
+/// diverge.
+fn paired_tlen(
+    mate1: &Transcript,
+    mate2: &Transcript,
+    is_first_mate: bool,
+    default_signed: i32,
+    params: &Parameters,
+) -> i32 {
+    if params.out_sam_tlen != 2 {
+        return default_signed;
+    }
+    let span = (mate1.genome_end.max(mate2.genome_end) - mate1.genome_start.min(mate2.genome_start))
+        as i64;
+    let mate1_is_leftmost = mate1.genome_start <= mate2.genome_start;
+    let this_is_leftmost = mate1_is_leftmost == is_first_mate;
+    let span = span as i32;
+    if this_is_leftmost { span } else { -span }
 }
 
 /// Convert FASTQ ASCII quality bytes (Phred+33) to raw Phred values (0-93) for
@@ -2744,6 +2778,59 @@ mod tests {
         // The secondary FLAG bit is unaffected by IHstart (still rank-based, not tag-value-based).
         assert!(!records[0].flags().is_secondary());
         assert!(records[1].flags().is_secondary());
+    }
+
+    #[test]
+    fn test_out_sam_tlen_mode2_contained_pair() {
+        use cigar::op::{Kind, Op};
+        // mate2 fully contained within mate1's span: [100,200) vs [120,180).
+        // Mode 1 (default) just returns whatever the caller already computed (opaque here).
+        // Mode 2 uses the per-mate max/min span (100) and signs by genomic leftmost (mate1).
+        let mate1 = Transcript {
+            chr_idx: 0,
+            genome_start: 100,
+            genome_end: 200,
+            is_reverse: false,
+            exons: vec![],
+            cigar: vec![Op::new(Kind::Match, 100)],
+            score: 100,
+            n_mismatch: 0,
+            n_gap: 0,
+            n_junction: 0,
+            junction_motifs: vec![],
+            junction_annotated: vec![],
+            read_seq: vec![0; 4],
+        };
+        let mate2 = Transcript {
+            genome_start: 120,
+            genome_end: 180,
+            ..mate1.clone()
+        };
+
+        let params_mode1 = Parameters::parse_from(["rustar-aligner", "--readFilesIn", "test.fq"]);
+        assert_eq!(
+            paired_tlen(&mate1, &mate2, true, 42, &params_mode1),
+            42,
+            "mode 1 (default) passes the caller-computed value through unchanged"
+        );
+
+        let params_mode2 = Parameters::parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "test.fq",
+            "--outSAMtlen",
+            "2",
+        ]);
+        assert_eq!(
+            paired_tlen(&mate1, &mate2, true, 42, &params_mode2),
+            100,
+            "mate1 is leftmost -> positive per-mate span"
+        );
+        assert_eq!(
+            paired_tlen(&mate1, &mate2, false, -42, &params_mode2),
+            -100,
+            "mate2 is not leftmost -> negative per-mate span"
+        );
     }
 
     #[test]

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -151,6 +151,7 @@ impl SamWriter {
                 mapq,
                 max_output,    // NH = number of reported alignments
                 hit_index + 1, // 1-based
+                params.out_sam_attr_ih_start,
                 attrs,
             )?;
             maybe_insert_rg_tag(&mut record, rg_id);
@@ -283,6 +284,7 @@ impl SamWriter {
                 mapq,
                 max_output,    // NH = number of reported alignments
                 hit_index + 1, // 1-based
+                params.out_sam_attr_ih_start,
                 attrs,
             )?;
             maybe_insert_rg_tag(&mut record, rg_id);
@@ -371,6 +373,7 @@ impl SamWriter {
                 paired_aln.insert_size,
                 max_output, // NH = number of reported alignments
                 hit_index,
+                params.out_sam_attr_ih_start,
                 combined_score,
                 attrs,
             )?;
@@ -393,6 +396,7 @@ impl SamWriter {
                 -paired_aln.insert_size, // Negative for mate2
                 max_output,              // NH = number of reported alignments
                 hit_index,
+                params.out_sam_attr_ih_start,
                 combined_score,
                 attrs,
             )?;
@@ -504,7 +508,10 @@ impl SamWriter {
             data.insert(Tag::ALIGNMENT_HIT_COUNT, Value::from(n_alignments as i32));
         }
         if attrs.contains(SamAttributes::HI) {
-            data.insert(Tag::HIT_INDEX, Value::from(1i32));
+            data.insert(
+                Tag::HIT_INDEX,
+                Value::from(params.out_sam_attr_ih_start as i32),
+            );
         }
         if attrs.contains(SamAttributes::AS) {
             data.insert(Tag::ALIGNMENT_SCORE, Value::from(mapped_transcript.score));
@@ -701,8 +708,12 @@ impl SamWriter {
                 data.insert(Tag::ALIGNMENT_HIT_COUNT, Value::from(n_alignments as i32));
             }
             if attrs.contains(SamAttributes::HI) {
-                // HI is 1-based; primary = 1, secondaries > 1 in emission order.
-                data.insert(Tag::HIT_INDEX, Value::from((hit_idx + 1) as i32));
+                // HI defaults to 1-based (primary = 1, secondaries > 1 in emission order);
+                // `--outSAMattrIHstart` shifts the whole sequence (0 = CellRanger convention).
+                data.insert(
+                    Tag::HIT_INDEX,
+                    Value::from(hit_idx as i32 + params.out_sam_attr_ih_start as i32),
+                );
             }
             if attrs.contains(SamAttributes::AS) {
                 data.insert(Tag::ALIGNMENT_SCORE, Value::from(t.score));
@@ -981,6 +992,7 @@ fn transcript_to_record(
     mapq: u8,
     n_alignments: usize,
     hit_index: usize,
+    ih_start: u32,
     attrs: SamAttributes,
 ) -> Result<RecordBuf, Error> {
     let mut record = RecordBuf::default();
@@ -1051,7 +1063,10 @@ fn transcript_to_record(
         data.insert(Tag::ALIGNMENT_HIT_COUNT, Value::from(n_alignments as i32));
     }
     if attrs.contains(SamAttributes::HI) {
-        data.insert(Tag::HIT_INDEX, Value::from(hit_index as i32));
+        data.insert(
+            Tag::HIT_INDEX,
+            Value::from(hit_index as i32 - 1 + ih_start as i32),
+        );
     }
     if attrs.contains(SamAttributes::AS) {
         data.insert(Tag::ALIGNMENT_SCORE, Value::from(transcript.score));
@@ -1302,6 +1317,7 @@ fn build_paired_mate_record(
     insert_size: i32,
     n_alignments: usize,
     hit_index: usize,
+    ih_start: u32,
     combined_score: i32,
     attrs: SamAttributes,
 ) -> Result<RecordBuf, Error> {
@@ -1402,7 +1418,10 @@ fn build_paired_mate_record(
         data.insert(Tag::ALIGNMENT_HIT_COUNT, Value::from(n_alignments as i32));
     }
     if attrs.contains(SamAttributes::HI) {
-        data.insert(Tag::HIT_INDEX, Value::from(hit_index as i32));
+        data.insert(
+            Tag::HIT_INDEX,
+            Value::from(hit_index as i32 - 1 + ih_start as i32),
+        );
     }
     if attrs.contains(SamAttributes::AS) {
         // STAR reports combined score (sum of both mates) for PE AS tag
@@ -1767,6 +1786,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             SamAttributes::STANDARD,
         );
         assert!(record.is_ok());
@@ -2004,6 +2024,7 @@ mod tests {
             300,
             1,   // n_alignments
             1,   // hit_index
+            1,   // ih_start
             190, // combined_score (100+90)
             SamAttributes::STANDARD,
         )
@@ -2032,6 +2053,7 @@ mod tests {
             -300,
             1,   // n_alignments
             1,   // hit_index
+            1,   // ih_start
             190, // combined_score (100+90)
             SamAttributes::STANDARD,
         )
@@ -2116,6 +2138,7 @@ mod tests {
             250,
             1,   // n_alignments
             1,   // hit_index
+            1,   // ih_start
             350, // combined_score (200+150)
             SamAttributes::STANDARD,
         )
@@ -2326,6 +2349,7 @@ mod tests {
             255,
             3, // n_alignments
             2, // hit_index
+            1, // ih_start
             SamAttributes::STANDARD,
         )
         .unwrap();
@@ -2443,6 +2467,7 @@ mod tests {
             255,
             1, // unique mapper
             1,
+            1, // ih_start
             SamAttributes::STANDARD,
         )
         .unwrap();
@@ -2648,6 +2673,80 @@ mod tests {
     }
 
     #[test]
+    fn test_out_sam_attr_ih_start_shifts_hi_tag() {
+        use cigar::op::{Kind, Op};
+        let genome = make_test_genome();
+        let params = Parameters::parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "test.fq",
+            "--outSAMattrIHstart",
+            "0",
+        ]);
+
+        let transcripts = vec![
+            Transcript {
+                chr_idx: 0,
+                genome_start: 0,
+                genome_end: 50,
+                is_reverse: false,
+                exons: vec![],
+                cigar: vec![Op::new(Kind::Match, 50)],
+                score: 100,
+                n_mismatch: 0,
+                n_gap: 0,
+                n_junction: 0,
+                junction_motifs: vec![],
+                junction_annotated: vec![],
+                read_seq: vec![0; 4],
+            },
+            Transcript {
+                chr_idx: 0,
+                genome_start: 2,
+                genome_end: 52,
+                is_reverse: false,
+                exons: vec![],
+                cigar: vec![Op::new(Kind::Match, 50)],
+                score: 98,
+                n_mismatch: 1,
+                n_gap: 0,
+                n_junction: 0,
+                junction_motifs: vec![],
+                junction_annotated: vec![],
+                read_seq: vec![0; 4],
+            },
+        ];
+
+        let read_seq = vec![0, 1, 2, 3];
+        let read_qual = vec![30, 30, 30, 30];
+
+        let records = SamWriter::build_alignment_records(
+            "read1",
+            &read_seq,
+            &read_qual,
+            &transcripts,
+            &genome,
+            &params,
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(records.len(), 2);
+        // --outSAMattrIHstart 0: HI starts at 0 instead of the STAR default 1.
+        assert_eq!(
+            records[0].data().get(&Tag::HIT_INDEX),
+            Some(&Value::from(0_i32))
+        );
+        assert_eq!(
+            records[1].data().get(&Tag::HIT_INDEX),
+            Some(&Value::from(1_i32))
+        );
+        // The secondary FLAG bit is unaffected by IHstart (still rank-based, not tag-value-based).
+        assert!(!records[0].flags().is_secondary());
+        assert!(records[1].flags().is_secondary());
+    }
+
+    #[test]
     fn test_xs_tag_spliced() {
         use cigar::op::{Kind, Op};
         let genome = make_test_genome();
@@ -2684,6 +2783,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             SamAttributes::ALL,
         )
         .unwrap();
@@ -2729,6 +2829,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             SamAttributes::ALL,
         )
         .unwrap();
@@ -2778,6 +2879,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             SamAttributes::ALL,
         )
         .unwrap();
@@ -2829,6 +2931,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             SamAttributes::ALL,
         )
         .unwrap();
@@ -2878,6 +2981,7 @@ mod tests {
             255,
             1,
             1,
+            1,                       // ih_start
             SamAttributes::STANDARD, // XS not in standard attrs
         )
         .unwrap();
@@ -3312,6 +3416,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             SamAttributes::ALL,
         )
         .unwrap();
@@ -3397,6 +3502,7 @@ mod tests {
             7,
             1,
             1,
+            1,   // ih_start
             190, // combined_score (100+90)
             SamAttributes::STANDARD,
         )
@@ -3420,6 +3526,7 @@ mod tests {
             -7,
             1,
             1,
+            1,   // ih_start
             190, // combined_score (100+90)
             SamAttributes::STANDARD,
         )
@@ -3506,6 +3613,7 @@ mod tests {
             7,
             1,
             1,
+            1,   // ih_start
             180, // combined_score (100+80)
             SamAttributes::STANDARD,
         )
@@ -3536,6 +3644,7 @@ mod tests {
             -7,
             1,
             1,
+            1,   // ih_start
             180, // combined_score (100+80)
             SamAttributes::STANDARD,
         )
@@ -3622,6 +3731,7 @@ mod tests {
             7,
             1,
             1,
+            1,   // ih_start
             190, // combined_score (100+90)
             SamAttributes::STANDARD,
         )
@@ -3642,6 +3752,7 @@ mod tests {
             -7,
             1,
             1,
+            1,   // ih_start
             190, // combined_score (100+90)
             SamAttributes::STANDARD,
         )
@@ -3684,6 +3795,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             SamAttributes::STANDARD,
         )
         .unwrap();
@@ -3761,6 +3873,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             empty_attrs,
         )
         .unwrap();
@@ -3836,6 +3949,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             attrs,
         )
         .unwrap();
@@ -3975,6 +4089,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             SamAttributes::ALL,
         )
         .unwrap();
@@ -4031,6 +4146,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             attrs,
         )
         .unwrap();
@@ -4057,6 +4173,7 @@ mod tests {
             255,
             1,
             1,
+            1, // ih_start
             no_nm,
         )
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -982,7 +982,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
         // Parallel alignment processing
         let batch_results: Vec<Result<AlignmentBatchResults, error::Error>> = batch_to_process
             .par_iter()
-            .map(|read| {
+            .enumerate()
+            .map(|(read_idx, read)| {
                 #[allow(clippy::needless_borrow)]
                 let index = Arc::clone(&index);
                 #[allow(clippy::needless_borrow)]
@@ -990,6 +991,16 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                 #[allow(clippy::needless_borrow)]
                 let sj_stats = Arc::clone(&sj_stats);
                 let quant = quant.as_ref().map(Arc::clone);
+
+                // --outSAMreadID Number: replace QNAME with the read's 1-based input index
+                // (deterministic regardless of thread count: derived from the sequential
+                // FASTQ read order, not from parallel execution order).
+                let out_read_name = if params.out_sam_read_id == crate::params::OutSamReadId::Number
+                {
+                    (read_count + read_idx as u64 + 1).to_string()
+                } else {
+                    read.name.clone()
+                };
 
                 // Apply clipping
                 let (clipped_seq, clipped_qual) =
@@ -1011,7 +1022,7 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                     }
                     if output_unmapped {
                         let record = SamWriter::build_unmapped_record(
-                            &read.name,
+                            &out_read_name,
                             &clipped_seq,
                             &clipped_qual,
                             params,
@@ -1020,7 +1031,11 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                         buffer.push(record);
                     }
                     let unmapped_m1 = if write_unmapped_fastq {
-                        vec![(read.name.clone(), clipped_seq.clone(), clipped_qual.clone())]
+                        vec![(
+                            out_read_name.clone(),
+                            clipped_seq.clone(),
+                            clipped_qual.clone(),
+                        )]
                     } else {
                         Vec::new()
                     };
@@ -1089,7 +1104,7 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                     // Unmapped
                     if output_unmapped {
                         let record = SamWriter::build_unmapped_record(
-                            &read.name,
+                            &out_read_name,
                             &clipped_seq,
                             &clipped_qual,
                             params,
@@ -1100,7 +1115,7 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                 } else if transcripts.len() <= max_multimaps {
                     // Mapped (within multimap limit)
                     let records = SamWriter::build_alignment_records(
-                        &read.name,
+                        &out_read_name,
                         &clipped_seq,
                         &clipped_qual,
                         &transcripts,
@@ -1119,7 +1134,7 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                     if let Some(ref tidx) = tr_local {
                         build_transcriptome_records_se(
                             &transcripts,
-                            &read.name,
+                            &out_read_name,
                             &clipped_seq,
                             &clipped_qual,
                             &index.genome,
@@ -1132,7 +1147,11 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                     };
 
                 let unmapped_m1 = if write_unmapped_fastq && is_unmapped_se {
-                    vec![(read.name.clone(), clipped_seq.clone(), clipped_qual.clone())]
+                    vec![(
+                        out_read_name.clone(),
+                        clipped_seq.clone(),
+                        clipped_qual.clone(),
+                    )]
                 } else {
                     Vec::new()
                 };
@@ -1412,7 +1431,8 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
         // Parallel alignment processing
         let batch_results: Vec<Result<AlignmentBatchResults, error::Error>> = batch_to_process
             .par_iter()
-            .map(|paired_read| {
+            .enumerate()
+            .map(|(pair_idx, paired_read)| {
                 #[allow(clippy::needless_borrow)]
                 let index = Arc::clone(&index);
                 #[allow(clippy::needless_borrow)]
@@ -1420,6 +1440,25 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                 #[allow(clippy::needless_borrow)]
                 let sj_stats = Arc::clone(&sj_stats);
                 let quant = quant.as_ref().map(Arc::clone);
+
+                // --outSAMreadID Number: replace QNAME with the pair's 1-based input index.
+                let out_read_id_number =
+                    params.out_sam_read_id == crate::params::OutSamReadId::Number;
+                let out_read_name = if out_read_id_number {
+                    (read_count + pair_idx as u64 + 1).to_string()
+                } else {
+                    paired_read.name.clone()
+                };
+                // Unmapped-FASTX mate names: per-mate (with /1,/2 suffix) in Standard mode, the
+                // shared numeric pair index in Number mode.
+                let (fastx_name1, fastx_name2) = if out_read_id_number {
+                    (out_read_name.clone(), out_read_name.clone())
+                } else {
+                    (
+                        paired_read.mate1.name.clone(),
+                        paired_read.mate2.name.clone(),
+                    )
+                };
 
                 // Apply clipping to both mates
                 let (m1_seq, m1_qual) = clip_read(
@@ -1450,7 +1489,7 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     }
                     if output_unmapped {
                         let records = SamWriter::build_paired_unmapped_records(
-                            &paired_read.name,
+                            &out_read_name,
                             &m1_seq,
                             &m1_qual,
                             &m2_seq,
@@ -1464,16 +1503,8 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     }
                     let (um1, um2) = if write_unmapped_fastq {
                         (
-                            vec![(
-                                paired_read.mate1.name.clone(),
-                                m1_seq.clone(),
-                                m1_qual.clone(),
-                            )],
-                            vec![(
-                                paired_read.mate2.name.clone(),
-                                m2_seq.clone(),
-                                m2_qual.clone(),
-                            )],
+                            vec![(fastx_name1.clone(), m1_seq.clone(), m1_qual.clone())],
+                            vec![(fastx_name2.clone(), m2_seq.clone(), m2_qual.clone())],
                         )
                     } else {
                         (Vec::new(), Vec::new())
@@ -1612,7 +1643,7 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     // Unmapped pair
                     if output_unmapped {
                         let records = SamWriter::build_paired_unmapped_records(
-                            &paired_read.name,
+                            &out_read_name,
                             &m1_seq,
                             &m1_qual,
                             &m2_seq,
@@ -1632,7 +1663,7 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     }) = results.first()
                     {
                         let records = SamWriter::build_half_mapped_records(
-                            &paired_read.name,
+                            &out_read_name,
                             &m1_seq,
                             &m1_qual,
                             &m2_seq,
@@ -1655,7 +1686,7 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                         .map(|pa| PairedAlignment::clone(pa))
                         .collect();
                     let records = SamWriter::build_paired_records(
-                        &paired_read.name,
+                        &out_read_name,
                         &m1_seq,
                         &m1_qual,
                         &m2_seq,
@@ -1676,7 +1707,7 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     if let Some(ref tidx) = tr_local {
                         build_transcriptome_records_pe(
                             both_mapped.iter().map(AsRef::as_ref),
-                            &paired_read.name,
+                            &out_read_name,
                             &m1_seq,
                             &m1_qual,
                             &m2_seq,
@@ -1697,16 +1728,8 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     let pair_unmapped = results.is_empty() || has_half_mapped;
                     if pair_unmapped {
                         (
-                            vec![(
-                                paired_read.mate1.name.clone(),
-                                m1_seq.clone(),
-                                m1_qual.clone(),
-                            )],
-                            vec![(
-                                paired_read.mate2.name.clone(),
-                                m2_seq.clone(),
-                                m2_qual.clone(),
-                            )],
+                            vec![(fastx_name1.clone(), m1_seq.clone(), m1_qual.clone())],
+                            vec![(fastx_name2.clone(), m2_seq.clone(), m2_qual.clone())],
                         )
                     } else {
                         (Vec::new(), Vec::new())

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -435,6 +435,10 @@ pub struct Parameters {
     #[arg(long = "outSAMprimaryFlag", default_value = "OneBestScore")]
     pub out_sam_primary_flag: OutSamPrimaryFlag,
 
+    /// Start value of the `HI` SAM attribute (STAR default 1; CellRanger convention uses 0)
+    #[arg(long = "outSAMattrIHstart", default_value_t = 1)]
+    pub out_sam_attr_ih_start: u32,
+
     /// Output filter type: Normal or BySJout
     #[arg(long = "outFilterType", default_value = "Normal")]
     pub out_filter_type: OutFilterType,

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -268,6 +268,34 @@ impl std::str::FromStr for OutSamPrimaryFlag {
 }
 
 // ---------------------------------------------------------------------------
+// SAM read-ID naming
+// ---------------------------------------------------------------------------
+
+/// QNAME source for SAM/FASTX output (`--outSAMreadID`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutSamReadId {
+    /// Use the FASTQ read name as-is (default).
+    #[default]
+    Standard,
+    /// Replace the QNAME with the read's 1-based input index, uniformly across every record
+    /// (mapped, unmapped, FASTX) the read emits.
+    Number,
+}
+
+impl std::str::FromStr for OutSamReadId {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Standard" => Ok(Self::Standard),
+            "Number" => Ok(Self::Number),
+            _ => Err(format!(
+                "unknown outSAMreadID value: '{s}'; expected 'Standard' or 'Number'"
+            )),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Two-pass mode
 // ---------------------------------------------------------------------------
 
@@ -438,6 +466,11 @@ pub struct Parameters {
     /// Start value of the `HI` SAM attribute (STAR default 1; CellRanger convention uses 0)
     #[arg(long = "outSAMattrIHstart", default_value_t = 1)]
     pub out_sam_attr_ih_start: u32,
+
+    /// QNAME source for SAM/FASTX output: `Standard` (default, the FASTQ read name) or
+    /// `Number` (the read's 1-based input index)
+    #[arg(long = "outSAMreadID", default_value = "Standard")]
+    pub out_sam_read_id: OutSamReadId,
 
     /// Output filter type: Normal or BySJout
     #[arg(long = "outFilterType", default_value = "Normal")]

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -241,6 +241,33 @@ impl std::str::FromStr for OutFilterType {
 }
 
 // ---------------------------------------------------------------------------
+// SAM primary-flag assignment
+// ---------------------------------------------------------------------------
+
+/// Which alignment(s) get the SAM primary flag (`--outSAMprimaryFlag`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutSamPrimaryFlag {
+    /// Only the single best-tie-broken alignment is primary (STAR default).
+    #[default]
+    OneBestScore,
+    /// Every alignment tied for the best score is marked primary.
+    AllBestScore,
+}
+
+impl std::str::FromStr for OutSamPrimaryFlag {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "OneBestScore" => Ok(Self::OneBestScore),
+            "AllBestScore" => Ok(Self::AllBestScore),
+            _ => Err(format!(
+                "unknown outSAMprimaryFlag value: '{s}'; expected 'OneBestScore' or 'AllBestScore'"
+            )),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Two-pass mode
 // ---------------------------------------------------------------------------
 
@@ -403,6 +430,10 @@ pub struct Parameters {
     /// Bits AND-ed into every mapped record's FLAG (`--outSAMflagAND`, default 65535 = keep all)
     #[arg(long = "outSAMflagAND", default_value_t = 65535)]
     pub out_sam_flag_and: u32,
+
+    /// Which alignment(s) get the SAM primary flag: `OneBestScore` (default) or `AllBestScore`
+    #[arg(long = "outSAMprimaryFlag", default_value = "OneBestScore")]
+    pub out_sam_primary_flag: OutSamPrimaryFlag,
 
     /// Output filter type: Normal or BySJout
     #[arg(long = "outFilterType", default_value = "Normal")]

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -472,6 +472,11 @@ pub struct Parameters {
     #[arg(long = "outSAMreadID", default_value = "Standard")]
     pub out_sam_read_id: OutSamReadId,
 
+    /// TLEN calculation: 1 (default, whole combined-transcript span) or 2 (per-mate span,
+    /// signed by whichever mate is genomically leftmost)
+    #[arg(long = "outSAMtlen", default_value_t = 1)]
+    pub out_sam_tlen: u8,
+
     /// Output filter type: Normal or BySJout
     #[arg(long = "outFilterType", default_value = "Normal")]
     pub out_filter_type: OutFilterType,

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -396,6 +396,14 @@ pub struct Parameters {
     #[arg(long = "outSAMmultNmax", default_value_t = -1, allow_hyphen_values = true)]
     pub out_sam_mult_nmax: i32,
 
+    /// Bits OR-ed into every mapped record's FLAG (`--outSAMflagOR`, default 0)
+    #[arg(long = "outSAMflagOR", default_value_t = 0)]
+    pub out_sam_flag_or: u32,
+
+    /// Bits AND-ed into every mapped record's FLAG (`--outSAMflagAND`, default 65535 = keep all)
+    #[arg(long = "outSAMflagAND", default_value_t = 65535)]
+    pub out_sam_flag_and: u32,
+
     /// Output filter type: Normal or BySJout
     #[arg(long = "outFilterType", default_value = "Normal")]
     pub out_filter_type: OutFilterType,


### PR DESCRIPTION
## Summary
Groups the small `--outSAM*` record-level output knobs into one themed PR (5 commits):

- `--outSAMattrIHstart`: start value of the `HI` SAM attribute (STAR default 1; CellRanger convention 0).
- `--outSAMflagOR` / `--outSAMflagAND`: bitwise FLAG override `(FLAG & flagAND) | flagOR`, applied only to mapped-mate records (matches STAR/STAR-rs scope: unmapped and transcriptome-BAM records untouched).
- `--outSAMprimaryFlag`: `OneBestScore` (default, unchanged behavior) vs `AllBestScore` (mark every best-score-tied alignment primary instead of just the sorted first).
- `--outSAMreadID`: `Standard` (default, FASTQ read name) vs `Number` (replace QNAME with the read's 1-based input index, uniformly across mapped/unmapped/FASTX output; deterministic regardless of thread count since it's derived from sequential FASTQ read order, not parallel execution order).
- `--outSAMtlen`: TLEN mode 1 (default, unchanged) vs mode 2 (per-mate span, signed by whichever mate is genomically leftmost; differs from mode 1 only for contained/dovetailed pairs).

Supersedes #125 (folded in as its own commit).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings)
- [x] `cargo test --workspace` (459 passed)
- [x] Manual smoke tests per feature: HI tag shift (1->0), FLAG 0->512 with flagOR/AND, OneBestScore vs AllBestScore on a duplicated-region genome (FLAG 0/256 -> 0/0), outSAMreadID Number on SE and PE (QNAME -> sequential 1-based index, shared across mates), outSAMtlen 2 producing identical TLEN to mode 1 on a normal FR pair (verifying no regression; the mode-2-specific contained/dovetail divergence is covered by a dedicated unit test since constructing a real contained-pair alignment through the full aligner pipeline is not practical)