### PR TITLE
fix: check too many loci after the quality filter, matching STAR's

### DIFF
--- a/src/align/read_align.rs
+++ b/src/align/read_align.rs
@@ -401,18 +401,6 @@ pub fn align_read(
         transcripts.retain(|t| t.score >= score_threshold);
     }
 
-    // Multimap count check: too many loci → unmapped.
-    if transcripts.len() > params.out_filter_multimap_nmax as usize {
-        let n_loci = transcripts.len();
-        transcripts.clear();
-        return Ok((
-            transcripts,
-            chimeric_alignments,
-            n_loci,
-            Some(UnmappedReason::TooManyLoci),
-        ));
-    }
-
     // Step 4: Quality filters (STAR's mappedFilter — runs after score-range selection).
     // STAR uses (Lread-1) for relative thresholds and casts to integer
     // (ReadAlign_mappedFilter.cpp lines 8-9)
@@ -644,6 +632,12 @@ pub fn align_read(
         }
     }
 
+    // STAR's mappedFilter (ReadAlign_mappedFilter.cpp) classifies the read by its
+    // BEST transcript, in strict order: too-short (score/match) → too-many-mismatches
+    // → too-many-loci → mapped. Crucially, `multi` (too many loci) is reached ONLY
+    // when the best alignment PASSES the score/match/mismatch gates. We mirror that:
+    // if the quality filter emptied the set, the best transcript failed → classify
+    // short/mismatch; otherwise, if too many loci survive, it's multi; else mapped.
     let unmapped_reason = if transcripts.is_empty() {
         let has_mismatch = filter_reasons.contains_key("mismatch_max")
             || filter_reasons.contains_key("mismatch_rate");
@@ -655,6 +649,11 @@ pub fn align_read(
         } else {
             Some(UnmappedReason::TooShort)
         }
+    } else if transcripts.len() > params.out_filter_multimap_nmax as usize {
+        // Best alignment passed quality, but too many loci → STAR unmapType=3.
+        // `n_for_mapq` already holds this count (computed above); drop the alignments.
+        transcripts.clear();
+        Some(UnmappedReason::TooManyLoci)
     } else {
         None
     };
@@ -1146,17 +1145,6 @@ pub fn align_paired_read(
         joint_pairs.retain(|pa| pa.combined_wt_score >= score_threshold);
     }
 
-    // Step 3: TooManyLoci check (post-dedup, matching STAR's ordering: multMapSelect → dedup → TooManyLoci).
-    if joint_pairs.len() > params.out_filter_multimap_nmax as usize {
-        let n_loci = joint_pairs.len();
-        return Ok((
-            Vec::new(),
-            pe_chimeric,
-            n_loci,
-            Some(UnmappedReason::TooManyLoci),
-        ));
-    }
-
     // Deterministic primary tie-break (combined score, then a fixed positional
     // order on mate1).
     joint_pairs.sort_by(|a, b| {
@@ -1189,6 +1177,20 @@ pub fn align_paired_read(
 
     // Step 4: quality filter (mappedFilter).
     filter_paired_transcripts(&mut joint_pairs, params);
+
+    // Step 5: too-many-loci — STAR checks `multi` AFTER mappedFilter, only when the
+    // best pair passes the score/match/mismatch gates (ReadAlign_mappedFilter.cpp).
+    // Pairs that survive quality but exceed outFilterMultimapNmax → too many loci;
+    // a read whose best pair fails quality was already emptied above (→ unmapped).
+    if joint_pairs.len() > params.out_filter_multimap_nmax as usize {
+        let n_loci = joint_pairs.len();
+        return Ok((
+            Vec::new(),
+            pe_chimeric,
+            n_loci,
+            Some(UnmappedReason::TooManyLoci),
+        ));
+    }
 
     // PE Tier 1: chimericDetectionOld per-mate — mirrors SE behavior but run independently
     // on each mate's transcript pool (joint-pair halves + single-mate WTs combined).


### PR DESCRIPTION
# fix: check `too many loci` after the quality filter, matching STAR's mappedFilter order

`Log.final.out`'s unmapped/multi buckets diverged badly from STAR because the too-many-loci check ran *before* the quality filter. This reorders both the SE and PE paths to match STAR, and folds off-target reads into the correct bucket.

## The bug

STAR's `ReadAlign_mappedFilter.cpp` classifies a read by its **best transcript** in a strict order:

1. `nW == 0` → **other**
2. best fails score / match thresholds → **too short**
3. best fails mismatch thresholds → **too many mismatches**
4. `nTr > outFilterMultimapNmax` → **too many loci** (multi)
5. otherwise → mapped

Crucially, step 4 (`multi`) is reached **only when the best alignment passes** the score/match/mismatch gates.

rustar checked the multimap **count first**, before the quality filter — `align_read` (SE) and the PE decision tree (`align_paired_read`, "Step 3"). So any read with more than `outFilterMultimapNmax` candidates was bucketed `too many loci` even when its best alignment was garbage and should have been `too short`. On a chr21-only index, huge numbers of off-target reads pile up many low-quality candidates and were mislabelled.

## The fix

Move the multimap-count check to run **after** the quality filter in both paths, so a read is `too many loci` only when the surviving (quality-passing) alignments exceed `outFilterMultimapNmax`; a read whose best alignment fails quality is already classified `too short` / `too many mismatches`. `n_for_mapq` naturally carries the surviving count. No change to which reads map or where — only `Log.final.out` bucketing.

## Verification (vs STAR 2.7.11b)

**Human chr21 (500k SE reads):**

| bucket | STAR | before | after |
|--------|-----:|-------:|------:|
| mapped to too many loci | 269 | 26 285 | **253** |
| unmapped: too many mismatches | 0 | 0 | 0 |
| unmapped: too short | 447 601 | 421 650 | **447 670** |
| unmapped: other | 6 | 6 | 6 |

The 98× over-count collapses to near-exact; the ~26 000 mislabelled reads move into `too short`. The small residual (253 vs 269, 447 670 vs 447 601) is the pre-existing ~59-read mapping/tie difference, not bucketing.

**Yeast SE — now matches STAR exactly on every bucket:** too-many-loci 26 = 26, too-short 1047 = 1047, other 1 = 1, uniquely mapped 8265 = 8265.

**No regression:** SE position agreement 8788/8926 unchanged; PE 8390 both-mapped unchanged; mapping decisions untouched. 579 tests pass · `clippy --all-targets` 0 warnings · `fmt` clean.

## Related

This also confirms #48 (`other` always 0) and #79 (mismatch → `too short`) no longer reproduce — `other` and `too many mismatches` already match STAR on both yeast and human. Those were filed against rustar 0.1.0; the classification code has since gained the no-seeds/no-clusters → `other` returns and the mismatch-vs-short split. This PR fixes the larger ordering bug that surfaced while reviewing that logic.