### PR TITLE
feat: splice-junction-DB / GTF annotation config (chr_start_end TSV, gene name/type tags)

### DIFF
--- a/src/index/io.rs
+++ b/src/index/io.rs
@@ -87,6 +87,8 @@ impl GenomeIndex {
                 &genome,
                 &params.sjdb_gtf_tag_exon_parent_transcript,
                 &params.sjdb_gtf_tag_exon_parent_gene,
+                &params.sjdb_gtf_tag_exon_parent_gene_name,
+                &params.sjdb_gtf_tag_exon_parent_gene_type,
             )?)
         } else {
             None

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -291,6 +291,8 @@ impl GenomeIndex {
                 &genome,
                 &params.sjdb_gtf_tag_exon_parent_transcript,
                 &params.sjdb_gtf_tag_exon_parent_gene,
+                &params.sjdb_gtf_tag_exon_parent_gene_name,
+                &params.sjdb_gtf_tag_exon_parent_gene_type,
             )?;
             log::info!(
                 "Transcriptome index built from GTF: {} transcripts, {} genes",

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -273,11 +273,12 @@ impl GenomeIndex {
         // preparation + Gsj append must happen BEFORE the suffix array is
         // built, because STAR indexes the flanking-sequence buffer alongside
         // the real genome in a single SA (`sjdbBuildIndex.cpp:293`).
-        let (junction_db, transcriptome, prepared_junctions) = if let Some(ref gtf_path) =
-            params.sjdb_gtf_file
-        {
-            let n_genome_real = genome.n_genome;
+        let n_genome_real = genome.n_genome;
 
+        let mut raw: Vec<(usize, u64, u64, u8)> = Vec::new();
+        let mut transcriptome = None;
+
+        if let Some(ref gtf_path) = params.sjdb_gtf_file {
             let exons = crate::junction::gtf::parse_gtf_configured(
                 gtf_path,
                 &params.sjdb_gtf_feature_exon,
@@ -297,12 +298,29 @@ impl GenomeIndex {
                 tr.gene_ids.len()
             );
 
-            let raw = crate::junction::gtf::extract_junctions_configured(
+            let gtf_raw = crate::junction::gtf::extract_junctions_configured(
                 exons,
                 &genome,
                 &params.sjdb_gtf_tag_exon_parent_transcript,
             )?;
-            log::info!("Extracted {} annotated junctions from GTF", raw.len());
+            log::info!("Extracted {} annotated junctions from GTF", gtf_raw.len());
+            raw.extend(gtf_raw);
+            transcriptome = Some(tr);
+        }
+
+        if !params.sjdb_file_chr_start_end.is_empty() {
+            let extra = crate::junction::chr_start_end::parse_sjdb_chr_start_end(
+                &params.sjdb_file_chr_start_end,
+                &genome,
+            )?;
+            log::info!(
+                "Parsed {} junctions from --sjdbFileChrStartEnd",
+                extra.len()
+            );
+            raw.extend(extra);
+        }
+
+        let (junction_db, prepared_junctions) = if !raw.is_empty() {
             let jdb = SpliceJunctionDb::from_raw_junctions(&raw);
 
             let prepared: Vec<PreparedJunction> = raw
@@ -335,10 +353,10 @@ impl GenomeIndex {
                 n_genome_real
             );
 
-            (jdb, Some(tr), prepared)
+            (jdb, prepared)
         } else {
-            log::info!("No GTF file provided, all junctions will be novel");
-            (SpliceJunctionDb::empty(), None, Vec::new())
+            log::info!("No GTF or --sjdbFileChrStartEnd provided, all junctions will be novel");
+            (SpliceJunctionDb::empty(), Vec::new())
         };
 
         log::info!(

--- a/src/junction/chr_start_end.rs
+++ b/src/junction/chr_start_end.rs
@@ -1,0 +1,131 @@
+//! `--sjdbFileChrStartEnd`: explicit splice junctions given as TSV files, unioned with any
+//! `--sjdbGTFfile`-derived junctions before sjdb insertion (STAR's `sjdbFileChrStartEnd`).
+//!
+//! Each line is `chr  start  end  [strand]`, whitespace-delimited, with `start`/`end` the 1-based
+//! coordinates of the intron's first and last base. The strand column is optional; `.` or absent
+//! means unknown (the motif is derived from the genome at sjdb-insertion time). Lines with fewer
+//! than 3 fields, or a non-integer `start`/`end`, are skipped (STAR's `istringstream >>` silently
+//! stops parsing a malformed line). An unresolvable chromosome name is a hard error, matching
+//! STAR's fatal exit on the same condition.
+
+use std::path::Path;
+
+use crate::error::Error;
+use crate::genome::Genome;
+
+/// Parse `--sjdbFileChrStartEnd` TSV files into raw junction tuples
+/// `(chr_idx, intron_start, intron_end, strand)`, in the same genome-absolute 0-based /
+/// `0=unknown,1=+,2=-` convention as [`crate::junction::gtf::extract_junctions_configured`].
+pub fn parse_sjdb_chr_start_end(
+    paths: &[std::path::PathBuf],
+    genome: &Genome,
+) -> Result<Vec<(usize, u64, u64, u8)>, Error> {
+    let mut out = Vec::new();
+    for path in paths {
+        let text = std::fs::read_to_string(path).map_err(|e| Error::io(e, path.clone()))?;
+        for line in text.lines() {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() < 3 {
+                continue;
+            }
+            let (Ok(start), Ok(end)) = (fields[1].parse::<u64>(), fields[2].parse::<u64>()) else {
+                continue;
+            };
+            let strand = match fields.get(3).and_then(|s| s.chars().next()) {
+                Some('+') => 1u8,
+                Some('-') => 2u8,
+                _ => 0u8,
+            };
+            let chr_idx = chr_index(genome, fields[0], path)?;
+            let base = genome.chr_start[chr_idx];
+            out.push((chr_idx, base + start - 1, base + end - 1, strand));
+        }
+    }
+    Ok(out)
+}
+
+fn chr_index(genome: &Genome, name: &str, path: &Path) -> Result<usize, Error> {
+    genome
+        .chr_name
+        .iter()
+        .position(|n| n == name)
+        .ok_or_else(|| {
+            Error::Parameter(format!(
+                "{}: chromosome '{name}' not found in the genome (--sjdbFileChrStartEnd)",
+                path.display()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_genome() -> Genome {
+        Genome {
+            sequence: vec![0u8; 2000],
+            n_genome: 2000,
+            n_genome_real: 2000,
+            n_chr_real: 2,
+            chr_name: vec!["chr1".to_string(), "chr2".to_string()],
+            chr_length: vec![1000, 1000],
+            chr_start: vec![0, 1000, 2000],
+        }
+    }
+
+    #[test]
+    fn parses_chr_start_end_strand() {
+        let genome = tiny_genome();
+        let dir =
+            std::env::temp_dir().join(format!("sjdb-chr-start-end-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("junctions.tsv");
+        std::fs::write(&path, "chr1\t101\t200\t+\nchr2\t51\t150\t-\n").unwrap();
+
+        let raw = parse_sjdb_chr_start_end(std::slice::from_ref(&path), &genome).unwrap();
+        assert_eq!(raw, vec![(0, 100, 199, 1), (1, 1050, 1149, 2)]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn missing_strand_defaults_to_unknown() {
+        let genome = tiny_genome();
+        let dir =
+            std::env::temp_dir().join(format!("sjdb-chr-start-end-test2-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("junctions.tsv");
+        std::fs::write(&path, "chr1\t101\t200\n").unwrap();
+
+        let raw = parse_sjdb_chr_start_end(std::slice::from_ref(&path), &genome).unwrap();
+        assert_eq!(raw, vec![(0, 100, 199, 0)]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn short_lines_are_skipped() {
+        let genome = tiny_genome();
+        let dir =
+            std::env::temp_dir().join(format!("sjdb-chr-start-end-test3-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("junctions.tsv");
+        std::fs::write(&path, "chr1\t101\n# comment too short\nchr1\t101\t200\t+\n").unwrap();
+
+        let raw = parse_sjdb_chr_start_end(std::slice::from_ref(&path), &genome).unwrap();
+        assert_eq!(raw, vec![(0, 100, 199, 1)]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn unknown_chromosome_errors() {
+        let genome = tiny_genome();
+        let dir =
+            std::env::temp_dir().join(format!("sjdb-chr-start-end-test4-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("junctions.tsv");
+        std::fs::write(&path, "chrZ\t101\t200\t+\n").unwrap();
+
+        let err = parse_sjdb_chr_start_end(std::slice::from_ref(&path), &genome).unwrap_err();
+        assert!(err.to_string().contains("chrZ"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/junction/mod.rs
+++ b/src/junction/mod.rs
@@ -5,6 +5,7 @@
 /// - Building a junction database from annotated exons
 /// - Junction lookup during alignment (annotated vs novel)
 /// - Junction statistics collection for SJ.out.tab output
+pub(crate) mod chr_start_end;
 pub(crate) mod gtf;
 mod sj_output;
 pub mod sjdb_insert;

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -633,6 +633,20 @@ pub struct Parameters {
     #[arg(long = "sjdbGTFtagExonParentGene", default_value = "gene_id")]
     pub sjdb_gtf_tag_exon_parent_gene: String,
 
+    /// GTF attribute name(s) for parent gene name of exon features; when several are given and
+    /// several match, the last one in the list wins
+    #[arg(long = "sjdbGTFtagExonParentGeneName", default_values_t = vec!["gene_name".to_string()], num_args = 1..)]
+    pub sjdb_gtf_tag_exon_parent_gene_name: Vec<String>,
+
+    /// GTF attribute name(s) for parent gene type of exon features; when several are given and
+    /// several match, the last one in the list wins
+    #[arg(
+        long = "sjdbGTFtagExonParentGeneType",
+        default_values_t = vec!["gene_type".to_string(), "gene_biotype".to_string()],
+        num_args = 1..
+    )]
+    pub sjdb_gtf_tag_exon_parent_gene_type: Vec<String>,
+
     /// Overhang length for splice junction database
     #[arg(long = "sjdbOverhang", default_value_t = 100)]
     pub sjdb_overhang: u32,

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -609,6 +609,11 @@ pub struct Parameters {
     #[arg(long = "sjdbGTFfile")]
     pub sjdb_gtf_file: Option<PathBuf>,
 
+    /// TSV file(s) of `chr start end [strand]` junctions (1-based intron first/last base) to
+    /// insert into the sjdb, unioned with any `--sjdbGTFfile` junctions
+    #[arg(long = "sjdbFileChrStartEnd", num_args = 1..)]
+    pub sjdb_file_chr_start_end: Vec<PathBuf>,
+
     /// Prefix to add to chromosome names from GTF file (e.g. "chr" when GTF uses bare numbers)
     #[arg(long = "sjdbGTFchrPrefix", default_value = "")]
     pub sjdb_gtf_chr_prefix: String,

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -23,12 +23,20 @@ use std::path::Path;
 /// GTF attribute names the transcriptome index reads.
 const GTF_ATTR_TRANSCRIPT_ID: &str = "transcript_id";
 const GTF_ATTR_GENE_ID: &str = "gene_id";
-const GTF_ATTR_GENE_NAME: &str = "gene_name";
-const GTF_ATTR_GENE_BIOTYPE: &str = "gene_biotype";
 
 /// STAR's fallback for GTF records missing `gene_biotype`
 /// (`source/GTF.cpp`).
 const MISSING_GENE_TYPE: &str = "MissingGeneType";
+
+/// STAR's `find_attr_list` (`GTF.cpp`): the last of `tags`, in list order, that has an entry in
+/// `attrs`. `--sjdbGTFtagExonParentGeneName`/`GeneType` accept several candidate keys; when more
+/// than one matches, the last one in the list wins.
+fn find_attr_list(attrs: &HashMap<String, String>, tags: &[String]) -> Option<String> {
+    tags.iter()
+        .filter_map(|t| attrs.get(t))
+        .next_back()
+        .cloned()
+}
 
 // ---------------------------------------------------------------------------
 // Filter-mode enum + softclip extension (subtask 3)
@@ -151,11 +159,16 @@ impl TranscriptomeIndex {
     ///
     /// `transcript_tag`: STAR `sjdbGTFtagExonParentTranscript` (default `"transcript_id"`).
     /// `gene_tag`: STAR `sjdbGTFtagExonParentGene` (default `"gene_id"`).
+    /// `gene_name_tags`/`gene_type_tags`: STAR `sjdbGTFtagExonParentGeneName`/`GeneType`
+    /// (defaults `["gene_name"]` / `["gene_type", "gene_biotype"]`); when several candidate keys
+    /// match, the last one in the list wins.
     pub fn from_gtf_exons_configured(
         exons: &[GtfRecord],
         genome: &Genome,
         transcript_tag: &str,
         gene_tag: &str,
+        gene_name_tags: &[String],
+        gene_type_tags: &[String],
     ) -> Result<Self, Error> {
         // Group exons by transcript_tag, preserving first-seen insertion order.
         let mut order: Vec<String> = Vec::new();
@@ -270,15 +283,9 @@ impl TranscriptomeIndex {
             // STAR-faithful fallbacks: when the GTF record omits gene_name,
             // STAR's GTF.cpp writes geneAttr[ig][0] = gene_id (not empty).
             // When gene_biotype is omitted, it writes `MISSING_GENE_TYPE`.
-            let gene_name = first
-                .attributes
-                .get(GTF_ATTR_GENE_NAME)
-                .cloned()
+            let gene_name = find_attr_list(&first.attributes, gene_name_tags)
                 .unwrap_or_else(|| gene_id.clone());
-            let gene_biotype = first
-                .attributes
-                .get(GTF_ATTR_GENE_BIOTYPE)
-                .cloned()
+            let gene_biotype = find_attr_list(&first.attributes, gene_type_tags)
                 .unwrap_or_else(|| MISSING_GENE_TYPE.to_string());
 
             // Intern the gene — first transcript for each gene_id wins the
@@ -355,7 +362,14 @@ impl TranscriptomeIndex {
 
     /// Build from already-parsed GTF exon records using default STAR attribute names.
     pub fn from_gtf_exons(exons: &[GtfRecord], genome: &Genome) -> Result<Self, Error> {
-        Self::from_gtf_exons_configured(exons, genome, GTF_ATTR_TRANSCRIPT_ID, GTF_ATTR_GENE_ID)
+        Self::from_gtf_exons_configured(
+            exons,
+            genome,
+            GTF_ATTR_TRANSCRIPT_ID,
+            GTF_ATTR_GENE_ID,
+            &["gene_name".to_string()],
+            &["gene_type".to_string(), "gene_biotype".to_string()],
+        )
     }
 
     /// Number of transcripts indexed.
@@ -1549,6 +1563,73 @@ mod tests {
             vec!["protein_coding".to_string(), "MissingGeneType".to_string()]
         );
         assert_eq!(idx.tr_gene_idx, vec![0, 0, 1]);
+    }
+
+    #[test]
+    fn gene_type_attribute_is_a_default_fallback_for_gene_biotype() {
+        // GENCODE-style GTFs use `gene_type`, not `gene_biotype`. The default
+        // `--sjdbGTFtagExonParentGeneType` candidate list (`["gene_type", "gene_biotype"]`) must
+        // pick it up even when `gene_biotype` is absent.
+        let genome = make_genome();
+        let exons = vec![make_exon_with_attrs(
+            "chr1",
+            101,
+            200,
+            '+',
+            "T1",
+            &[("gene_id", "G1"), ("gene_type", "lncRNA")],
+        )];
+        let idx = TranscriptomeIndex::from_gtf_exons(&exons, &genome).unwrap();
+        assert_eq!(idx.gene_biotypes, vec!["lncRNA".to_string()]);
+    }
+
+    #[test]
+    fn gene_biotype_wins_over_gene_type_when_both_present() {
+        // Default candidate order is `["gene_type", "gene_biotype"]`; the last match in the list
+        // wins, so `gene_biotype` takes precedence over `gene_type`.
+        let genome = make_genome();
+        let exons = vec![make_exon_with_attrs(
+            "chr1",
+            101,
+            200,
+            '+',
+            "T1",
+            &[
+                ("gene_id", "G1"),
+                ("gene_type", "lncRNA"),
+                ("gene_biotype", "protein_coding"),
+            ],
+        )];
+        let idx = TranscriptomeIndex::from_gtf_exons(&exons, &genome).unwrap();
+        assert_eq!(idx.gene_biotypes, vec!["protein_coding".to_string()]);
+    }
+
+    #[test]
+    fn custom_gene_name_and_type_tags_are_configurable() {
+        let genome = make_genome();
+        let exons = vec![make_exon_with_attrs(
+            "chr1",
+            101,
+            200,
+            '+',
+            "T1",
+            &[
+                ("gene_id", "G1"),
+                ("gene_symbol", "GENE1"),
+                ("gene_class", "custom_class"),
+            ],
+        )];
+        let idx = TranscriptomeIndex::from_gtf_exons_configured(
+            &exons,
+            &genome,
+            "transcript_id",
+            "gene_id",
+            &["gene_symbol".to_string()],
+            &["gene_class".to_string()],
+        )
+        .unwrap();
+        assert_eq!(idx.gene_names, vec!["GENE1".to_string()]);
+        assert_eq!(idx.gene_biotypes, vec!["custom_class".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Groups the splice-junction-DB / GTF-annotation config knobs into one themed PR (2 commits, supersedes #122 and #124):

- `--sjdbFileChrStartEnd`: explicit junction TSV file(s), independent of (and unionable with) a GTF's derived junctions.
- `--sjdbGTFtagExonParentGeneName` / `--sjdbGTFtagExonParentGeneType`: configurable candidate attribute-key lists for gene name/biotype, with STAR's "last match in list wins" semantics. Bundled fix: rustar-aligner previously only checked `gene_biotype`, never `gene_type`, so GENCODE-style GTFs silently fell back to `MissingGeneType`; the new default candidate list checks both.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings)
- [x] `cargo test --workspace` (462 passed)
- [x] Manual smoke tests (from #122/#124): `genomeGenerate` with only `--sjdbFileChrStartEnd` (no GTF) round-trips through `sjdbList.out.tab`; a GTF using only `gene_type "lncRNA"` now correctly populates `geneInfo.tab` instead of `MissingGeneType`