### PR TITLE
Solo halfmapped softclip

### DIFF
--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -460,12 +460,17 @@ impl SamWriter {
     /// **Unmapped mate:** FLAG 0x4, co-located at mapped mate's position.
     ///   SEQ/QUAL in forward orientation (no RC).
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn build_half_mapped_records(
         read_name: &str,
         mate1_seq: &[u8],
         mate1_qual: &[u8],
         mate2_seq: &[u8],
         mate2_qual: &[u8],
+        m1_clip5p: usize,
+        m1_clip3p: usize,
+        m2_clip5p: usize,
+        m2_clip3p: usize,
         mapped_transcript: &Transcript,
         mate1_is_mapped: bool,
         genome: &Genome,
@@ -485,12 +490,22 @@ impl SamWriter {
         let chr_start = genome.chr_start[mapped_transcript.chr_idx];
         let mapped_pos = (mapped_transcript.genome_start - chr_start + 1) as usize;
 
-        // Determine which sequences go where
-        let (mapped_seq, mapped_qual, unmapped_seq, unmapped_qual) = if mate1_is_mapped {
-            (mate1_seq, mate1_qual, mate2_seq, mate2_qual)
-        } else {
-            (mate2_seq, mate2_qual, mate1_seq, mate1_qual)
-        };
+        // Determine which sequences (and clip amounts) go where. mate seqs are the
+        // full original reads; the mapped mate's core is built from its aligned slice
+        // and soft-clipped below, the unmapped mate keeps the full read.
+        let (mapped_seq, mapped_qual, unmapped_seq, unmapped_qual, mapped_clip5p, mapped_clip3p) =
+            if mate1_is_mapped {
+                (
+                    mate1_seq, mate1_qual, mate2_seq, mate2_qual, m1_clip5p, m1_clip3p,
+                )
+            } else {
+                (
+                    mate2_seq, mate2_qual, mate1_seq, mate1_qual, m2_clip5p, m2_clip3p,
+                )
+            };
+        // Aligned slice of the mapped mate (core SEQ/CIGAR/MD built from this).
+        let aligned_mapped_seq = &mapped_seq[mapped_clip5p..mapped_seq.len() - mapped_clip3p];
+        let aligned_mapped_qual = &mapped_qual[mapped_clip5p..mapped_qual.len() - mapped_clip3p];
 
         // --- Build mapped mate record ---
         let mut mapped_rec = RecordBuf::default();
@@ -525,22 +540,22 @@ impl SamWriter {
             })?);
         *mapped_rec.template_length_mut() = 0;
 
-        // SEQ/QUAL
+        // SEQ/QUAL (core from the aligned slice; apply_read_clips restores full read)
         if mapped_transcript.is_reverse {
-            let seq_bytes: Vec<u8> = mapped_seq
+            let seq_bytes: Vec<u8> = aligned_mapped_seq
                 .iter()
                 .rev()
                 .map(|&b| decode_base(complement_base(b)))
                 .collect();
             *mapped_rec.sequence_mut() = Sequence::from(seq_bytes);
-            let mut qual = fastq_qual_to_phred(mapped_qual);
+            let mut qual = fastq_qual_to_phred(aligned_mapped_qual);
             qual.reverse();
             *mapped_rec.quality_scores_mut() = QualityScores::from(qual);
         } else {
-            let seq_bytes: Vec<u8> = mapped_seq.iter().map(|&b| decode_base(b)).collect();
+            let seq_bytes: Vec<u8> = aligned_mapped_seq.iter().map(|&b| decode_base(b)).collect();
             *mapped_rec.sequence_mut() = Sequence::from(seq_bytes);
             *mapped_rec.quality_scores_mut() =
-                QualityScores::from(fastq_qual_to_phred(mapped_qual));
+                QualityScores::from(fastq_qual_to_phred(aligned_mapped_qual));
         }
 
         // Optional tags on mapped mate
@@ -590,7 +605,7 @@ impl SamWriter {
         if attrs.contains(SamAttributes::MD) {
             let md = build_md_tag(
                 mapped_transcript,
-                mapped_seq,
+                aligned_mapped_seq,
                 genome,
                 mapped_transcript.is_reverse,
             );
@@ -598,6 +613,19 @@ impl SamWriter {
         }
         maybe_insert_rg_tag(&mut mapped_rec, rg_id);
         apply_sam_flag_or_and(&mut mapped_rec, params);
+        // Soft-clip the mapped mate's clipped bases (STAR convention), matching the
+        // both-mapped path. No-op when the mapped mate has no clip.
+        if mapped_clip5p > 0 || mapped_clip3p > 0 {
+            apply_read_clips(
+                &mut mapped_rec,
+                &mapped_transcript.cigar,
+                mapped_seq,
+                mapped_qual,
+                mapped_clip5p,
+                mapped_clip3p,
+                mapped_transcript.is_reverse,
+            );
+        }
 
         // --- Build unmapped mate record ---
         let mut unmapped_rec = RecordBuf::default();
@@ -4488,6 +4516,10 @@ mod tests {
             &mate1_qual,
             &mate2_seq,
             &mate2_qual,
+            0,
+            0,
+            0,
+            0,
             &mapped_transcript,
             true, // mate1_is_mapped
             &genome,
@@ -4556,6 +4588,10 @@ mod tests {
             &mate1_qual,
             &mate2_seq,
             &mate2_qual,
+            0,
+            0,
+            0,
+            0,
             &mapped_transcript,
             true,
             &genome,
@@ -4639,6 +4675,10 @@ mod tests {
             &mate1_qual,
             &mate2_seq,
             &mate2_qual,
+            0,
+            0,
+            0,
+            0,
             &mapped_transcript,
             true,
             &genome,
@@ -4656,6 +4696,10 @@ mod tests {
             &mate1_qual,
             &mate2_seq,
             &mate2_qual,
+            0,
+            0,
+            0,
+            0,
             &mapped_transcript,
             false,
             &genome,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2154,13 +2154,17 @@ fn align_reads_solo<W: AlignmentWriter + ?Sized>(
                                 };
                             // CellRanger4 adapter clipping (TSO 5' + polyA 3') runs before
                             // the fixed clip5p/clip3p Nbases trimming.
-                            let (cr_seq, cr_qual) = if cr4_clip {
+                            let (cr_seq, cr_qual, cr4_5p, cr4_3p) = if cr4_clip {
                                 crate::solo::clip_adapter_cr4(&read.sequence, &read.quality)
                             } else {
-                                (read.sequence.clone(), read.quality.clone())
+                                (read.sequence.clone(), read.quality.clone(), 0, 0)
                             };
                             let (clipped_seq, clipped_qual) =
                                 clip_read(&cr_seq, &cr_qual, clip5p, clip3p);
+                            // Total clip against the ORIGINAL read = CR4 (TSO/polyA) + fixed
+                            // Nbases; used to soft-clip all trimmed bases (STARsolo convention).
+                            let total_clip5p = cr4_5p + clip5p;
+                            let total_clip3p = cr4_3p + clip3p;
                             let mut buffer = BufferedSamRecords::new();
                             stats.record_read_bases(clipped_seq.len() as u64);
 
@@ -2234,15 +2238,15 @@ fn align_reads_solo<W: AlignmentWriter + ?Sized>(
                                         buffer.push(record);
                                     }
                                 } else if transcripts.len() <= max_multimaps {
-                                    // Soft-clip the fixed clip5p/clip3p against the post-CR4
-                                    // read (cr_seq), matching SE/PE. Default 10x has clip=0 so
-                                    // this is inert; the CR4 TSO/polyA bases stay dropped.
+                                    // Soft-clip ALL trimmed bases (CR4 TSO/polyA + fixed
+                                    // clip5p/clip3p) against the original read, matching
+                                    // STARsolo (e.g. 60M30S). Inert at default 10x.
                                     let mut records = SamWriter::build_alignment_records(
                                         &out_read_name,
-                                        &cr_seq,
-                                        &cr_qual,
-                                        clip5p,
-                                        clip3p,
+                                        &read.sequence,
+                                        &read.quality,
+                                        total_clip5p,
+                                        total_clip3p,
                                         &transcripts,
                                         &index.genome,
                                         params,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2234,15 +2234,15 @@ fn align_reads_solo<W: AlignmentWriter + ?Sized>(
                                         buffer.push(record);
                                     }
                                 } else if transcripts.len() <= max_multimaps {
-                                    // Solo: preserve current (drop) behavior — pass the
-                                    // already-clipped read with 0/0, so nothing is
-                                    // re-attached (the batch-1 STARsolo validation holds).
+                                    // Soft-clip the fixed clip5p/clip3p against the post-CR4
+                                    // read (cr_seq), matching SE/PE. Default 10x has clip=0 so
+                                    // this is inert; the CR4 TSO/polyA bases stay dropped.
                                     let mut records = SamWriter::build_alignment_records(
                                         &out_read_name,
-                                        &clipped_seq,
-                                        &clipped_qual,
-                                        0,
-                                        0,
+                                        &cr_seq,
+                                        &cr_qual,
+                                        clip5p,
+                                        clip3p,
                                         &transcripts,
                                         &index.genome,
                                         params,
@@ -2597,10 +2597,14 @@ fn align_reads_solo_pe<W: AlignmentWriter + ?Sized>(
                                 {
                                     let records = SamWriter::build_half_mapped_records(
                                         &out_read_name,
-                                        &m1_seq,
-                                        &m1_qual,
-                                        &m2_seq,
-                                        &m2_qual,
+                                        &pread.mate1.sequence,
+                                        &pread.mate1.quality,
+                                        &pread.mate2.sequence,
+                                        &pread.mate2.quality,
+                                        clip5p_m1,
+                                        clip3p_m1,
+                                        clip5p_m2,
+                                        clip3p_m2,
                                         mapped_transcript,
                                         *mate1_is_mapped,
                                         &index.genome,
@@ -2616,18 +2620,18 @@ fn align_reads_solo_pe<W: AlignmentWriter + ?Sized>(
                                     .iter()
                                     .map(|pa| PairedAlignment::clone(pa))
                                     .collect();
-                                // Solo: preserve current (drop) behavior — already-clipped
-                                // mate seqs with 0/0 clips (batch-1 STARsolo validation holds).
+                                // Soft-clip the fixed per-mate clips against the original
+                                // mate reads (matching SE/PE non-solo). Inert at default 10x.
                                 let records = SamWriter::build_paired_records(
                                     &out_read_name,
-                                    &m1_seq,
-                                    &m1_qual,
-                                    &m2_seq,
-                                    &m2_qual,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
+                                    &pread.mate1.sequence,
+                                    &pread.mate1.quality,
+                                    &pread.mate2.sequence,
+                                    &pread.mate2.quality,
+                                    clip5p_m1,
+                                    clip3p_m1,
+                                    clip5p_m2,
+                                    clip3p_m2,
                                     &paired_alns,
                                     &index.genome,
                                     params,
@@ -3316,10 +3320,14 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
                             {
                                 let records = SamWriter::build_half_mapped_records(
                                     &out_read_name,
-                                    &m1_seq,
-                                    &m1_qual,
-                                    &m2_seq,
-                                    &m2_qual,
+                                    &paired_read.mate1.sequence,
+                                    &paired_read.mate1.quality,
+                                    &paired_read.mate2.sequence,
+                                    &paired_read.mate2.quality,
+                                    m1_clip5p,
+                                    m1_clip3p,
+                                    m2_clip5p,
+                                    m2_clip3p,
                                     mapped_transcript,
                                     *mate1_is_mapped,
                                     &index.genome,

--- a/src/solo/mod.rs
+++ b/src/solo/mod.rs
@@ -393,7 +393,10 @@ const TSO_SEQ: &[u8] = b"AAGCAGTGGTATCAACGCAGAGTACATGGG";
 ///
 /// Conservative thresholds (full-length TSO match ≤ 3 mismatches at the 5'
 /// anchor; trailing polyA run ≥ 8) keep this a no-op on adapter-free reads.
-pub fn clip_adapter_cr4(seq: &[u8], qual: &[u8]) -> (Vec<u8>, Vec<u8>) {
+/// Returns `(clipped_seq, clipped_qual, clip5p, clip3p)` — the CR4-clipped read plus
+/// the bases trimmed from the 5' (TSO) and 3' (polyA) ends, so the caller can soft-clip
+/// them (STARsolo keeps them in SEQ as soft-clips, e.g. `60M30S`, not dropped).
+pub fn clip_adapter_cr4(seq: &[u8], qual: &[u8]) -> (Vec<u8>, Vec<u8>, usize, usize) {
     let mut start = 0usize;
     let mut end = seq.len();
 
@@ -424,13 +427,15 @@ pub fn clip_adapter_cr4(seq: &[u8], qual: &[u8]) -> (Vec<u8>, Vec<u8>) {
     }
 
     if start == 0 && end == seq.len() {
-        return (seq.to_vec(), qual.to_vec());
+        return (seq.to_vec(), qual.to_vec(), 0, 0);
     }
     (
         seq[start..end].to_vec(),
         qual.get(start..end.min(qual.len()))
             .map(<[u8]>::to_vec)
             .unwrap_or_default(),
+        start,
+        seq.len() - end,
     )
 }
 


### PR DESCRIPTION
# Soft-clip clipped bases in the solo, half-mapped, and CR4 paths (matching STAR)

Completes the soft-clip convention introduced in batch 2 (mapped SE/PE + unmapped) for the three remaining paths that still **dropped** clipped bases. Same principle throughout: STAR keeps clipped bases in SEQ as soft-clips (full read + leading/trailing `S`); we now do too, via the shared `apply_read_clips`.

## Changes

**Solo SE/PE** (`src/lib.rs`) — the two solo closures previously passed `0,0` to the record builders (drop). Now:
- Solo SE soft-clips `clip5p/clip3p` against the post-CR4 read.
- Solo PE soft-clips per-mate against the original mate reads.

**Half-mapped** (`src/io/sam.rs`) — `build_half_mapped_records` now takes per-mate clip params; the mapped mate's core is built from its aligned slice and soft-clipped via `apply_read_clips`, while the unmapped mate keeps the full read. Both prod + 4 test call sites updated.

**CR4 (CellRanger4)** (`src/solo/mod.rs` + `src/lib.rs`) — `clip_adapter_cr4` now returns the TSO(5')/polyA(3') clip amounts; solo SE soft-clips those **plus** the fixed clips against the original read, matching STARsolo's representation (`60M30S`, full SEQ) instead of dropping the TSO/polyA.

## Verification (vs STAR 2.7.11b)

- **Solo, default 10x (clip=0):** Gene matrix **229 cells / 379 entries unchanged** — soft-clip is inert without clipping and doesn't touch gene counting, so the batch-1 STARsolo validation holds. With `--clip5pNbases 5`, soft-clips appear (strand-aware) where they were dropped before.
- **Half-mapped:** forced a half-map (garbled mate2 + lowered thresholds so mate1's solo alignment qualifies). The mapped mate now emits `5S145M` (full SEQ 150), with merged (`6S144M`) and spliced (`5S18M421N127M`) cases correct — soft-clipped where it was dropped.
- **CR4 vs STARsolo (`--clipAdapterType CellRanger4`):** rustar now soft-clips CR4 (39% of mapped records, STAR 41%), and **15 171 records are byte-identical** (93% of records in both). Before, rustar dropped all CR4 bases (0% soft-clipped, shortened SEQ).

**Gate:** 553 tests pass · `clippy --all-targets` 0 warnings · `fmt` clean · yeast SE 8788 / PE 8390 unchanged.

## Known residual (tracked in TODO, not blocking)

The last ~0.9% of CR4 records clip a slightly different *amount* than STAR: rustar's TSO(≤3mm)/polyA(≥8-run) heuristic vs STAR's `ClipCR4`, which runs a deterministic overlap-mode Smith-Waterman (via Opal) against a 64-sequence adapter DB. The **representation** now matches STAR (soft-clip, not drop); byte-exact clip *amounts* need porting that SW clipping — a bounded, pure-Rust follow-up (STAR-rs has a ~100-line scalar port to crib from). This PR does not attempt it. James is making a rust simd version on the side