### PR TITLE
Ben consolidation 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ target
 *.log
 *.tab
 *.sam
+TODO.md
 
 # Linux build dir used by the solo Docker benchmark/diff (CARGO_TARGET_DIR)
 /target-linux/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ src/
     segment.rs     -- ChimericSegment and ChimericAlignment data structures
     score.rs       -- Junction type classification, repeat length calculation
     output.rs      -- Chimeric.out.junction writer (14-column format)
+  clip/
+    mod.rs         -- Adapter-aware clipping (--clip{5,3}pNbases + Hamming --clip3pAdapterSeq/*MMp/*AfterAdapterNbases)
+  wasp/
+    mod.rs         -- WASP allele-specific-mapping filter (--waspOutputMode SAMtag, --varVCFfile), SE + PE
 ```
 
 ## Development Philosophy — Match STAR Exactly

--- a/src/clip/mod.rs
+++ b/src/clip/mod.rs
@@ -1,0 +1,234 @@
+//! Adapter-aware read clipping (STAR `ClipMate` / `ParametersClip`, Hamming mode).
+//!
+//! Ported from STAR-rs `crates/star-align/src/star_clip.rs`. Extends the plain
+//! `--clip5pNbases`/`--clip3pNbases` fixed clip with a 3' adapter Hamming scan
+//! (`--clip3pAdapterSeq`/`--clip3pAdapterMMp`) and the after-adapter trim
+//! (`--clip{5,3}pAfterAdapterNbases`).
+//!
+//! STAR removes the clipped bases from the read before mapping (the mapped read
+//! is the clipped one); this module reproduces the clip amounts. rustar-aligner
+//! feeds the clipped read straight to the aligner and to SAM output (matching its
+//! existing `--clip5pNbases`/`--clip3pNbases` convention), so clipped bases are
+//! dropped rather than reinserted as soft-clips.
+//!
+//! STAR clips a mate as two passes in order: 5' first (`clip5pNbases`, then
+//! `clip5pAfterAdapterNbases`), then 3' on the 5'-clipped read (`clip3pNbases`,
+//! then the 3' adapter Hamming scan, then `clip3pAfterAdapterNbases`).
+//!
+//! Only `--clipAdapterType Hamming` (STAR's default) is supported; a 5' Hamming
+//! adapter is not a thing STAR itself supports either (only `CellRanger4` mode
+//! clips a 5' adapter, the 10x TSO) — that mode is out of scope here.
+
+use crate::io::fastq::encode_base;
+use crate::params::Parameters;
+
+/// One end's clipping parameters (STAR `ClipMate`). `n` = fixed clip, `adapter` =
+/// the adapter sequence (ASCII; empty = none), `ad_mmp` = max mismatch fraction,
+/// `n_after` = extra clip after the adapter.
+#[derive(Debug, Clone, Default)]
+pub struct ClipEnd {
+    /// `--clip{5,3}pNbases` for this end.
+    pub n: usize,
+    /// `--clip3pAdapterSeq` (ASCII), empty when none. Only meaningful for the 3' end.
+    pub adapter: Vec<u8>,
+    /// `--clip3pAdapterMMp` (default 0.1).
+    pub ad_mmp: f64,
+    /// `--clip{5,3}pAfterAdapterNbases`.
+    pub n_after: usize,
+}
+
+/// One mate's clipping parameters: the 5' and 3' ends.
+#[derive(Debug, Clone, Default)]
+pub struct ClipParams {
+    /// 5' end (STAR `ClipMate` type 0).
+    pub five: ClipEnd,
+    /// 3' end (STAR `ClipMate` type 1).
+    pub three: ClipEnd,
+}
+
+/// Build [`ClipParams`] from the run's `--clip{5,3}pNbases` / `--clip3pAdapterSeq`
+/// / `--clip3pAdapterMMp` / `--clip{5,3}pAfterAdapterNbases`. `-` (STAR's sentinel)
+/// means no adapter. Built once per run and reused for every read.
+pub fn clip_params_from(params: &Parameters) -> ClipParams {
+    let adapter = if params.clip3p_adapter_seq == "-" {
+        Vec::new()
+    } else {
+        params.clip3p_adapter_seq.as_bytes().to_vec()
+    };
+    ClipParams {
+        five: ClipEnd {
+            n: params.clip5p_nbases as usize,
+            adapter: Vec::new(),
+            ad_mmp: 0.0,
+            n_after: params.clip5p_after_adapter_nbases as usize,
+        },
+        three: ClipEnd {
+            n: params.clip3p_nbases as usize,
+            adapter,
+            ad_mmp: params.clip3p_adapter_mmp,
+            n_after: params.clip3p_after_adapter_nbases as usize,
+        },
+    }
+}
+
+/// STAR `localSearch`: the offset `ixBest` in `x` where `y` best matches (max
+/// matches, then min mismatches, subject to `nMM/nMatch <= p_mm`); `nx` when no
+/// acceptable match (so nothing clips).
+fn local_search(x: &[u8], y: &[u8], p_mm: f64) -> usize {
+    let nx = x.len();
+    let ny = y.len();
+    let (mut best_ix, mut best_match, mut best_mm) = (nx, 0usize, 0usize);
+    for ix in 0..nx {
+        let (mut n_match, mut n_mm) = (0usize, 0usize);
+        for iy in 0..ny.min(nx - ix) {
+            if x[ix + iy] > 3 {
+                continue;
+            }
+            if x[ix + iy] == y[iy] {
+                n_match += 1;
+            } else {
+                n_mm += 1;
+            }
+        }
+        if (n_match > best_match || (n_match == best_match && n_mm < best_mm))
+            && (n_match == 0 || n_mm as f64 / n_match as f64 <= p_mm)
+        {
+            best_ix = ix;
+            best_match = n_match;
+            best_mm = n_mm;
+        }
+    }
+    best_ix
+}
+
+/// Clip one mate (STAR's two `ClipMate::clip` passes: 5' then 3'). Returns
+/// `(clip5p_total, clip3p_total)`; the clipped region is
+/// `read[clip5p_total .. len-clip3p_total]`.
+///
+/// STAR marks a `ClipMate` inactive (no clip at all) when it has no fixed clip
+/// AND no adapter: an end's `n_after` alone is a no-op, matching the oracle.
+pub fn clip_mate(read: &[u8], p: &ClipParams) -> (usize, usize) {
+    let len = read.len();
+
+    // ---- 5' end (STAR ClipMate type 0) ----
+    let five_active = p.five.n > 0;
+    let mut c5 = 0;
+    if five_active {
+        c5 = p.five.n.min(len);
+        if p.five.n_after > 0 {
+            c5 += p.five.n_after.min(len - c5);
+        }
+    }
+
+    // ---- 3' end (STAR ClipMate type 1), on the 5'-clipped read ----
+    let three_active = p.three.n > 0 || !p.three.adapter.is_empty();
+    let s = &read[c5..];
+    let sl = s.len();
+    let mut c3 = 0;
+    if three_active {
+        c3 = p.three.n.min(sl);
+        if !p.three.adapter.is_empty() {
+            // Hamming 3' adapter scan on the read after the fixed 3' clip.
+            let x_num: Vec<u8> = s[..sl - c3].iter().map(|&b| encode_base(b)).collect();
+            let y_num: Vec<u8> = p.three.adapter.iter().map(|&b| encode_base(b)).collect();
+            let nx = x_num.len();
+            let ix_best = local_search(&x_num, &y_num, p.three.ad_mmp);
+            c3 += nx - ix_best;
+        }
+        if p.three.n_after > 0 {
+            let remaining = sl.saturating_sub(c3);
+            c3 += p.three.n_after.min(remaining);
+        }
+    }
+
+    (c5, c3)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hamming_3p(adapter: &[u8], mmp: f64) -> ClipParams {
+        ClipParams {
+            three: ClipEnd {
+                adapter: adapter.to_vec(),
+                ad_mmp: mmp,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fixed_5p_3p() {
+        let p = ClipParams {
+            five: ClipEnd {
+                n: 3,
+                ..Default::default()
+            },
+            three: ClipEnd {
+                n: 2,
+                ..Default::default()
+            },
+        };
+        assert_eq!(clip_mate(b"AAACCCGGGTT", &p), (3, 2));
+    }
+
+    #[test]
+    fn adapter_3p_hamming() {
+        // Adapter "AGATCGGAAGAGC"; read = insert + adapter tail -> the 13-base tail is clipped.
+        let p = hamming_3p(b"AGATCGGAAGAGC", 0.1);
+        let (c5, c3) = clip_mate(b"CCCCGGGGAGATCGGAAGAGC", &p);
+        assert_eq!((c5, c3), (0, 13));
+    }
+
+    #[test]
+    fn adapter_3p_mmp_rejects_when_strict() {
+        // One mismatch in a 13-base adapter: allowed at 0.1 (1/12<=0.1), rejected at 0.0.
+        let read = b"CCCCGGGGAGATCGGAtGAGC"; // 't' lowercase -> code T, a mismatch vs adapter G
+        let read = &read.to_ascii_uppercase();
+        let (_, c3_loose) = clip_mate(read, &hamming_3p(b"AGATCGGAAGAGC", 0.1));
+        assert_eq!(c3_loose, 13);
+        let (_, c3_strict) = clip_mate(read, &hamming_3p(b"AGATCGGAAGAGC", 0.0));
+        assert_eq!(c3_strict, 0);
+    }
+
+    #[test]
+    fn after_adapter_alone_is_noop() {
+        // STAR's inactive-end short-circuit: n_after with no fixed clip and no adapter clips nothing.
+        let p = ClipParams {
+            five: ClipEnd {
+                n_after: 4,
+                ..Default::default()
+            },
+            three: ClipEnd {
+                n_after: 4,
+                ..Default::default()
+            },
+        };
+        assert_eq!(clip_mate(b"ACGTACGTACGTACGTACGT", &p), (0, 0));
+    }
+
+    #[test]
+    fn after_adapter_nbases_3p() {
+        let mut p = hamming_3p(b"AGATCGGAAGAGC", 0.1);
+        p.three.n_after = 3;
+        let (_, c3) = clip_mate(b"CCCCGGGGAGATCGGAAGAGC", &p);
+        assert_eq!(c3, 16); // 13 adapter + 3 after
+    }
+
+    #[test]
+    fn no_adapter_configured_only_fixed_clips() {
+        let p = ClipParams {
+            five: ClipEnd {
+                n: 2,
+                ..Default::default()
+            },
+            three: ClipEnd {
+                n: 1,
+                ..Default::default()
+            },
+        };
+        assert_eq!(clip_mate(b"AAACCCGGGTT", &p), (2, 1));
+    }
+}

--- a/src/clip/mod.rs
+++ b/src/clip/mod.rs
@@ -5,11 +5,13 @@
 //! (`--clip3pAdapterSeq`/`--clip3pAdapterMMp`) and the after-adapter trim
 //! (`--clip{5,3}pAfterAdapterNbases`).
 //!
-//! STAR removes the clipped bases from the read before mapping (the mapped read
-//! is the clipped one); this module reproduces the clip amounts. rustar-aligner
-//! feeds the clipped read straight to the aligner and to SAM output (matching its
-//! existing `--clip5pNbases`/`--clip3pNbases` convention), so clipped bases are
-//! dropped rather than reinserted as soft-clips.
+//! STAR maps the *clipped* read (the clipped bases don't participate in alignment)
+//! but keeps them in the SAM record as **soft-clips**: the output SEQ is the full
+//! original read and the CIGAR gains leading/trailing `S` ops for the clipped ends.
+//! rustar-aligner matches this — it aligns the clipped read, then `io::sam`'s
+//! `apply_read_clips` restores the full read and wraps the CIGAR with soft-clips
+//! (strand-aware: a read-3' clip is a leading `S` on a reverse-strand record).
+//! Unmapped reads keep the full read too (CIGAR `*`, no soft-clip).
 //!
 //! STAR clips a mate as two passes in order: 5' first (`clip5pNbases`, then
 //! `clip5pAfterAdapterNbases`), then 3' on the 5'-clipped read (`clip3pNbases`,
@@ -23,13 +25,15 @@ use crate::io::fastq::encode_base;
 use crate::params::Parameters;
 
 /// One end's clipping parameters (STAR `ClipMate`). `n` = fixed clip, `adapter` =
-/// the adapter sequence (ASCII; empty = none), `ad_mmp` = max mismatch fraction,
-/// `n_after` = extra clip after the adapter.
+/// the adapter sequence (base codes A=0..T=3; empty = none), `ad_mmp` = max
+/// mismatch fraction, `n_after` = extra clip after the adapter.
 #[derive(Debug, Clone, Default)]
 pub struct ClipEnd {
     /// `--clip{5,3}pNbases` for this end.
     pub n: usize,
-    /// `--clip3pAdapterSeq` (ASCII), empty when none. Only meaningful for the 3' end.
+    /// `--clip3pAdapterSeq` as base codes (A=0..T=3), empty when none. Only
+    /// meaningful for the 3' end. Encoded once in [`clip_params_from`] so the
+    /// scan matches the already-numeric read without re-encoding.
     pub adapter: Vec<u8>,
     /// `--clip3pAdapterMMp` (default 0.1).
     pub ad_mmp: f64,
@@ -46,24 +50,30 @@ pub struct ClipParams {
     pub three: ClipEnd,
 }
 
-/// Build [`ClipParams`] from the run's `--clip{5,3}pNbases` / `--clip3pAdapterSeq`
-/// / `--clip3pAdapterMMp` / `--clip{5,3}pAfterAdapterNbases`. `-` (STAR's sentinel)
-/// means no adapter. Built once per run and reused for every read.
-pub fn clip_params_from(params: &Parameters) -> ClipParams {
+/// Build [`ClipParams`] for `mate` (0 or 1) from the run's `--clip{5,3}pNbases`
+/// / `--clip3pAdapterSeq` / `--clip3pAdapterMMp` / `--clip{5,3}pAfterAdapterNbases`.
+/// `-` (STAR's sentinel) means no adapter. The fixed `--clip{5,3}pNbases` are
+/// per-mate (`clip5p(mate)`/`clip3p(mate)`); the adapter / mmp / after-adapter
+/// clips are single-valued and apply to both mates. Cheap to build per batch.
+pub fn clip_params_from(params: &Parameters, mate: usize) -> ClipParams {
+    // Encode the adapter to base codes (A=0..T=3) ONCE here. The read reaching
+    // clip_mate is already numeric (io::fastq encodes at read time), so the 3'
+    // Hamming scan compares numeric-vs-numeric — re-encoding the read there turned
+    // every base into N (code 4) and silently disabled all adapter clipping.
     let adapter = if params.clip3p_adapter_seq == "-" {
         Vec::new()
     } else {
-        params.clip3p_adapter_seq.as_bytes().to_vec()
+        params.clip3p_adapter_seq.bytes().map(encode_base).collect()
     };
     ClipParams {
         five: ClipEnd {
-            n: params.clip5p_nbases as usize,
+            n: params.clip5p(mate),
             adapter: Vec::new(),
             ad_mmp: 0.0,
             n_after: params.clip5p_after_adapter_nbases as usize,
         },
         three: ClipEnd {
-            n: params.clip3p_nbases as usize,
+            n: params.clip3p(mate),
             adapter,
             ad_mmp: params.clip3p_adapter_mmp,
             n_after: params.clip3p_after_adapter_nbases as usize,
@@ -128,11 +138,12 @@ pub fn clip_mate(read: &[u8], p: &ClipParams) -> (usize, usize) {
     if three_active {
         c3 = p.three.n.min(sl);
         if !p.three.adapter.is_empty() {
-            // Hamming 3' adapter scan on the read after the fixed 3' clip.
-            let x_num: Vec<u8> = s[..sl - c3].iter().map(|&b| encode_base(b)).collect();
-            let y_num: Vec<u8> = p.three.adapter.iter().map(|&b| encode_base(b)).collect();
+            // Hamming 3' adapter scan on the (already-numeric) read after the fixed
+            // 3' clip. Both `x` and the adapter are base codes; local_search skips
+            // N (code > 3) internally.
+            let x_num = &s[..sl - c3];
             let nx = x_num.len();
-            let ix_best = local_search(&x_num, &y_num, p.three.ad_mmp);
+            let ix_best = local_search(x_num, &p.three.adapter, p.three.ad_mmp);
             c3 += nx - ix_best;
         }
         if p.three.n_after > 0 {
@@ -148,10 +159,20 @@ pub fn clip_mate(read: &[u8], p: &ClipParams) -> (usize, usize) {
 mod tests {
     use super::*;
 
+    /// Encode an ASCII sequence to base codes (A=0..T=3), matching how `io::fastq`
+    /// stores reads. `clip_mate` receives numeric reads in production, so every
+    /// test feeds numeric input — passing raw ASCII would exercise a path the real
+    /// pipeline never hits (and previously masked the double-encode dead-code bug).
+    fn enc(ascii: &[u8]) -> Vec<u8> {
+        ascii.iter().map(|&b| encode_base(b)).collect()
+    }
+
+    /// 3'-adapter-only params; the adapter is stored as base codes exactly as
+    /// [`clip_params_from`] produces it.
     fn hamming_3p(adapter: &[u8], mmp: f64) -> ClipParams {
         ClipParams {
             three: ClipEnd {
-                adapter: adapter.to_vec(),
+                adapter: enc(adapter),
                 ad_mmp: mmp,
                 ..Default::default()
             },
@@ -171,25 +192,24 @@ mod tests {
                 ..Default::default()
             },
         };
-        assert_eq!(clip_mate(b"AAACCCGGGTT", &p), (3, 2));
+        assert_eq!(clip_mate(&enc(b"AAACCCGGGTT"), &p), (3, 2));
     }
 
     #[test]
     fn adapter_3p_hamming() {
         // Adapter "AGATCGGAAGAGC"; read = insert + adapter tail -> the 13-base tail is clipped.
         let p = hamming_3p(b"AGATCGGAAGAGC", 0.1);
-        let (c5, c3) = clip_mate(b"CCCCGGGGAGATCGGAAGAGC", &p);
+        let (c5, c3) = clip_mate(&enc(b"CCCCGGGGAGATCGGAAGAGC"), &p);
         assert_eq!((c5, c3), (0, 13));
     }
 
     #[test]
     fn adapter_3p_mmp_rejects_when_strict() {
         // One mismatch in a 13-base adapter: allowed at 0.1 (1/12<=0.1), rejected at 0.0.
-        let read = b"CCCCGGGGAGATCGGAtGAGC"; // 't' lowercase -> code T, a mismatch vs adapter G
-        let read = &read.to_ascii_uppercase();
-        let (_, c3_loose) = clip_mate(read, &hamming_3p(b"AGATCGGAAGAGC", 0.1));
+        let read = enc(b"CCCCGGGGAGATCGGATGAGC"); // 'T' at pos 16 -> mismatch vs adapter 'G'
+        let (_, c3_loose) = clip_mate(&read, &hamming_3p(b"AGATCGGAAGAGC", 0.1));
         assert_eq!(c3_loose, 13);
-        let (_, c3_strict) = clip_mate(read, &hamming_3p(b"AGATCGGAAGAGC", 0.0));
+        let (_, c3_strict) = clip_mate(&read, &hamming_3p(b"AGATCGGAAGAGC", 0.0));
         assert_eq!(c3_strict, 0);
     }
 
@@ -206,14 +226,14 @@ mod tests {
                 ..Default::default()
             },
         };
-        assert_eq!(clip_mate(b"ACGTACGTACGTACGTACGT", &p), (0, 0));
+        assert_eq!(clip_mate(&enc(b"ACGTACGTACGTACGTACGT"), &p), (0, 0));
     }
 
     #[test]
     fn after_adapter_nbases_3p() {
         let mut p = hamming_3p(b"AGATCGGAAGAGC", 0.1);
         p.three.n_after = 3;
-        let (_, c3) = clip_mate(b"CCCCGGGGAGATCGGAAGAGC", &p);
+        let (_, c3) = clip_mate(&enc(b"CCCCGGGGAGATCGGAAGAGC"), &p);
         assert_eq!(c3, 16); // 13 adapter + 3 after
     }
 
@@ -229,6 +249,19 @@ mod tests {
                 ..Default::default()
             },
         };
-        assert_eq!(clip_mate(b"AAACCCGGGTT", &p), (2, 1));
+        assert_eq!(clip_mate(&enc(b"AAACCCGGGTT"), &p), (2, 1));
+    }
+
+    /// Regression guard for the double-encode dead-code bug: a numeric read (as the
+    /// pipeline delivers) whose 3' tail is the adapter MUST clip. Before the fix,
+    /// clip_mate re-encoded the numeric read to all-N and never clipped.
+    #[test]
+    fn numeric_read_adapter_actually_clips() {
+        let p = hamming_3p(b"AGATCGGAAGAGC", 0.1);
+        // 8-base insert + 13-base adapter, delivered as base codes.
+        let read = enc(b"CCCCGGGGAGATCGGAAGAGC");
+        assert!(read.iter().all(|&b| b <= 3), "test read must be numeric");
+        let (_, c3) = clip_mate(&read, &p);
+        assert_eq!(c3, 13, "adapter tail must be clipped on a numeric read");
     }
 }

--- a/src/io/bam.rs
+++ b/src/io/bam.rs
@@ -562,6 +562,8 @@ mod tests {
             read_name,
             &read_seq,
             &read_qual,
+            0,
+            0,
             &[transcript],
             &genome,
             &params,

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -243,10 +243,13 @@ impl SamWriter {
     /// * `transcripts` - Alignment transcripts (1 or more for multi-mappers)
     /// * `genome` - Genome index
     /// * `params` - Parameters
+    #[allow(clippy::too_many_arguments)]
     pub fn build_alignment_records(
         read_name: &str,
         read_seq: &[u8],
         read_qual: &[u8],
+        clip5p: usize,
+        clip3p: usize,
         transcripts: &[Transcript],
         genome: &Genome,
         params: &Parameters,
@@ -255,6 +258,12 @@ impl SamWriter {
         if transcripts.is_empty() {
             return Ok(Vec::new());
         }
+
+        // The transcripts were aligned against the clipped read; the core record
+        // (CIGAR core, MD, NM) is built from that aligned slice, then apply_read_clips
+        // restores the full read + soft-clips. clip5p/clip3p == 0 => aligned == full.
+        let aligned_seq = &read_seq[clip5p..read_seq.len() - clip3p];
+        let aligned_qual = &read_qual[clip5p..read_qual.len() - clip3p];
 
         let n_alignments = transcripts.len();
         let max_output = if params.out_sam_mult_nmax < 0 {
@@ -278,8 +287,8 @@ impl SamWriter {
             let mut record = transcript_to_record(
                 transcript,
                 read_name,
-                read_seq,
-                read_qual,
+                aligned_seq,
+                aligned_qual,
                 genome,
                 mapq,
                 max_output,    // NH = number of reported alignments
@@ -287,6 +296,17 @@ impl SamWriter {
                 params.out_sam_attr_ih_start,
                 attrs,
             )?;
+            if clip5p > 0 || clip3p > 0 {
+                apply_read_clips(
+                    &mut record,
+                    &transcript.cigar,
+                    read_seq,
+                    read_qual,
+                    clip5p,
+                    clip3p,
+                    transcript.is_reverse,
+                );
+            }
             maybe_insert_rg_tag(&mut record, rg_id);
             apply_sam_flag_or_and(&mut record, params);
             apply_primary_flag(&mut record, transcript.score, best_score, params);
@@ -310,12 +330,17 @@ impl SamWriter {
     /// * `genome` - Genome index
     /// * `params` - Parameters
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn build_paired_records(
         read_name: &str,
         mate1_seq: &[u8],
         mate1_qual: &[u8],
         mate2_seq: &[u8],
         mate2_qual: &[u8],
+        m1_clip5p: usize,
+        m1_clip3p: usize,
+        m2_clip5p: usize,
+        m2_clip3p: usize,
         paired_alignments: &[PairedAlignment],
         genome: &Genome,
         params: &Parameters,
@@ -364,6 +389,8 @@ impl SamWriter {
                 read_name,
                 mate1_seq,
                 mate1_qual,
+                m1_clip5p,
+                m1_clip3p,
                 &paired_aln.mate1_transcript,
                 &paired_aln.mate2_transcript,
                 genome,
@@ -393,6 +420,8 @@ impl SamWriter {
                 read_name,
                 mate2_seq,
                 mate2_qual,
+                m2_clip5p,
+                m2_clip3p,
                 &paired_aln.mate2_transcript,
                 &paired_aln.mate1_transcript,
                 genome,
@@ -1032,6 +1061,68 @@ fn fastq_qual_to_phred(qual: &[u8]) -> Vec<u8> {
     qual.iter().map(|&b| b.saturating_sub(33)).collect()
 }
 
+/// Re-attach clipped bases to a mapped record as soft-clips, matching STAR (and
+/// STAR-rs): the record is first built from the *clipped* read (so CIGAR core, MD
+/// and NM cover only the aligned bases), then this restores the full original read
+/// as SEQ/QUAL and wraps the CIGAR with soft-clips for the clipped ends.
+///
+/// `clip5p`/`clip3p` are in read 5'/3' coordinates. In SAM (genome-forward)
+/// orientation the read-5' clip is the leading soft-clip and the read-3' clip the
+/// trailing one; on a reverse-strand record the two swap. A clip adjacent to an
+/// existing (genomic) soft-clip is merged into a single `S` op (valid SAM). POS is
+/// unaffected — soft-clips consume read bases but no reference.
+fn apply_read_clips(
+    record: &mut RecordBuf,
+    core_cigar: &[cigar::Op],
+    orig_seq: &[u8],
+    orig_qual: &[u8],
+    clip5p: usize,
+    clip3p: usize,
+    is_reverse: bool,
+) {
+    use cigar::op::Kind;
+    // Full original read as SEQ/QUAL (strand-aware), replacing the clipped SEQ.
+    if is_reverse {
+        let seq: Vec<u8> = orig_seq
+            .iter()
+            .rev()
+            .map(|&b| decode_base(complement_base(b)))
+            .collect();
+        *record.sequence_mut() = Sequence::from(seq);
+        let mut q = fastq_qual_to_phred(orig_qual);
+        q.reverse();
+        *record.quality_scores_mut() = QualityScores::from(q);
+    } else {
+        let seq: Vec<u8> = orig_seq.iter().map(|&b| decode_base(b)).collect();
+        *record.sequence_mut() = Sequence::from(seq);
+        *record.quality_scores_mut() = QualityScores::from(fastq_qual_to_phred(orig_qual));
+    }
+    // Wrap the core CIGAR with soft-clips (merging into an adjacent S if present).
+    let (lead, trail) = if is_reverse {
+        (clip3p, clip5p)
+    } else {
+        (clip5p, clip3p)
+    };
+    let mut ops: Vec<cigar::Op> = Vec::with_capacity(core_cigar.len() + 2);
+    ops.extend_from_slice(core_cigar);
+    if lead > 0 {
+        if ops.first().map(|o| o.kind()) == Some(Kind::SoftClip) {
+            ops[0] = cigar::Op::new(Kind::SoftClip, ops[0].len() + lead);
+        } else {
+            ops.insert(0, cigar::Op::new(Kind::SoftClip, lead));
+        }
+    }
+    if trail > 0 {
+        let li = ops.len() - 1;
+        if ops[li].kind() == Kind::SoftClip {
+            ops[li] = cigar::Op::new(Kind::SoftClip, ops[li].len() + trail);
+        } else {
+            ops.push(cigar::Op::new(Kind::SoftClip, trail));
+        }
+    }
+    *record.cigar_mut() = ops.into_iter().collect();
+}
+
 /// Convert Transcript to SAM record
 #[allow(clippy::too_many_arguments)]
 fn transcript_to_record(
@@ -1359,6 +1450,8 @@ fn build_paired_mate_record(
     read_name: &str,
     mate_seq: &[u8],
     mate_qual: &[u8],
+    clip5p: usize,
+    clip3p: usize,
     transcript: &Transcript,
     mate_transcript: &Transcript,
     genome: &Genome,
@@ -1445,22 +1538,27 @@ fn build_paired_mate_record(
     // TLEN (insert size)
     *record.template_length_mut() = insert_size;
 
+    // Core SEQ/QUAL/MD are built from the aligned (clipped) slice; apply_read_clips
+    // below restores the full mate read + soft-clips (clip==0 => aligned == mate_seq).
+    let aligned_seq = &mate_seq[clip5p..mate_seq.len() - clip3p];
+    let aligned_qual = &mate_qual[clip5p..mate_qual.len() - clip3p];
+
     // Sequence and quality scores (reverse complement for reverse strand)
     if transcript.is_reverse {
-        let seq_bytes: Vec<u8> = mate_seq
+        let seq_bytes: Vec<u8> = aligned_seq
             .iter()
             .rev()
             .map(|&b| decode_base(complement_base(b)))
             .collect();
         *record.sequence_mut() = Sequence::from(seq_bytes);
 
-        let mut qual = fastq_qual_to_phred(mate_qual);
+        let mut qual = fastq_qual_to_phred(aligned_qual);
         qual.reverse();
         *record.quality_scores_mut() = QualityScores::from(qual);
     } else {
-        let seq_bytes: Vec<u8> = mate_seq.iter().map(|&b| decode_base(b)).collect();
+        let seq_bytes: Vec<u8> = aligned_seq.iter().map(|&b| decode_base(b)).collect();
         *record.sequence_mut() = Sequence::from(seq_bytes);
-        *record.quality_scores_mut() = QualityScores::from(fastq_qual_to_phred(mate_qual));
+        *record.quality_scores_mut() = QualityScores::from(fastq_qual_to_phred(aligned_qual));
     }
 
     // Optional tags: gated by --outSAMattributes
@@ -1504,8 +1602,20 @@ fn build_paired_mate_record(
         data.insert(Tag::new(b'j', b'I'), ji);
     }
     if attrs.contains(SamAttributes::MD) {
-        let md = build_md_tag(transcript, mate_seq, genome, transcript.is_reverse);
+        let md = build_md_tag(transcript, aligned_seq, genome, transcript.is_reverse);
         data.insert(Tag::new(b'M', b'D'), Value::String(BString::from(md)));
+    }
+
+    if clip5p > 0 || clip3p > 0 {
+        apply_read_clips(
+            &mut record,
+            &transcript.cigar,
+            mate_seq,
+            mate_qual,
+            clip5p,
+            clip3p,
+            transcript.is_reverse,
+        );
     }
 
     Ok(record)
@@ -2067,6 +2177,8 @@ mod tests {
             "read1",
             &mate_seq,
             &mate_qual,
+            0,
+            0,
             &mate1_transcript,
             &mate2_transcript,
             &genome,
@@ -2096,6 +2208,8 @@ mod tests {
             "read1",
             &mate_seq,
             &mate_qual,
+            0,
+            0,
             &mate2_transcript,
             &mate1_transcript,
             &genome,
@@ -2181,6 +2295,8 @@ mod tests {
             "read1",
             &mate_seq,
             &mate_qual,
+            0,
+            0,
             &this_transcript,
             &mate_transcript,
             &genome,
@@ -2598,6 +2714,8 @@ mod tests {
             "read1",
             &read_seq,
             &read_qual,
+            0,
+            0,
             &transcripts,
             &genome,
             &params,
@@ -2654,6 +2772,8 @@ mod tests {
             "read1",
             &read_seq,
             &read_qual,
+            0,
+            0,
             std::slice::from_ref(&transcript),
             &genome,
             &params,
@@ -2705,6 +2825,8 @@ mod tests {
             "read1",
             &read_seq,
             &read_qual,
+            0,
+            0,
             &transcripts,
             &genome,
             &params,
@@ -2776,6 +2898,8 @@ mod tests {
             "read1",
             &read_seq,
             &read_qual,
+            0,
+            0,
             &transcripts,
             &genome,
             &params,
@@ -3136,6 +3260,8 @@ mod tests {
             "read1",
             &read_seq,
             &read_qual,
+            0,
+            0,
             &transcripts,
             &genome,
             &params,
@@ -3598,6 +3724,8 @@ mod tests {
             "read1",
             &seq,
             &qual,
+            0,
+            0,
             &mate1_trans,
             &mate2_trans,
             &genome,
@@ -3622,6 +3750,8 @@ mod tests {
             "read1",
             &seq,
             &qual,
+            0,
+            0,
             &mate2_trans,
             &mate1_trans,
             &genome,
@@ -3709,6 +3839,8 @@ mod tests {
             "read1",
             &seq1,
             &qual1,
+            0,
+            0,
             &mate1_trans,
             &mate2_trans,
             &genome,
@@ -3740,6 +3872,8 @@ mod tests {
             "read1",
             &seq2,
             &qual2,
+            0,
+            0,
             &mate2_trans,
             &mate1_trans,
             &genome,
@@ -3827,6 +3961,8 @@ mod tests {
             "read1",
             &seq,
             &qual,
+            0,
+            0,
             &mate1_trans,
             &mate2_trans,
             &genome,
@@ -3848,6 +3984,8 @@ mod tests {
             "read1",
             &seq,
             &qual,
+            0,
+            0,
             &mate2_trans,
             &mate1_trans,
             &genome,
@@ -4558,6 +4696,8 @@ mod tests {
             "read1",
             &read_seq,
             &read_qual,
+            0,
+            0,
             &transcripts,
             &genome,
             &params,
@@ -4597,6 +4737,8 @@ mod tests {
             "read1",
             &read_seq,
             &read_qual,
+            0,
+            0,
             &transcripts,
             &genome,
             &params,
@@ -4625,6 +4767,8 @@ mod tests {
             "read1",
             &read_seq,
             &read_qual,
+            0,
+            0,
             &transcripts,
             &genome,
             &params,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod params;
 pub mod align;
 pub mod bam_dedup;
 pub mod chimeric;
+pub mod clip;
 pub mod cpu;
 pub mod genome;
 pub mod index;
@@ -35,6 +36,7 @@ pub mod junction;
 pub mod liftover;
 pub mod mapq;
 pub mod quant;
+pub mod signal;
 pub mod solo;
 pub mod stats;
 
@@ -976,6 +978,12 @@ struct AlignmentBatchResults {
     unmapped_mate1: Vec<(String, Vec<u8>, Vec<u8>)>,
     /// Unmapped mate2 reads (PE only). Empty unless outReadsUnmapped=Fastx.
     unmapped_mate2: Vec<(String, Vec<u8>, Vec<u8>)>,
+    /// `--outWigType bedGraph` signal contributions: (transcript, is_second_mate)
+    /// per reported alignment. Empty unless enabled and the read/pair mapped within
+    /// the multimap limit. `signal_n_tr` is the shared NH for all of them
+    /// (transcripts.len() for SE, both_mapped.len() for PE).
+    signal_contrib: Vec<(crate::align::transcript::Transcript, bool)>,
+    signal_n_tr: usize,
 }
 
 /// One `Result` per read/pair in an aligned batch.
@@ -1293,6 +1301,47 @@ fn extract_junction_keys(
     keys
 }
 
+/// Write the four `--outWigType bedGraph` stranded tracks (STAR's `Signal.{Unique,
+/// UniqueMultiple}.str{1,2}.out.bg`). No-op if `signal` is `None` (feature disabled).
+/// RPM scales the `Unique` tracks by `1e6/nUniq` and `UniqueMultiple` by
+/// `1e6/(nUniq+nMult)` (STAR `signalFromBAM` `normFactor[0]` vs `[1]`); one norm
+/// for both would double `UniqueMultiple` when multimappers exist.
+fn write_signal_tracks(
+    signal: Option<&crate::signal::Signal>,
+    sig_n_uniq: u64,
+    sig_n_mult: u64,
+    params: &Parameters,
+) -> anyhow::Result<()> {
+    let Some(sig) = signal else {
+        return Ok(());
+    };
+    let norm_unique = if sig_n_uniq > 0 {
+        1.0e6 / sig_n_uniq as f64
+    } else {
+        0.0
+    };
+    let norm_mult = if sig_n_uniq + sig_n_mult > 0 {
+        1.0e6 / (sig_n_uniq + sig_n_mult) as f64
+    } else {
+        0.0
+    };
+    for (unique, strand, file) in [
+        (true, 0, "Signal.Unique.str1.out.bg"),
+        (false, 0, "Signal.UniqueMultiple.str1.out.bg"),
+        (true, 1, "Signal.Unique.str2.out.bg"),
+        (false, 1, "Signal.UniqueMultiple.str2.out.bg"),
+    ] {
+        let body = if params.out_wig_rpm() {
+            let norm = if unique { norm_unique } else { norm_mult };
+            sig.bedgraph_rpm(unique, strand, norm)
+        } else {
+            sig.bedgraph(unique, strand)
+        };
+        std::fs::write(params.output_path(file), body)?;
+    }
+    Ok(())
+}
+
 /// Align single-end reads
 #[allow(clippy::too_many_arguments)]
 fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
@@ -1342,8 +1391,6 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
     };
 
     let batch_size = 10000;
-    let clip5p = params.clip5p(0);
-    let clip3p = params.clip3p(0);
     let max_multimaps = params.out_filter_multimap_nmax as usize;
     // `--outSAMtype None` (e.g. quant-only) skips building SAM records.
     let emit_sam = params.emits_alignments();
@@ -1423,10 +1470,35 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
             let mut chimeric_writer = chimeric_writer;
             let mut bysj_temp_writer = bysj_temp_writer;
             let mut bysj_meta = bysj_meta;
+            // --outWigType bedGraph: the coverage signal + RPM counters are folded
+            // here (sequential, in chunk order) — the Vec<f64> accumulator isn't safe
+            // to update from the parallel per-read closures. SE: 1 record/read.
+            let mut signal = params.out_wig_bedgraph().then(|| {
+                crate::signal::Signal::new(&index.genome.chr_name, &index.genome.chr_length)
+            });
+            let (mut sig_n_uniq, mut sig_n_mult) = (0u64, 0u64);
             for batch_results in &res_rx {
                 if by_sjout {
                     for result in batch_results {
                         let batch = result?;
+                        // --outWigType bedGraph: fold this read's contribution.
+                        if let Some(sig) = signal.as_mut()
+                            && !batch.signal_contrib.is_empty()
+                        {
+                            if batch.signal_n_tr == 1 {
+                                sig_n_uniq += 1;
+                            } else {
+                                sig_n_mult += 1;
+                            }
+                            for (tr, second_mate) in &batch.signal_contrib {
+                                sig.add_transcript(
+                                    &index.genome,
+                                    tr,
+                                    batch.signal_n_tr,
+                                    *second_mate,
+                                );
+                            }
+                        }
                         // Write SAM records to temp file (disk, not RAM)
                         let n_sam_records = batch.sam_records.records.len() as u32;
                         if let (Some(tw), Some(hdr)) = (&mut bysj_temp_writer, &bysj_sam_header) {
@@ -1454,6 +1526,25 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                     // Normal mode: sequential writing (merge buffers in chunk order)
                     for result in batch_results {
                         let batch = result?;
+
+                        // --outWigType bedGraph: fold this read's contribution.
+                        if let Some(sig) = signal.as_mut()
+                            && !batch.signal_contrib.is_empty()
+                        {
+                            if batch.signal_n_tr == 1 {
+                                sig_n_uniq += 1;
+                            } else {
+                                sig_n_mult += 1;
+                            }
+                            for (tr, second_mate) in &batch.signal_contrib {
+                                sig.add_transcript(
+                                    &index.genome,
+                                    tr,
+                                    batch.signal_n_tr,
+                                    *second_mate,
+                                );
+                            }
+                        }
 
                         // Write SAM/BAM records
                         writer.write_batch(&batch.sam_records.records)?;
@@ -1564,6 +1655,9 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                 info!("BySJout: filtered {filtered_count} reads with non-surviving junctions");
             }
 
+            // --outWigType bedGraph: write the four Signal.*.out.bg tracks.
+            write_signal_tracks(signal.as_ref(), sig_n_uniq, sig_n_mult, params)?;
+
             // Flush chimeric output if enabled
             if let Some(ref mut chim_writer) = chimeric_writer {
                 // --chimOutJunctionFormat 1: STAR-Fusion comment trailer with read counts
@@ -1600,6 +1694,9 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                               batch: Vec<crate::io::fastq::EncodedRead>|
                   -> BatchOut<AlignmentBatchResults> {
                 let params: &Parameters = &params_arc;
+                // Adapter-aware clip params (fixed 5'/3' Nbases + 3' adapter Hamming
+                // scan); built once per batch, applied per read via clip_mate.
+                let clip_params = crate::clip::clip_params_from(params, 0);
                 batch
                     .par_iter()
                     .enumerate()
@@ -1622,7 +1719,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                         let sj_stats = Arc::clone(&sj_stats);
                         let quant = quant.as_ref().map(Arc::clone);
 
-                        // Apply clipping
+                        // Apply clipping: fixed Nbases + 3' adapter (clip_mate), then trim.
+                        let (clip5p, clip3p) = crate::clip::clip_mate(&read.sequence, &clip_params);
                         let (clipped_seq, clipped_qual) =
                             clip_read(&read.sequence, &read.quality, clip5p, clip3p);
 
@@ -1641,10 +1739,12 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                                 q.counts.count_se_read(&[], 0, &q.gene_ann);
                             }
                             if output_unmapped {
+                                // Unmapped reads keep the full original read (STAR: clipped
+                                // bases are never removed from an unmapped record's SEQ).
                                 let record = SamWriter::build_unmapped_record(
                                     &out_read_name,
-                                    &clipped_seq,
-                                    &clipped_qual,
+                                    &read.sequence,
+                                    &read.quality,
                                     params,
                                     crate::stats::UnmappedReason::Other,
                                 )?;
@@ -1653,8 +1753,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                             let unmapped_m1 = if write_unmapped_fastq {
                                 vec![(
                                     out_read_name.clone(),
-                                    clipped_seq.clone(),
-                                    clipped_qual.clone(),
+                                    read.sequence.clone(),
+                                    read.quality.clone(),
                                 )]
                             } else {
                                 Vec::new()
@@ -1666,6 +1766,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                                 transcriptome_records: Vec::new(),
                                 unmapped_mate1: unmapped_m1,
                                 unmapped_mate2: Vec::new(),
+                                signal_contrib: Vec::new(),
+                                signal_n_tr: 0,
                             });
                         }
 
@@ -1717,6 +1819,20 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                                 Vec::new()
                             };
 
+                        // --outWigType bedGraph: this read's coverage contribution is
+                        // its reported alignments (same set written to SAM: mapped and
+                        // within the multimap limit). signal_n_tr is the shared NH.
+                        let signal_n_tr = transcripts.len();
+                        let signal_contrib: Vec<(crate::align::transcript::Transcript, bool)> =
+                            if params.out_wig_bedgraph()
+                                && !transcripts.is_empty()
+                                && transcripts.len() <= max_multimaps
+                            {
+                                transcripts.iter().cloned().map(|t| (t, false)).collect()
+                            } else {
+                                Vec::new()
+                            };
+
                         // Build SAM records (no I/O, just construction).
                         // Skipped entirely under `--outSAMtype None`.
                         let is_unmapped_se = transcripts.is_empty();
@@ -1724,10 +1840,11 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                             if is_unmapped_se {
                                 // Unmapped
                                 if output_unmapped {
+                                    // Full original read for unmapped (STAR convention).
                                     let record = SamWriter::build_unmapped_record(
                                         &out_read_name,
-                                        &clipped_seq,
-                                        &clipped_qual,
+                                        &read.sequence,
+                                        &read.quality,
                                         params,
                                         unmapped_reason
                                             .unwrap_or(crate::stats::UnmappedReason::Other),
@@ -1738,8 +1855,10 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                                 // Mapped (within multimap limit)
                                 let records = SamWriter::build_alignment_records(
                                     &out_read_name,
-                                    &clipped_seq,
-                                    &clipped_qual,
+                                    &read.sequence,
+                                    &read.quality,
+                                    clip5p,
+                                    clip3p,
                                     &transcripts,
                                     &index.genome,
                                     params,
@@ -1773,8 +1892,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                         let unmapped_m1 = if write_unmapped_fastq && is_unmapped_se {
                             vec![(
                                 out_read_name.clone(),
-                                clipped_seq.clone(),
-                                clipped_qual.clone(),
+                                read.sequence.clone(),
+                                read.quality.clone(),
                             )]
                         } else {
                             Vec::new()
@@ -1787,6 +1906,8 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                             transcriptome_records,
                             unmapped_mate1: unmapped_m1,
                             unmapped_mate2: Vec::new(),
+                            signal_contrib,
+                            signal_n_tr,
                         })
                     })
                     .collect()
@@ -2069,10 +2190,15 @@ fn align_reads_solo<W: AlignmentWriter + ?Sized>(
                                         buffer.push(record);
                                     }
                                 } else if transcripts.len() <= max_multimaps {
+                                    // Solo: preserve current (drop) behavior — pass the
+                                    // already-clipped read with 0/0, so nothing is
+                                    // re-attached (the batch-1 STARsolo validation holds).
                                     let mut records = SamWriter::build_alignment_records(
                                         &out_read_name,
                                         &clipped_seq,
                                         &clipped_qual,
+                                        0,
+                                        0,
                                         &transcripts,
                                         &index.genome,
                                         params,
@@ -2446,12 +2572,18 @@ fn align_reads_solo_pe<W: AlignmentWriter + ?Sized>(
                                     .iter()
                                     .map(|pa| PairedAlignment::clone(pa))
                                     .collect();
+                                // Solo: preserve current (drop) behavior — already-clipped
+                                // mate seqs with 0/0 clips (batch-1 STARsolo validation holds).
                                 let records = SamWriter::build_paired_records(
                                     &out_read_name,
                                     &m1_seq,
                                     &m1_qual,
                                     &m2_seq,
                                     &m2_qual,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
                                     &paired_alns,
                                     &index.genome,
                                     params,
@@ -2547,8 +2679,6 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
     };
 
     let batch_size = 10000;
-    let clip5p = params.clip5p(0);
-    let clip3p = params.clip3p(0);
     let max_multimaps = params.out_filter_multimap_nmax as usize;
     // `--outSAMtype None` (e.g. quant-only) skips building SAM records.
     let emit_sam = params.emits_alignments();
@@ -2625,10 +2755,35 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
             let mut chimeric_writer = chimeric_writer;
             let mut bysj_temp_writer = bysj_temp_writer;
             let mut bysj_meta = bysj_meta;
+            // --outWigType bedGraph: coverage signal + RPM counters, folded here in
+            // chunk order. PE: 2 mate records per pair, so a uniquely-mapped pair adds
+            // 2 to nUniq and a multimapped pair adds 2 to nMult (STAR signalFromBAM
+            // counts BAM records, not pairs — one per reported mate alignment).
+            let mut signal = params.out_wig_bedgraph().then(|| {
+                crate::signal::Signal::new(&index.genome.chr_name, &index.genome.chr_length)
+            });
+            let (mut sig_n_uniq, mut sig_n_mult) = (0u64, 0u64);
             for batch_results in &res_rx {
                 if by_sjout {
                     for result in batch_results {
                         let batch = result?;
+                        if let Some(sig) = signal.as_mut()
+                            && !batch.signal_contrib.is_empty()
+                        {
+                            if batch.signal_n_tr == 1 {
+                                sig_n_uniq += 2;
+                            } else {
+                                sig_n_mult += 2;
+                            }
+                            for (tr, second_mate) in &batch.signal_contrib {
+                                sig.add_transcript(
+                                    &index.genome,
+                                    tr,
+                                    batch.signal_n_tr,
+                                    *second_mate,
+                                );
+                            }
+                        }
                         let n_sam_records = batch.sam_records.records.len() as u32;
                         if let (Some(tw), Some(hdr)) = (&mut bysj_temp_writer, &bysj_sam_header) {
                             crate::io::sam::bysj_write_records(
@@ -2659,6 +2814,23 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                     // Normal mode: sequential SAM writing
                     for result in batch_results {
                         let batch = result?;
+                        if let Some(sig) = signal.as_mut()
+                            && !batch.signal_contrib.is_empty()
+                        {
+                            if batch.signal_n_tr == 1 {
+                                sig_n_uniq += 2;
+                            } else {
+                                sig_n_mult += 2;
+                            }
+                            for (tr, second_mate) in &batch.signal_contrib {
+                                sig.add_transcript(
+                                    &index.genome,
+                                    tr,
+                                    batch.signal_n_tr,
+                                    *second_mate,
+                                );
+                            }
+                        }
                         writer.write_batch(&batch.sam_records.records)?;
                         if let Some(ref mut tw) = tr_writer {
                             tw.write_batch(&batch.transcriptome_records)?;
@@ -2747,6 +2919,9 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                 info!("BySJout: filtered {filtered_count} pairs with non-surviving junctions");
             }
 
+            // --outWigType bedGraph: write the four Signal.*.out.bg tracks.
+            write_signal_tracks(signal.as_ref(), sig_n_uniq, sig_n_mult, params)?;
+
             // Flush chimeric output if enabled
             if let Some(ref mut chim_writer) = chimeric_writer {
                 // --chimOutJunctionFormat 1: STAR-Fusion comment trailer with read counts
@@ -2785,6 +2960,10 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                               batch: Vec<crate::io::fastq::PairedRead>|
                   -> BatchOut<AlignmentBatchResults> {
                 let params: &Parameters = &params_arc;
+                // Adapter-aware clip params per mate (fixed Nbases are per-mate; the
+                // adapter is shared). Applied via clip_mate below.
+                let clip_params_m1 = crate::clip::clip_params_from(params, 0);
+                let clip_params_m2 = crate::clip::clip_params_from(params, 1);
                 batch
                     .par_iter()
                     .enumerate()
@@ -2817,18 +2996,23 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                             )
                         };
 
-                        // Apply clipping to both mates
+                        // Apply clipping to both mates: each mate's adapter position is
+                        // scanned independently (fixed Nbases + 3' adapter Hamming), then trim.
+                        let (m1_clip5p, m1_clip3p) =
+                            crate::clip::clip_mate(&paired_read.mate1.sequence, &clip_params_m1);
+                        let (m2_clip5p, m2_clip3p) =
+                            crate::clip::clip_mate(&paired_read.mate2.sequence, &clip_params_m2);
                         let (m1_seq, m1_qual) = clip_read(
                             &paired_read.mate1.sequence,
                             &paired_read.mate1.quality,
-                            clip5p,
-                            clip3p,
+                            m1_clip5p,
+                            m1_clip3p,
                         );
                         let (m2_seq, m2_qual) = clip_read(
                             &paired_read.mate2.sequence,
                             &paired_read.mate2.quality,
-                            clip5p,
-                            clip3p,
+                            m2_clip5p,
+                            m2_clip3p,
                         );
 
                         let mut buffer = BufferedSamRecords::new();
@@ -2845,12 +3029,13 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                                 q.counts.count_pe_read(&[], true, false, &q.gene_ann);
                             }
                             if output_unmapped {
+                                // Full original mates for unmapped pairs (STAR convention).
                                 let records = SamWriter::build_paired_unmapped_records(
                                     &out_read_name,
-                                    &m1_seq,
-                                    &m1_qual,
-                                    &m2_seq,
-                                    &m2_qual,
+                                    &paired_read.mate1.sequence,
+                                    &paired_read.mate1.quality,
+                                    &paired_read.mate2.sequence,
+                                    &paired_read.mate2.quality,
                                     params,
                                     crate::stats::UnmappedReason::Other,
                                 )?;
@@ -2860,8 +3045,16 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                             }
                             let (um1, um2) = if write_unmapped_fastq {
                                 (
-                                    vec![(fastx_name1.clone(), m1_seq.clone(), m1_qual.clone())],
-                                    vec![(fastx_name2.clone(), m2_seq.clone(), m2_qual.clone())],
+                                    vec![(
+                                        fastx_name1.clone(),
+                                        paired_read.mate1.sequence.clone(),
+                                        paired_read.mate1.quality.clone(),
+                                    )],
+                                    vec![(
+                                        fastx_name2.clone(),
+                                        paired_read.mate2.sequence.clone(),
+                                        paired_read.mate2.quality.clone(),
+                                    )],
                                 )
                             } else {
                                 (Vec::new(), Vec::new())
@@ -2873,6 +3066,8 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                                 transcriptome_records: Vec::new(),
                                 unmapped_mate1: um1,
                                 unmapped_mate2: um2,
+                                signal_contrib: Vec::new(),
+                                signal_n_tr: 0,
                             });
                         }
 
@@ -2961,6 +3156,29 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                         }
                         record_read_junctions(read_trs, &index, &sj_stats, is_unique);
 
+                        // --outWigType bedGraph: both-mapped pairs' reported alignments,
+                        // both mates per pair (mate1 sense, mate2 flipped). signal_n_tr is
+                        // the pair NH; each mate record is counted in the writer thread.
+                        let signal_n_tr = both_mapped.len();
+                        let signal_contrib: Vec<(crate::align::transcript::Transcript, bool)> =
+                            if params.out_wig_bedgraph()
+                                && !both_mapped.is_empty()
+                                && both_mapped.len() <= max_multimaps
+                            {
+                                both_mapped
+                                    .iter()
+                                    .flat_map(|pa| {
+                                        let pa = pa.as_ref();
+                                        [
+                                            (pa.mate1_transcript.clone(), false),
+                                            (pa.mate2_transcript.clone(), true),
+                                        ]
+                                    })
+                                    .collect()
+                            } else {
+                                Vec::new()
+                            };
+
                         // Extract junction keys from primary alignment for BySJout
                         let primary_junction_keys = if by_sjout && !results.is_empty() {
                             let mut keys = Vec::new();
@@ -3001,12 +3219,13 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                         } else if results.is_empty() {
                             // Unmapped pair
                             if output_unmapped {
+                                // Full original mates for unmapped pairs (STAR convention).
                                 let records = SamWriter::build_paired_unmapped_records(
                                     &out_read_name,
-                                    &m1_seq,
-                                    &m1_qual,
-                                    &m2_seq,
-                                    &m2_qual,
+                                    &paired_read.mate1.sequence,
+                                    &paired_read.mate1.quality,
+                                    &paired_read.mate2.sequence,
+                                    &paired_read.mate2.quality,
                                     params,
                                     unmapped_reason.unwrap_or(crate::stats::UnmappedReason::Other),
                                 )?;
@@ -3046,10 +3265,14 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                                 .collect();
                             let records = SamWriter::build_paired_records(
                                 &out_read_name,
-                                &m1_seq,
-                                &m1_qual,
-                                &m2_seq,
-                                &m2_qual,
+                                &paired_read.mate1.sequence,
+                                &paired_read.mate1.quality,
+                                &paired_read.mate2.sequence,
+                                &paired_read.mate2.quality,
+                                m1_clip5p,
+                                m1_clip3p,
+                                m2_clip5p,
+                                m2_clip3p,
                                 &paired_alns,
                                 &index.genome,
                                 params,
@@ -3105,6 +3328,8 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                             transcriptome_records,
                             unmapped_mate1,
                             unmapped_mate2,
+                            signal_contrib,
+                            signal_n_tr,
                         })
                     })
                     .collect()

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -487,6 +487,22 @@ pub struct Parameters {
     #[arg(long = "clipAdapterType", default_value = "Hamming")]
     pub clip_adapter_type: String,
 
+    /// 3' adapter sequence to clip (Hamming scan), `-` = none
+    #[arg(long = "clip3pAdapterSeq", default_value = "-")]
+    pub clip3p_adapter_seq: String,
+
+    /// Max mismatch proportion for the 3' adapter clip
+    #[arg(long = "clip3pAdapterMMp", default_value_t = 0.1)]
+    pub clip3p_adapter_mmp: f64,
+
+    /// Extra bases to clip from the 3' end after the adapter
+    #[arg(long = "clip3pAfterAdapterNbases", default_value_t = 0)]
+    pub clip3p_after_adapter_nbases: u32,
+
+    /// Extra bases to clip from the 5' end after `clip5pNbases`
+    #[arg(long = "clip5pAfterAdapterNbases", default_value_t = 0)]
+    pub clip5p_after_adapter_nbases: u32,
+
     // ── Output ──────────────────────────────────────────────────────────
     /// Output file name prefix (including path)
     #[arg(long = "outFileNamePrefix", default_value = "./")]

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -503,6 +503,20 @@ pub struct Parameters {
     #[arg(long = "clip5pAfterAdapterNbases", default_value_t = 0)]
     pub clip5p_after_adapter_nbases: u32,
 
+    /// Coverage signal output: `None` (default) or `bedGraph`. `wiggle` and a 2nd
+    /// word (`read1_5p`/`read2`) are rejected (see `Parameters::validate`)
+    #[arg(long = "outWigType", num_args = 1.., default_values_t = vec![String::from("None")])]
+    pub out_wig_type: Vec<String>,
+
+    /// Coverage-signal normalization: `RPM` (default) or `None` (raw counts)
+    #[arg(long = "outWigNorm", default_value = "RPM")]
+    pub out_wig_norm: String,
+
+    /// Coverage-signal strandedness: `Stranded` (default). `Unstranded` is
+    /// rejected (see `Parameters::validate`)
+    #[arg(long = "outWigStrand", default_value = "Stranded")]
+    pub out_wig_strand: String,
+
     // ── Output ──────────────────────────────────────────────────────────
     /// Output file name prefix (including path)
     #[arg(long = "outFileNamePrefix", default_value = "./")]
@@ -1335,6 +1349,41 @@ impl Parameters {
             }
         }
 
+        // --outWigType at alignReads: only `bedGraph` (stranded, full-length) is
+        // implemented. `wiggle`, `--outWigStrand Unstranded`, and the 2nd word
+        // (`read1_5p`/`read2`) are STAR features of `--runMode
+        // inputAlignmentsFromBAM`, which rustar-aligner doesn't have; reject them
+        // loudly rather than silently emitting bedGraph / stranded / full-length
+        // tracks instead.
+        if params
+            .out_wig_type
+            .iter()
+            .any(|t| !t.eq_ignore_ascii_case("None"))
+        {
+            if params
+                .out_wig_type
+                .iter()
+                .any(|t| t.eq_ignore_ascii_case("wiggle"))
+            {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "--outWigType wiggle is not implemented; use --outWigType bedGraph",
+                ));
+            }
+            if params.out_wig_strand.eq_ignore_ascii_case("Unstranded") {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "--outWigStrand Unstranded is not implemented; use --outWigStrand Stranded",
+                ));
+            }
+            if params.out_wig_type.len() > 1 {
+                return Err(command.error(
+                    ErrorKind::InvalidValue,
+                    "the --outWigType 2nd word (read1_5p / read2) is not implemented; omit it",
+                ));
+            }
+        }
+
         // quantMode GeneCounts requires a GTF file
         if params.quant_gene_counts() && params.sjdb_gtf_file.is_none() {
             return Err(command.error(
@@ -1648,6 +1697,18 @@ impl Parameters {
     pub fn clip3p(&self, mate: usize) -> usize {
         let v = &self.clip3p_nbases;
         v[mate.min(v.len().saturating_sub(1))] as usize
+    }
+
+    /// Returns true if `--outWigType bedGraph` was requested.
+    pub fn out_wig_bedgraph(&self) -> bool {
+        self.out_wig_type
+            .iter()
+            .any(|t| t.eq_ignore_ascii_case("bedGraph"))
+    }
+
+    /// Returns true unless `--outWigNorm None` was requested (RPM is the default).
+    pub fn out_wig_rpm(&self) -> bool {
+        !self.out_wig_norm.eq_ignore_ascii_case("None")
     }
 
     /// True when the literal `None` whitelist was given (keep all barcodes).

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -1,0 +1,259 @@
+//! Coverage signal / `Signal.*.out.bg` bedGraph output (STAR `signalFromBAM.cpp`,
+//! `--outWigType bedGraph`, stranded).
+//!
+//! Ported from STAR-rs `crates/star-align/src/star_wig.rs`. Per strand (str1 =
+//! forward, str2 = reverse) two tracks accumulate: `Unique` (only `NH == 1`
+//! reads, +1 per covered base) and `UniqueMultiple` (every reported alignment,
+//! `+1/NH`). bedGraph intervals are emitted wherever the coverage changes.
+//!
+//! Only `--outWigType bedGraph` (stranded, full-length) is implemented, matching
+//! STAR-rs's own align-time scope: `wiggle`, `--outWigStrand Unstranded`, and the
+//! `--outWigType` 2nd word (`read1_5p`/`read2`) selector are only available via
+//! STAR's `--runMode inputAlignmentsFromBAM`, which neither STAR-rs nor
+//! rustar-aligner implement at align time. `Parameters::validate` rejects them
+//! loudly rather than silently emitting the wrong tracks.
+
+use crate::align::transcript::Transcript;
+use crate::genome::Genome;
+
+/// Per-chromosome coverage for the two strands, `Unique` and `UniqueMultiple` tracks.
+pub struct Signal {
+    /// `[chr][strand] = (unique, unique_multiple)`, each `chr_len + 1` bases (STAR's trailing zero).
+    per_chr: Vec<[(Vec<f64>, Vec<f64>); 2]>,
+    chr_len: Vec<usize>,
+    chr_name: Vec<String>,
+}
+
+impl Signal {
+    pub fn new(chr_name: &[String], chr_length: &[u64]) -> Self {
+        let chr_len: Vec<usize> = chr_length.iter().map(|&l| l as usize).collect();
+        let per_chr = chr_len
+            .iter()
+            .map(|&l| {
+                [
+                    (vec![0.0; l + 1], vec![0.0; l + 1]),
+                    (vec![0.0; l + 1], vec![0.0; l + 1]),
+                ]
+            })
+            .collect();
+        Self {
+            per_chr,
+            chr_len,
+            chr_name: chr_name.to_vec(),
+        }
+    }
+
+    /// Accumulate covered genomic `M`-blocks (chr-local `(start, len)`) on one strand
+    /// with `NH = n_tr`: `+1` to `Unique` iff `n_tr == 1`, always `+1/n_tr` to
+    /// `UniqueMultiple`. Introns and deletions are simply the gaps between blocks.
+    pub fn add_blocks(
+        &mut self,
+        chr: usize,
+        strand: usize,
+        blocks: &[(usize, usize)],
+        n_tr: usize,
+    ) {
+        let (uniq, umult) = {
+            let s = &mut self.per_chr[chr][strand];
+            (&mut s.0, &mut s.1)
+        };
+        let w = 1.0 / n_tr as f64;
+        for &(g0, len) in blocks {
+            for p in g0..g0 + len {
+                if n_tr == 1 {
+                    uniq[p] += 1.0;
+                }
+                umult[p] += w;
+            }
+        }
+    }
+
+    /// Accumulate one reported alignment (`tr`) with `NH = n_tr`. Only exon blocks
+    /// are covered; introns/deletions between exons are skipped by the block's
+    /// genomic jump. `second_mate` selects STAR's `iStrand` rule (`signalFromBAM.cpp`):
+    /// `iStrand = is_reverse == is_not_second_mate` — mate1 (and SE) use the
+    /// alignment's own strand directly, mate2's is flipped.
+    pub fn add_transcript(
+        &mut self,
+        genome: &Genome,
+        tr: &Transcript,
+        n_tr: usize,
+        second_mate: bool,
+    ) {
+        let cs = genome.chr_start[tr.chr_idx];
+        let blocks: Vec<(usize, usize)> = tr
+            .exons
+            .iter()
+            .map(|ex| {
+                (
+                    (ex.genome_start - cs) as usize,
+                    (ex.genome_end - ex.genome_start) as usize,
+                )
+            })
+            .collect();
+        let strand = usize::from(tr.is_reverse != second_mate);
+        self.add_blocks(tr.chr_idx, strand, &blocks, n_tr);
+    }
+
+    /// bedGraph text for one track (`unique = true` for the `Unique` track, else
+    /// `UniqueMultiple`) on one strand (0 = str1, 1 = str2), un-normalized
+    /// (`--outWigNorm None`). STAR emits `chr start end value` per constant-coverage run.
+    pub fn bedgraph(&self, unique: bool, strand: usize) -> String {
+        self.bedgraph_fmt(unique, strand, fmt_g6)
+    }
+
+    /// bedGraph text normalized to reads-per-million (`--outWigNorm RPM`): each
+    /// coverage value is scaled by `norm` (`1e6 / nReadsUnique`) and printed with 5
+    /// decimals, matching STAR.
+    pub fn bedgraph_rpm(&self, unique: bool, strand: usize, norm: f64) -> String {
+        self.bedgraph_fmt(unique, strand, |v| format!("{:.5}", v * norm))
+    }
+
+    /// The shared bedGraph run-length emitter; `fmt` renders one coverage value.
+    fn bedgraph_fmt(&self, unique: bool, strand: usize, fmt: impl Fn(f64) -> String) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        for chr in 0..self.chr_len.len() {
+            let track = if unique {
+                &self.per_chr[chr][strand].0
+            } else {
+                &self.per_chr[chr][strand].1
+            };
+            let mut prev = 0.0f64;
+            for ig in 0..=self.chr_len[chr] {
+                let new = if ig < track.len() { track[ig] } else { 0.0 };
+                // Exact comparison is intentional: `new`/`prev` are read back
+                // unmodified from the accumulator, so a run boundary is a real
+                // change, not float noise (clippy::float_cmp).
+                #[allow(clippy::float_cmp)]
+                let changed = new != prev;
+                if changed {
+                    if prev != 0.0 {
+                        let _ = writeln!(out, "{}\t{}", ig, fmt(prev));
+                    }
+                    if new != 0.0 {
+                        let _ = write!(out, "{}\t{}\t", self.chr_name[chr], ig);
+                    }
+                    prev = new;
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Format a coverage value like C++'s default `ostream` for `--outWigNorm None`:
+/// `%g` with 6 significant digits (NOT 6 decimal places). Integers print without a
+/// decimal point; for `|v| >= 1` the number of fractional digits is
+/// `5 - floor(log10|v|)` (so a total of 6 significant digits), then trailing zeros
+/// and a trailing `.` are stripped. Values `|v| < 1` keep 6 fractional digits (the
+/// leading `0.` does not count toward significant digits at these magnitudes).
+/// Coverage sums are small and positive, so the scientific branch of `%g` never
+/// triggers here.
+pub(crate) fn fmt_g6(v: f64) -> String {
+    // Exact comparison is intentional: this checks whether `v` is a whole number
+    // (to print it without a decimal point), not an approximate-equality test
+    // (clippy::float_cmp).
+    #[allow(clippy::float_cmp)]
+    let is_integer = v == v.trunc();
+    if is_integer && v.abs() < 1e15 {
+        return format!("{}", v as i64);
+    }
+    let decimals = if v.abs() >= 1.0 {
+        (5 - v.abs().log10().floor() as i64).max(0) as usize
+    } else {
+        6
+    };
+    let mut s = format!("{v:.decimals$}");
+    while s.ends_with('0') {
+        s.pop();
+    }
+    if s.ends_with('.') {
+        s.pop();
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::align::transcript::Exon;
+    use noodles::sam::alignment::record::cigar::{Op, op::Kind};
+
+    fn tr_fwd(chr_idx: usize, genome_start: u64, len: u64) -> Transcript {
+        Transcript {
+            chr_idx,
+            genome_start,
+            genome_end: genome_start + len,
+            is_reverse: false,
+            exons: vec![Exon {
+                genome_start,
+                genome_end: genome_start + len,
+                read_start: 0,
+                read_end: len as usize,
+                i_frag: 0,
+            }],
+            cigar: vec![Op::new(Kind::Match, len as usize)],
+            score: len as i32 - 1,
+            n_mismatch: 0,
+            n_gap: 0,
+            n_junction: 0,
+            junction_motifs: vec![],
+            junction_annotated: vec![],
+            read_seq: vec![],
+        }
+    }
+
+    #[test]
+    fn fmt_g6_matches_cpp_percent_g() {
+        assert_eq!(fmt_g6(1.0), "1");
+        assert_eq!(fmt_g6(5.0), "5");
+        assert_eq!(fmt_g6(0.5), "0.5");
+        assert_eq!(fmt_g6(1.0 + 1.0 / 3.0), "1.33333");
+        assert_eq!(fmt_g6(1.0 / 3.0), "0.333333");
+        assert_eq!(fmt_g6(12.0 + 5.0 / 6.0), "12.8333");
+        assert_eq!(fmt_g6(100.0 + 1.0 / 3.0), "100.333");
+    }
+
+    #[test]
+    fn add_blocks_unique_and_multi() {
+        let mut sig = Signal::new(&["chrI".to_string()], &[100]);
+        sig.add_blocks(0, 0, &[(10, 5)], 1);
+        assert_eq!(sig.bedgraph(true, 0), "chrI\t10\t15\t1\n");
+        assert_eq!(sig.bedgraph(false, 0), "chrI\t10\t15\t1\n");
+    }
+
+    #[test]
+    fn add_blocks_multimapper_splits_weight() {
+        let mut sig = Signal::new(&["chrI".to_string()], &[100]);
+        sig.add_blocks(0, 0, &[(10, 2)], 2);
+        // Not unique -> no Unique track contribution, UniqueMultiple gets 1/2.
+        assert_eq!(sig.bedgraph(true, 0), "");
+        assert_eq!(sig.bedgraph(false, 0), "chrI\t10\t12\t0.5\n");
+    }
+
+    #[test]
+    fn add_transcript_mate2_strand_is_flipped() {
+        let mut sig = Signal::new(&["chrI".to_string()], &[100]);
+        let genome = crate::genome::Genome {
+            transform_blocks: None,
+            sequence: vec![].into(),
+            n_genome: 100,
+            n_genome_real: 100,
+            n_chr_real: 1,
+            chr_name: vec!["chrI".to_string()],
+            chr_length: vec![100],
+            chr_start: vec![0],
+        };
+        let tr = tr_fwd(0, 10, 5); // forward alignment
+        // SE / mate1: forward alignment -> str1 (strand 0).
+        sig.add_transcript(&genome, &tr, 1, false);
+        assert_eq!(sig.bedgraph(true, 0), "chrI\t10\t15\t1\n");
+        assert_eq!(sig.bedgraph(true, 1), "");
+        // mate2: forward alignment -> flipped to str2 (strand 1).
+        let mut sig2 = Signal::new(&["chrI".to_string()], &[100]);
+        sig2.add_transcript(&genome, &tr, 1, true);
+        assert_eq!(sig2.bedgraph(true, 0), "");
+        assert_eq!(sig2.bedgraph(true, 1), "chrI\t10\t15\t1\n");
+    }
+}


### PR DESCRIPTION
# Batch 2: adapter clipping + STAR-faithful soft-clips + coverage signal (closes #113, #114)

Second consolidation batch of BenjaminDEMAILLE's STAR-rs-ported PRs. Each PR's logic was reviewed against **real STAR** (not trusted on STAR-rs provenance), the flagged bugs were fixed, and every change is byte-validated against STAR on the yeast test set.

Closes #113, #114

## #113 — adapter-aware read clipping (`--clip3pAdapterSeq`)

Ported from STAR-rs, but the review found the headline feature was **dead code**: reads reaching `clip_mate` are already numeric base codes, but it called `encode_base` on them *again* → every base became `N` → the 3' adapter Hamming scan never matched → nothing was ever clipped. The unit tests passed only because they fed ASCII string literals, a path production never hits.

- **Fix:** encode the adapter **once** in `clip_params_from` (it's the ASCII CLI value); `clip_mate` now compares the already-numeric read against the numeric adapter with no re-encoding.
- **Wired into the current pipelined loop** (the PR was written against the old sequential loop): SE + PE non-solo, per-mate (`clip_params_from(params, mate)` — the fixed `--clip{5,3}pNbases` are per-mate).
- Added a regression test that feeds **numeric** reads like the real pipeline.

## Soft-clip convention — align rustar's clip output with STAR

Investigating #113 surfaced a broader, pre-existing divergence: rustar **dropped** clipped bases from the record, while **STAR (and STAR-rs) soft-clip them** — the mapped read is the clipped insert, but the output SEQ keeps the full read with leading/trailing `S` in the CIGAR. (Notably: on clipping, **STAR-rs is byte-identical to STAR** — rustar was the one diverging. The drop was an early phase-6 shortcut, no real reason.)

This is now fixed to match STAR:

- New `apply_read_clips` in `io/sam.rs`: the record is built from the clipped read (so CIGAR core / MD / NM stay correct over the aligned bases), then the full original read is restored as SEQ/QUAL and the CIGAR is wrapped with **strand-aware** soft-clips (a read-3' clip becomes a *leading* `S` on a reverse-strand record; adjacent soft-clips are merged).
- Applies to mapped **SE + PE** reads. Unmapped reads (SE + PE) now emit the full original read too (STAR convention — clipping never removes bases from an unmapped record).
- **Solo** clip paths intentionally left on the drop path (pass `0,0`) to preserve the batch-1 byte-exact STARsolo validation; inert on default 10x (no cDNA clipping). Tracked in TODO.
- **Half-mapped** mapped-mate soft-clip is the one remaining edge case (rare: clipped mate maps, partner doesn't) — left valid-but-dropped, tracked in TODO.

## #114 — coverage signal (`--outWigType bedGraph`)

Ported from STAR-rs's `star_wig.rs` (STAR's `signalFromBAM.cpp`): four stranded `Signal.{Unique,UniqueMultiple}.str{1,2}.out.bg` tracks, RPM (default) or raw.

- **Integrated into the pipelined writer thread** — the PR targeted the old sequential loop; the coverage accumulator + RPM counters now live in the writer thread (they aren't safe to update from the parallel per-read closures).
- **PE RPM 2× bug fixed** (the review's main finding). STAR's `signalFromBAM` counts BAM **records**, so both mates of a pair contribute to `nUniq`/`nMult`; the PR counted once per **pair**, halving the denominator and doubling every PE RPM track. Fix: per mate-record — a uniquely-mapped pair adds **2** to `nUniq`, a multimapped pair adds **2** to `nMult`. SE stays `+1` (a multimapper's records sum to exactly 1: `NH × 1/NH`), verified against `signalFromBAM.cpp:22-28`.

## Validation

Byte-compared against **STAR 2.7.11b** (and STAR-rs) on synthetic + 10k yeast reads:

| Check | Result |
|---|---|
| Adapter clip, SE forward | `137M13S`, full SEQ — **byte-identical to STAR** |
| Adapter clip, SE reverse | `13S137M` (leading soft-clip) — **byte-identical** |
| Adapter clip, PE (both mates) | `99/137M13S` + `147/13S137M` — **byte-identical** |
| `--outWigType bedGraph` PE RPM | `Signal.*.str1` **byte-identical**; total ratio **1.0000** (was 2.0) |
| `--outWigType bedGraph` SE | **byte-identical** |
| No regression (default SE / PE) | SE 8788, PE 16582 — **unchanged**, byte-identical to baseline |

(The `str2` bedGraph differs by ~0.002% — one read's coverage — from the known PE alignment tie-break divergence bleeding into coverage, not a signal bug.)

**Gate:** 559 tests pass · `clippy --all-targets` 0 warnings · `fmt` clean.