### PR TITLE
feat: --chimOutJunctionFormat (STAR-Fusion comment trailer)

### DIFF
--- a/src/chimeric/output.rs
+++ b/src/chimeric/output.rs
@@ -102,6 +102,29 @@ impl ChimericJunctionWriter {
             .flush()
             .map_err(|e| Error::Chimeric(format!("Failed to flush chimeric junction file: {e}")))
     }
+
+    /// `--chimOutJunctionFormat 1` (STAR-Fusion): append a comment header line (version + command
+    /// line) then a `# Nreads .. NreadsUnique .. NreadsMulti ..` count summary, after all junction
+    /// lines have been written.
+    pub fn write_format1_trailer(
+        &mut self,
+        command_line: &str,
+        n_reads: u64,
+        n_reads_unique: u64,
+        n_reads_multi: u64,
+    ) -> Result<(), Error> {
+        writeln!(
+            self.writer,
+            "# {}   {command_line}",
+            env!("CARGO_PKG_VERSION")
+        )
+        .map_err(|e| Error::Chimeric(format!("Failed to write chimeric format-1 header: {e}")))?;
+        writeln!(
+            self.writer,
+            "# Nreads {n_reads}\tNreadsUnique {n_reads_unique}\tNreadsMulti {n_reads_multi}"
+        )
+        .map_err(|e| Error::Chimeric(format!("Failed to write chimeric format-1 counts: {e}")))
+    }
 }
 
 /// Build two SAM records for `--chimOutType WithinBAM`.
@@ -278,6 +301,30 @@ mod tests {
         let mut path = prefix_path.clone();
         path.push("Chimeric.out.junction");
         assert!(path.exists(), "chim output file should exist at {path:?}");
+    }
+
+    #[test]
+    fn test_chim_out_junction_format1_trailer() {
+        let dir = tempdir().unwrap();
+        let prefix = format!("{}/", dir.path().display());
+        let path = PathBuf::from(format!("{prefix}Chimeric.out.junction"));
+
+        let mut writer = ChimericJunctionWriter::new(&prefix).unwrap();
+        writer
+            .write_format1_trailer("star --runMode alignReads", 100, 5, 0)
+            .unwrap();
+        writer.flush().unwrap();
+
+        let mut contents = String::new();
+        File::open(&path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].starts_with("# "));
+        assert!(lines[0].contains("star --runMode alignReads"));
+        assert_eq!(lines[1], "# Nreads 100\tNreadsUnique 5\tNreadsMulti 0");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1295,6 +1295,13 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
 
     // Flush chimeric output if enabled
     if let Some(ref mut chim_writer) = chimeric_writer {
+        if params.chim_out_junction_format == 1 {
+            use std::sync::atomic::Ordering;
+            let command_line = params.command_line.as_deref().unwrap_or("");
+            let n_reads = stats.total_reads.load(Ordering::Relaxed);
+            let n_unique = stats.chimeric_reads.load(Ordering::Relaxed);
+            chim_writer.write_format1_trailer(command_line, n_reads, n_unique, 0)?;
+        }
         chim_writer.flush()?;
         info!("Chimeric junction output complete");
     }
@@ -1854,6 +1861,13 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
 
     // Flush chimeric output if enabled
     if let Some(ref mut chim_writer) = chimeric_writer {
+        if params.chim_out_junction_format == 1 {
+            use std::sync::atomic::Ordering;
+            let command_line = params.command_line.as_deref().unwrap_or("");
+            let n_reads = stats.total_reads.load(Ordering::Relaxed);
+            let n_unique = stats.chimeric_reads.load(Ordering::Relaxed);
+            chim_writer.write_format1_trailer(command_line, n_reads, n_unique, 0)?;
+        }
         chim_writer.flush()?;
     }
 

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -704,6 +704,11 @@ pub struct Parameters {
     #[arg(long = "chimOutType", num_args = 1..=2, default_values_t = vec!["Junctions".to_string()])]
     pub chim_out_type: Vec<String>,
 
+    /// `Chimeric.out.junction` format: `0` (plain, default) or `1` (append a STAR-Fusion-style
+    /// comment header with the command line and read counts)
+    #[arg(long = "chimOutJunctionFormat", default_value_t = 0)]
+    pub chim_out_junction_format: u8,
+
     /// Full command line as invoked, embedded in the BAM `@PG` `CL:` field.
     #[arg(skip)]
     pub command_line: Option<String>,


### PR DESCRIPTION
## Summary
- Adds `--chimOutJunctionFormat`: `0` (plain, default) or `1` (append a STAR-Fusion-style comment trailer to `Chimeric.out.junction` after all junction lines: a `# <version>   <command line>` header, then `# Nreads .. NreadsUnique .. NreadsMulti ..` counts).
- Scoped out of this PR (deferred, needs more study before touching): `--chimFilter banGenomicN` requires retrofitting a genomic-N junction-rejection check into rustar-aligner's chimeric breakpoint placement, which is structurally simpler than STAR's exhaustive ambiguous-breakpoint search that the check is normally embedded in — risks silently changing which junction position gets chosen. `--chimMultimapNmax` / `--chimMultimapScoreRange` / `--chimNonchimScoreDropMin` are a genuinely separate, larger feature (full multimap chimeric detection with extra output columns), not a config knob on existing behavior.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings)
- [x] `cargo test --workspace` (456 passed, incl. new `test_chim_out_junction_format1_trailer`)
- [x] Manual smoke test: synthetic two-chromosome genome + a chimeric read spanning both, confirmed `Chimeric.out.junction` gets the junction line plus the two trailer comment lines (version/command-line, then `Nreads 1 NreadsUnique 1 NreadsMulti 0`) with `--chimOutJunctionFormat 1`