### PR TITLE
fix: split NM/nM attributes — default outSAMattributes byte-matches STAR

### DIFF
--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -63,7 +63,7 @@ fn insert_unmapped_tags(record: &mut RecordBuf, attrs: SamAttributes, reason: Un
     if attrs.contains(SamAttributes::AS) {
         data.insert(Tag::ALIGNMENT_SCORE, Value::from(0i32));
     }
-    if attrs.contains(SamAttributes::NM) {
+    if attrs.contains(SamAttributes::NMM) {
         data.insert(Tag::new(b'n', b'M'), Value::from(0i32));
     }
     let ut = match reason {
@@ -557,6 +557,12 @@ impl SamWriter {
         if attrs.contains(SamAttributes::AS) {
             data.insert(Tag::ALIGNMENT_SCORE, Value::from(mapped_transcript.score));
         }
+        if attrs.contains(SamAttributes::NMM) {
+            data.insert(
+                Tag::new(b'n', b'M'),
+                Value::from(mapped_transcript.n_mismatch as i32),
+            );
+        }
         if attrs.contains(SamAttributes::NM) {
             data.insert(
                 Tag::EDIT_DISTANCE,
@@ -564,10 +570,6 @@ impl SamWriter {
                     mapped_transcript.n_mismatch,
                     &mapped_transcript.cigar,
                 )),
-            );
-            data.insert(
-                Tag::new(b'n', b'M'),
-                Value::from(mapped_transcript.n_mismatch as i32),
             );
         }
         if attrs.contains(SamAttributes::XS)
@@ -759,12 +761,14 @@ impl SamWriter {
             if attrs.contains(SamAttributes::AS) {
                 data.insert(Tag::ALIGNMENT_SCORE, Value::from(t.score));
             }
+            if attrs.contains(SamAttributes::NMM) {
+                data.insert(Tag::new(b'n', b'M'), Value::from(t.n_mismatch as i32));
+            }
             if attrs.contains(SamAttributes::NM) {
                 data.insert(
                     Tag::EDIT_DISTANCE,
                     Value::from(sam_spec_nm(t.n_mismatch, &t.cigar)),
                 );
-                data.insert(Tag::new(b'n', b'M'), Value::from(t.n_mismatch as i32));
             }
 
             maybe_insert_rg_tag(&mut record, rg_id);
@@ -1213,14 +1217,17 @@ fn transcript_to_record(
     if attrs.contains(SamAttributes::AS) {
         data.insert(Tag::ALIGNMENT_SCORE, Value::from(transcript.score));
     }
+    // nM (mismatch count) before NM (edit distance), matching STAR's tag order.
+    if attrs.contains(SamAttributes::NMM) {
+        data.insert(
+            Tag::new(b'n', b'M'),
+            Value::from(transcript.n_mismatch as i32),
+        );
+    }
     if attrs.contains(SamAttributes::NM) {
         data.insert(
             Tag::EDIT_DISTANCE,
             Value::from(sam_spec_nm(transcript.n_mismatch, &transcript.cigar)),
-        );
-        data.insert(
-            Tag::new(b'n', b'M'),
-            Value::from(transcript.n_mismatch as i32),
         );
     }
     if attrs.contains(SamAttributes::XS)
@@ -1576,14 +1583,17 @@ fn build_paired_mate_record(
         // STAR reports combined score (sum of both mates) for PE AS tag
         data.insert(Tag::ALIGNMENT_SCORE, Value::from(combined_score));
     }
+    // nM (mismatch count) before NM (edit distance), matching STAR's tag order.
+    if attrs.contains(SamAttributes::NMM) {
+        data.insert(
+            Tag::new(b'n', b'M'),
+            Value::from(transcript.n_mismatch as i32),
+        );
+    }
     if attrs.contains(SamAttributes::NM) {
         data.insert(
             Tag::EDIT_DISTANCE,
             Value::from(sam_spec_nm(transcript.n_mismatch, &transcript.cigar)),
-        );
-        data.insert(
-            Tag::new(b'n', b'M'),
-            Value::from(transcript.n_mismatch as i32),
         );
     }
     if attrs.contains(SamAttributes::XS)
@@ -2518,7 +2528,8 @@ mod tests {
             3, // n_alignments
             2, // hit_index
             1, // ih_start
-            SamAttributes::STANDARD,
+            // Standard + NM so both nM (mismatch count) and NM (edit distance) emit.
+            SamAttributes::STANDARD | SamAttributes::NM,
         )
         .unwrap();
 
@@ -2648,7 +2659,8 @@ mod tests {
         );
         assert_eq!(data.get(&Tag::HIT_INDEX), Some(&Value::from(1_i32)));
         assert_eq!(data.get(&Tag::ALIGNMENT_SCORE), Some(&Value::from(100_i32)));
-        assert_eq!(data.get(&Tag::EDIT_DISTANCE), Some(&Value::from(2_i32)));
+        // Standard = NH HI AS nM: the mismatch count nM, not the edit-distance NM.
+        assert_eq!(data.get(&Tag::EDIT_DISTANCE), None);
         assert_eq!(data.get(&Tag::new(b'n', b'M')), Some(&Value::from(2_i32)));
         assert_eq!(data.get(&Tag::new(b'X', b'S')), None);
     }
@@ -4054,13 +4066,15 @@ mod tests {
             data.get(&Tag::ALIGNMENT_SCORE).is_some(),
             "AS should be present"
         );
+        // STAR's Standard preset is NH HI AS nM — the mismatch count, NOT the
+        // edit-distance NM (which is opt-in via `NM` / `All`).
         assert!(
-            data.get(&Tag::EDIT_DISTANCE).is_some(),
-            "NM should be present"
+            data.get(&Tag::EDIT_DISTANCE).is_none(),
+            "NM (edit distance) should be absent from Standard"
         );
         assert!(
             data.get(&Tag::new(b'n', b'M')).is_some(),
-            "nM should be present"
+            "nM should be present in Standard"
         );
         // Non-standard tags absent
         assert!(
@@ -4378,8 +4392,9 @@ mod tests {
         let read_seq = vec![0, 1, 2, 3];
         let read_qual = vec![30, 30, 30, 30];
 
-        // SamAttributes::NM covers both "NM" and "nM" CLI tokens and emits both tags.
-        let attrs = SamAttributes::NM;
+        // NM (edit distance) and NMM (nM, mismatch count) are distinct flags now;
+        // request both to emit both tags.
+        let attrs = SamAttributes::NM | SamAttributes::NMM;
         let record = transcript_to_record(
             &transcript,
             "read1",

--- a/src/params/sam.rs
+++ b/src/params/sam.rs
@@ -14,6 +14,8 @@ bitflags::bitflags! {
         const NH = 1 << 0;
         const HI = 1 << 1;
         const AS = 1 << 2;
+        /// `NM:i` — SAM-standard edit distance (mismatches + inserted + deleted
+        /// bases). NOT in STAR's `Standard` preset; opt-in via `NM` / `All`.
         const NM = 1 << 3;
         const MD = 1 << 4;
         const JM = 1 << 5;
@@ -24,12 +26,18 @@ bitflags::bitflags! {
         const GX = 1 << 9;
         /// STARsolo gene name (symbol) of the Gene-feature assignment (GN:Z).
         const GN = 1 << 10;
+        /// `nM:i` — STAR's mismatch count (mismatches only, excluding indels). This
+        /// is the tag in STAR's `Standard` preset (distinct from `NM`).
+        const NMM = 1 << 11;
 
+        // STAR `Standard` = NH HI AS nM  (the mismatch count nM, NOT edit-distance NM).
         const STANDARD =
             Self::NH.bits() | Self::HI.bits() | Self::AS.bits()
-            | Self::NM.bits();
+            | Self::NMM.bits();
+        // STAR `All` additionally includes the edit-distance NM, MD, jM, jI (+ XS here).
         const ALL =
             Self::STANDARD.bits()
+            | Self::NM.bits()
             | Self::MD.bits() | Self::JM.bits() | Self::JI.bits() | Self::XS.bits();
     }
 }
@@ -46,8 +54,10 @@ impl FromStr for SamAttributes {
             "NH" => Self::NH,
             "HI" => Self::HI,
             "AS" => Self::AS,
-            // STAR maps NM attribute to 'nM' tag (mismatches only, not edit distance)
-            "NM" | "nM" => Self::NM,
+            // `NM` = SAM-standard edit distance; `nM` = STAR's mismatch count. These
+            // are distinct tags (only `nM` is in the `Standard` preset).
+            "NM" => Self::NM,
+            "nM" => Self::NMM,
             "MD" => Self::MD,
             "jM" => Self::JM,
             "jI" => Self::JI,


### PR DESCRIPTION
# Split NM / nM SAM attributes: default `--outSAMattributes` byte-matches STAR

Makes rustar's **default** SAM tag set match STAR's `Standard` exactly, by separating two tags that were previously conflated.

## Problem

`NM` and `nM` are two *different* SAM tags:

- **`NM:i`** — the SAM-standard **edit distance** (mismatches + inserted + deleted bases).
- **`nM:i`** — STAR's own tag: **mismatch count only** (excludes indels).

STAR's presets:
- `Standard` = `NH HI AS nM` — the mismatch count, **not** edit-distance NM.
- `All` = `Standard` + `NM MD jM jI …` — edit-distance NM is opt-in.

rustar conflated the two into a single `SamAttributes::NM` flag (`"NM" | "nM" => Self::NM`) that emitted **both** tags, and `STANDARD` included it. So rustar's default output was `NH HI AS NM nM` (5 tags) where STAR emits `NH HI AS nM` (4) — a spurious `NM:i` tag on every mapped read.

## Fix

- `src/params/sam.rs`: split into two flags — `NM` (edit distance) and `NMM` (`nM`, mismatch count). `"NM"` and `"nM"` CLI tokens now map to their own flag. **`STANDARD = NH | HI | AS | NMM`** (nM, not NM); **`ALL`** additionally includes `NM`.
- `src/io/sam.rs`: the four record-builder sites (primary, paired-mate, half-mapped, unmapped) emit `nM` and `NM` **independently**, `nM` before `NM` (STAR's tag order).
- Updated four unit tests that had encoded the old conflated behavior to assert the split (Standard → nM only; `NM`/`All` → edit distance).

## Validation (vs STAR 2.7.11b)

- **Default output is now byte-identical to STAR**: `NH:i:1 HI:i:1 AS:i:135 nM:i:0` (the spurious `NM:i:0` is gone). On the 10k yeast SE set, 9377 records now byte-match STAR through the tag fields.
- `--outSAMattributes All` / `NM` still emit the edit-distance `NM` (opt-in intact), in STAR's `nM`-then-`NM` order.
- No mapping change (tags don't affect position): SE 8788/8926 unchanged.
- 559 tests pass · `clippy --all-targets` 0 warnings · `fmt` clean.