### PR TITLE
STAR-compat batch (--alignEndsType, --outSAMorder, chimeric/transcriptome) + PGO CI fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,11 +132,16 @@ jobs:
             target: aarch64-unknown-linux-gnu
             pgo: true
 
-          # Linux aarch64 with SVE (Graviton 3+, Axion, Grace)
+          # Linux aarch64 with SVE (Graviton 3+, Axion, Grace).
+          # PGO trains at the generic armv8-a baseline because the SVE (neoverse-v1)
+          # instrumented binary would SIGILL on any aarch64 runner without SVE. The
+          # shipped binary is still built at neoverse-v1 (profiles transfer across
+          # -Ctarget-cpu levels). Same mechanism as linux-x86_64-v4.
           - name: linux-aarch64-neoverse-v1
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             target_cpu: neoverse-v1
+            pgo_train_cpu: generic
             pgo: true
 
           # macOS x86_64 (cross-compiled on Apple Silicon runner)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,11 +114,16 @@ jobs:
             target_cpu: x86-64-v3
             pgo: true
 
-          # Linux x86_64 with AVX-512 (x86-64-v4)
+          # Linux x86_64 with AVX-512 (x86-64-v4).
+          # PGO trains at v3 (AVX2) because GitHub runners do not reliably have
+          # AVX-512 — running a v4-compiled instrumented binary SIGILLs (exit
+          # 132). The shipped binary is still built at v4 (profiles transfer
+          # across -Ctarget-cpu levels). See scripts/pgo-build.sh.
           - name: linux-x86_64-v4
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             target_cpu: x86-64-v4
+            pgo_train_cpu: x86-64-v3
             pgo: true
 
           # Linux aarch64 (native arm64 runner, baseline)
@@ -182,9 +187,15 @@ jobs:
             --genomeSAindexNbases 8 --runThreadN 2
           PGO_TARGET="${{ matrix.target }}" \
           PGO_EXTRA_RUSTFLAGS="${TARGET_CPU:+-Ctarget-cpu=$TARGET_CPU}" \
+          PGO_TRAIN_EXTRA_RUSTFLAGS="${PGO_TRAIN_CPU:+-Ctarget-cpu=$PGO_TRAIN_CPU}" \
             bash scripts/pgo-build.sh "$IDX_DIR" "$FIXTURE_DIR/reads.fastq" 50000
         env:
           TARGET_CPU: ${{ matrix.target_cpu || '' }}
+          # ISA for the instrumented/training binary that actually runs on the
+          # build machine. Falls back to the ship CPU when unset; overridden to
+          # a runner-safe level (e.g. v3) for targets whose ISA the runner may
+          # lack (v4/AVX-512).
+          PGO_TRAIN_CPU: ${{ matrix.pgo_train_cpu || matrix.target_cpu || '' }}
 
       - name: Build
         if: ${{ !matrix.pgo }}

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ resident; the 16 GB sparse index is stable at ~54 s.</sub>
 ## Supported Features
 
 - Single-end and paired-end alignment with mate rescue
+- Read-end alignment mode (`--alignEndsType Local` (default) / `EndToEnd` / `Extend5pOfRead1` / `Extend5pOfReads12` / `Extend3pOfRead1`)
 - SAM, unsorted BAM, and coordinate-sorted BAM output (`--outSAMtype SAM`, `BAM Unsorted`, or `BAM SortedByCoordinate`)
 - Multi-threaded parallel alignment (`--runThreadN`)
 - GTF-based junction annotation with scoring bonus (`--sjdbGTFfile`)
@@ -226,6 +227,7 @@ resident; the 16 GB sparse index is stable at ~54 s.</sub>
 - Unmapped read output to FASTQ (`--outReadsUnmapped Fastx` → `Unmapped.out.mate1` / `mate2`)
 - Gzip-compressed FASTQ input (`--readFilesCommand zcat`)
 - Read group tags (`--outSAMattrRGline`)
+- Deterministic input-order output regardless of thread count (`--outSAMorder Paired` / `PairedKeepInputOrder`, both accepted; rustar always preserves FASTQ order)
 - Deterministic in-tree RNG for reproducible tie-breaking (`--runRNGseed`; no `rand` dependency)
 - SAM optional tags: NH, HI, AS, nM, NM, XS, jM, jI, MD (default `NH HI AS nM` matches STAR; `NM` opt-in)
 - `--outSAMattributes` control (Standard/All/None/explicit list)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Rust reimplementation of [STAR](https://github.com/alexdobin/STAR) (Spliced Tr
 
 rustar-aligner aims to be a faithful port of STAR, matching the original behavior as closely as possible. It uses the same genome index format, accepts the same `--camelCase` command-line parameters, and produces compatible SAM/BAM output.
 
-**Current status**: End-to-end single-end and paired-end RNA-seq alignment with splice junction detection, two-pass mode, chimeric alignment detection (including multi-junction Tier 3), gene-level quantification, **single-cell quantification (STARsolo: Gene / GeneFull / SJ / Velocyto features, barcode correction, UMI dedup, EmptyDrops_CR cell calling)**, and multi-threaded parallel processing. Solo count matrices are byte-identical to STARsolo's. 516 tests passing (491 unit + 25 integration), 0 clippy warnings. See [Performance & Benchmarks](#performance--benchmarks) for a native three-way comparison against STARsolo and CellRanger.
+**Current status**: End-to-end single-end and paired-end RNA-seq alignment with splice junction detection, two-pass mode, chimeric alignment detection (including multi-junction Tier 3), gene-level quantification, **single-cell quantification (STARsolo: Gene / GeneFull / SJ / Velocyto features, barcode correction, UMI dedup, EmptyDrops_CR cell calling)**, WASP allele-specific filtering, paired-end mate-overlap merging, coverage-track output, adapter/CellRanger clipping, and multi-threaded parallel processing. Default SAM output is byte-identical to STAR's (`NH HI AS nM` attributes); solo count matrices are byte-identical to STARsolo's. Pure-Rust core with an in-tree deterministic RNG (no `rand` dependency). 578 tests passing (553 unit + 25 integration), 0 clippy warnings. See [Performance & Benchmarks](#performance--benchmarks) for a native three-way comparison against STARsolo and CellRanger.
 
 ## Quick Start
 
@@ -216,14 +216,18 @@ resident; the 16 GB sparse index is stable at ~54 s.</sub>
 - Gene-level read counting (`--quantMode GeneCounts` → `ReadsPerGene.out.tab`)
 - Transcriptome-coordinate SAM output (`--quantMode TranscriptomeSAM`)
 - **Single-cell quantification (STARsolo)** — `--soloType CB_UMI_Simple`, `CB_UMI_Complex` (multi-segment barcodes), and `SmartSeq` (plate-based, SE + PE); features `Gene`, `GeneFull` (pre-mRNA), `SJ`, and `Velocyto` (spliced/unspliced/ambiguous); barcode correction (`--soloCBmatchWLtype` Exact/1MM/1MM_multi/…), UMI dedup (`--soloUMIdedup` 1MM_All/1MM_CR/1MM_Directional/…), multi-gene UMI filtering, multi-mapper resolution (`--soloMultiMappers` Uniform/PropUnique/EM/Rescue), cell calling (`--soloCellFilter` CellRanger2.2/TopCells/EmptyDrops_CR), gzip output, and `Summary.csv` — writes STARsolo-compatible `Solo.out/<feature>/{raw,filtered}/{matrix.mtx, barcodes.tsv, features.tsv}`
+- WASP allele-specific-mapping filter (`--waspOutputMode SAMtag`, `--varVCFfile`) — vW/vA/vG tags, SE + PE
+- Paired-end mate-overlap merging (`--peOverlapNbasesMin`, `--peOverlapMMp`)
+- Coverage-track output (`--outWigType bedGraph` → `Signal.{Unique,UniqueMultiple}.str{1,2}.out.bg`)
+- Adapter and fixed clipping (`--clip5pNbases`, `--clip3pNbases`, `--clip3pAdapterSeq`, `--clipAdapterType` including CellRanger4 TSO + poly-A) — clipped bases soft-clipped in SAM, matching STAR's convention
 - Sparse suffix array (`--genomeSAsparseD`) for reduced index memory
 - Post-alignment read filtering (`--outFilterType BySJout`)
 - Splice junction output (`SJ.out.tab`)
 - Unmapped read output to FASTQ (`--outReadsUnmapped Fastx` → `Unmapped.out.mate1` / `mate2`)
 - Gzip-compressed FASTQ input (`--readFilesCommand zcat`)
 - Read group tags (`--outSAMattrRGline`)
-- Seeded RNG for reproducible tie-breaking (`--runRNGseed`)
-- SAM optional tags: NH, HI, AS, NM, nM, XS, jM, jI, MD
+- Deterministic in-tree RNG for reproducible tie-breaking (`--runRNGseed`; no `rand` dependency)
+- SAM optional tags: NH, HI, AS, nM, NM, XS, jM, jI, MD (default `NH HI AS nM` matches STAR; `NM` opt-in)
 - `--outSAMattributes` control (Standard/All/None/explicit list)
 - SECONDARY flag (0x100) on multi-mapper alignments
 - Configurable output limits (`--outSAMmultNmax`)

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -11,18 +11,25 @@
 #
 # Optional env vars (used by the CI release build; empty = host default):
 #   PGO_TARGET          — cargo --target triple, e.g. x86_64-unknown-linux-gnu
-#   PGO_EXTRA_RUSTFLAGS — extra rustflags composed with the PGO flags on every
-#                         build in this script, e.g. "-Ctarget-cpu=x86-64-v3"
-#                         (must be applied to BOTH the instrumented build and
-#                         the profile-use rebuild, or the training profile
-#                         reflects a different instruction-selection profile
-#                         than what ships).
+#   PGO_EXTRA_RUSTFLAGS — extra rustflags for the SHIPPED (profile-use) build,
+#                         e.g. "-Ctarget-cpu=x86-64-v4".
+#   PGO_TRAIN_EXTRA_RUSTFLAGS — extra rustflags for the INSTRUMENTED build that
+#                         is executed to collect the profile. Defaults to
+#                         PGO_EXTRA_RUSTFLAGS. Set this to a runner-executable
+#                         ISA when the ship target uses instructions the build
+#                         machine may lack: e.g. ship at x86-64-v4 (AVX-512) but
+#                         train at x86-64-v3 (AVX2), since GitHub runners do not
+#                         reliably have AVX-512 and would SIGILL (exit 132) on
+#                         the training run. PGO profiles are behavioral (block/
+#                         branch frequencies) and transfer across -Ctarget-cpu
+#                         levels, so the shipped binary is still v4-optimized.
 set -euo pipefail
 GENOME_DIR="${1:?usage: pgo-build.sh <genomeDir> <readsFastq> [nTrainReads]}"
 READS="${2:?need a training FASTQ}"
 NTRAIN="${3:-1000000}"
 PGO_TARGET="${PGO_TARGET:-}"
 PGO_EXTRA_RUSTFLAGS="${PGO_EXTRA_RUSTFLAGS:-}"
+PGO_TRAIN_EXTRA_RUSTFLAGS="${PGO_TRAIN_EXTRA_RUSTFLAGS:-$PGO_EXTRA_RUSTFLAGS}"
 PGO_DIR="$(pwd)/target/pgo-data"
 PROFDATA_BIN="$(find "$(rustc --print sysroot)" -name llvm-profdata | head -1)"
 [ -x "$PROFDATA_BIN" ] || { echo "llvm-profdata not found; run: rustup component add llvm-tools-preview"; exit 1; }
@@ -35,9 +42,9 @@ if [ -n "$PGO_TARGET" ]; then
 fi
 BIN="$BIN_DIR/rustar-aligner"
 
-echo "== PGO phase 1: build instrumented binary =="
+echo "== PGO phase 1: build instrumented binary (train flags: ${PGO_TRAIN_EXTRA_RUSTFLAGS:-none}) =="
 rm -rf "$PGO_DIR"
-RUSTFLAGS="-Cprofile-generate=$PGO_DIR $PGO_EXTRA_RUSTFLAGS" \
+RUSTFLAGS="-Cprofile-generate=$PGO_DIR $PGO_TRAIN_EXTRA_RUSTFLAGS" \
   cargo build --release "${TARGET_ARGS[@]+"${TARGET_ARGS[@]}"}"
 
 echo "== PGO phase 1: training run ($NTRAIN reads) =="
@@ -50,7 +57,7 @@ rm -rf "$TRAIN_OUT"
 echo "== PGO: merge profiles =="
 "$PROFDATA_BIN" merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"
 
-echo "== PGO phase 2: rebuild with profile =="
+echo "== PGO phase 2: rebuild with profile (ship flags: ${PGO_EXTRA_RUSTFLAGS:-none}) =="
 RUSTFLAGS="-Cprofile-use=$PGO_DIR/merged.profdata -Cllvm-args=-pgo-warn-missing-function $PGO_EXTRA_RUSTFLAGS" \
   cargo build --release "${TARGET_ARGS[@]+"${TARGET_ARGS[@]}"}"
 echo "== done: $BIN is PGO-optimized =="

--- a/src/align/read_align.rs
+++ b/src/align/read_align.rs
@@ -864,6 +864,7 @@ pub fn align_paired_read(
                     m1_orig_rev,
                     m1_orig_rev,  // no_left_ext = inner for reverse (orig_is_rev=true)
                     !m1_orig_rev, // no_right_ext = inner for forward (orig_is_rev=false)
+                    0,            // mate1
                 ) else {
                     continue;
                 };
@@ -876,6 +877,7 @@ pub fn align_paired_read(
                     m2_orig_rev,
                     m2_orig_rev,  // no_left_ext = inner for reverse (orig_is_rev=true)
                     !m2_orig_rev, // no_right_ext = inner for forward (orig_is_rev=false)
+                    1,            // mate2
                 ) else {
                     continue;
                 };
@@ -929,6 +931,7 @@ pub fn align_paired_read(
                         orig_rev,
                         false,
                         false,
+                        0, // mate1
                     ) {
                         t.is_reverse = stitch_is_reverse;
                         t.read_seq = mate1_seq.to_vec();
@@ -952,6 +955,7 @@ pub fn align_paired_read(
                         orig_rev,
                         false,
                         false,
+                        1, // mate2
                     ) {
                         t.is_reverse = !stitch_is_reverse;
                         t.read_seq = mate2_seq.to_vec();

--- a/src/align/score.rs
+++ b/src/align/score.rs
@@ -49,6 +49,9 @@ pub struct AlignmentScorer {
     pub align_spliced_mate_map_lmin_over_lmate: f64,
     /// Minimum alignment score relative to read length (outFilterScoreMinOverLread, default 0.66)
     pub out_filter_score_min_over_lread: f64,
+    /// Read-end extension policy (alignEndsType). `ext[iMate][iEnd]==true` forces
+    /// full end-to-end extension (no terminal soft-clip) of that mate/end.
+    pub align_ends_type: crate::params::AlignEndsType,
 }
 
 impl AlignmentScorer {
@@ -76,6 +79,7 @@ impl AlignmentScorer {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         }
     }
 
@@ -114,6 +118,8 @@ impl AlignmentScorer {
             align_spliced_mate_map_lmin: params.align_spliced_mate_map_lmin,
             align_spliced_mate_map_lmin_over_lmate: params.align_spliced_mate_map_lmin_over_lmate,
             out_filter_score_min_over_lread: params.out_filter_score_min_over_lread,
+            // Parsed+validated in Parameters::validate; default to Local if unset.
+            align_ends_type: params.align_ends_type.parse().unwrap_or_default(),
         }
     }
 
@@ -686,6 +692,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         // Intron from position 2, length 12 (spans positions 2-13 inclusive)
@@ -730,6 +737,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         let motif = scorer.detect_splice_motif(2, 12, &genome);
@@ -773,6 +781,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         let motif = scorer.detect_splice_motif(2, 12, &genome);
@@ -814,6 +823,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         let motif = scorer.detect_splice_motif(2, 12, &genome);
@@ -848,6 +858,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         let (score, gap_type) = scorer.score_gap(0, 5, 0, &genome);
@@ -880,6 +891,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         // Small gap (< align_intron_min) is deletion
@@ -920,6 +932,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         // Gap starting at position 2 (GT), length 26 (>= 21) is splice junction
@@ -958,6 +971,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         let annotated_score = scorer.score_annotated_junction(0, true);
@@ -997,6 +1011,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         // CT-AC motif: (1,3,0,1) — reverse complement of GT-AG
@@ -1104,6 +1119,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         // Gap of exactly 589824 starting at position 100 should be splice junction
@@ -1183,6 +1199,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         // Gap of 1001 (> 1000 max) should be deletion, not splice junction
@@ -1234,6 +1251,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         }
     }
 

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -9,6 +9,11 @@ use noodles::sam::alignment::record::cigar;
 /// Separates mate1 and mate2 fragments in the combined PE read.
 pub(crate) const PE_SPACER_BASE: u8 = 11;
 
+/// Sentinel score returned by end-to-end extension (`--alignEndsType`) when the
+/// forced extension runs into a chromosome boundary. STAR sets a large negative
+/// score here; we use it to reject the transcript in `finalize_transcript`.
+const EXTEND_TO_END_KILL: i32 = i32::MIN / 2;
+
 /// Count mismatches in an alignment by comparing read sequence to genome sequence.
 ///
 /// The read sequence is always in forward orientation. For reverse-strand alignments,
@@ -191,6 +196,7 @@ fn extend_alignment(
     p_mm_max: f64,
     index: &GenomeIndex,
     is_reverse: bool,
+    extend_to_end: bool,
 ) -> ExtendResult {
     if max_extend == 0 {
         return ExtendResult {
@@ -201,6 +207,86 @@ fn extend_alignment(
     }
 
     let genome_offset = if is_reverse { index.genome.n_genome } else { 0 };
+
+    // --alignEndsType end-to-end extension (STAR extendAlign.cpp, extendToEnd==true):
+    // force extension over the entire remaining read, scoring +1 match / -1 mismatch
+    // with no maximum-score tracking and no mismatch-limit break. Ns are free.
+    // Hitting a chromosome boundary kills the transcript (no soft-clip past the end).
+    if extend_to_end {
+        let mut score: i32 = 0;
+        let mut n_mm = 0u32;
+        let mut ext_len = 0usize;
+        for i in 0..max_extend {
+            let read_pos = if direction > 0 {
+                read_start + i
+            } else {
+                if read_start < 1 + i {
+                    break;
+                }
+                read_start - 1 - i
+            };
+            if read_pos >= read_seq.len() {
+                break;
+            }
+            let read_base = read_seq[read_pos];
+            // No extension through the inter-mate spacer.
+            if read_base == PE_SPACER_BASE {
+                break;
+            }
+            let genome_pos = if direction > 0 {
+                genome_start + i as u64
+            } else {
+                if genome_start < 1 + i as u64 {
+                    // ran off the genome start — treat as boundary kill
+                    return ExtendResult {
+                        extend_len: 0,
+                        max_score: EXTEND_TO_END_KILL,
+                        n_mismatch: n_mm_max + 1,
+                    };
+                }
+                genome_start - 1 - i as u64
+            };
+            let Some(genome_base) = index.genome.get_base(genome_pos + genome_offset) else {
+                return ExtendResult {
+                    extend_len: 0,
+                    max_score: EXTEND_TO_END_KILL,
+                    n_mismatch: n_mm_max + 1,
+                };
+            };
+            // Chromosome boundary: cannot extend to the read end here.
+            if genome_base == 5 {
+                return ExtendResult {
+                    extend_len: 0,
+                    max_score: EXTEND_TO_END_KILL,
+                    n_mismatch: n_mm_max + 1,
+                };
+            }
+            ext_len = i + 1;
+            // Ns (read or genome) carry no score.
+            if read_base == 4 || genome_base == 4 {
+                continue;
+            }
+            if read_base == genome_base {
+                score += 1;
+            } else {
+                n_mm += 1;
+                score -= 1;
+            }
+        }
+        return if ext_len > 0 {
+            ExtendResult {
+                extend_len: ext_len,
+                max_score: score,
+                n_mismatch: n_mm,
+            }
+        } else {
+            ExtendResult {
+                extend_len: 0,
+                max_score: 0,
+                n_mismatch: 0,
+            }
+        };
+    }
 
     let mut score: i32 = 0;
     let mut max_score: i32 = 0;
@@ -1125,6 +1211,7 @@ fn stitch_align_to_transcript(
             scorer.p_mm_max,
             index,
             cluster.is_reverse,
+            false, // internal stitch extension: alignEndsType applied at finalize
         );
         if right_ext.extend_len > 0 {
             let last = new_wt.exons.last_mut().unwrap();
@@ -1183,6 +1270,7 @@ fn stitch_align_to_transcript(
             scorer.p_mm_max,
             index,
             cluster.is_reverse,
+            false, // internal stitch extension: alignEndsType applied at finalize
         );
         if left_ext.extend_len > 0 {
             let last = new_wt.exons.last_mut().unwrap();
@@ -1665,11 +1753,23 @@ pub(crate) fn finalize_transcript(
     original_is_reverse: bool,
     no_left_ext: bool,
     no_right_ext: bool,
+    imate: u8,
 ) -> Option<Transcript> {
     use crate::align::transcript::Exon;
 
     let alignment_start = wt.read_start;
     let alignment_end = wt.read_end;
+
+    // --alignEndsType: decide whether each end is force-extended (no soft-clip).
+    // `read_seq` is a single mate's slice, so `original_is_reverse` here equals
+    // STAR's `(Str != imate)`: when the slice is reverse-complemented, the read's
+    // 5' end sits on the right. STAR indexes ext[imate][iEnd] with iEnd 0 = 5',
+    // 1 = 3', so the left/start end maps to `original_is_reverse` and the
+    // right/end to its complement.
+    let ext = scorer.align_ends_type.ext;
+    let mi = (imate as usize).min(1);
+    let extend_left_to_end = ext[mi][original_is_reverse as usize];
+    let extend_right_to_end = ext[mi][(!original_is_reverse) as usize];
 
     // Guard: exon positions must be within read bounds. Out-of-bounds positions can
     // arise when a combined PE read's WorkingTranscript has junction shifts that extend
@@ -1708,6 +1808,7 @@ pub(crate) fn finalize_transcript(
                 scorer.p_mm_max,
                 index,
                 cluster.is_reverse,
+                extend_left_to_end,
             )
         } else {
             zero_extend.clone()
@@ -1726,6 +1827,7 @@ pub(crate) fn finalize_transcript(
                 scorer.p_mm_max,
                 index,
                 cluster.is_reverse,
+                extend_right_to_end,
             )
         } else {
             zero_extend.clone()
@@ -1746,6 +1848,7 @@ pub(crate) fn finalize_transcript(
                 scorer.p_mm_max,
                 index,
                 cluster.is_reverse,
+                extend_right_to_end,
             )
         } else {
             zero_extend.clone()
@@ -1764,12 +1867,19 @@ pub(crate) fn finalize_transcript(
                 scorer.p_mm_max,
                 index,
                 cluster.is_reverse,
+                extend_left_to_end,
             )
         } else {
             zero_extend
         };
         (left, right)
     };
+
+    // End-to-end extension that ran into a chromosome boundary kills the
+    // transcript (STAR: no soft-clipping past the read end in EndToEnd mode).
+    if left_extend.max_score == EXTEND_TO_END_KILL || right_extend.max_score == EXTEND_TO_END_KILL {
+        return None;
+    }
 
     // STAR finalization check: exon lengths including repeat lengths (shiftSJ)
     // For non-annotated junctions: exon_len >= alignSJoverhangMin + shiftSJ[side]
@@ -2113,6 +2223,7 @@ fn stitch_recurse(
                         scorer.p_mm_max,
                         index,
                         cluster.is_reverse,
+                        false, // internal stitch extension: alignEndsType applied at finalize
                     )
                 } else {
                     zero_ext.clone()
@@ -2132,6 +2243,7 @@ fn stitch_recurse(
                         scorer.p_mm_max,
                         index,
                         cluster.is_reverse,
+                        false, // internal stitch extension: alignEndsType applied at finalize
                     )
                 } else {
                     zero_ext.clone()
@@ -2157,6 +2269,7 @@ fn stitch_recurse(
                         scorer.p_mm_max,
                         index,
                         cluster.is_reverse,
+                        false, // internal stitch extension: alignEndsType applied at finalize
                     )
                 } else {
                     zero_ext
@@ -2177,6 +2290,7 @@ fn stitch_recurse(
                         scorer.p_mm_max,
                         index,
                         cluster.is_reverse,
+                        false, // internal stitch extension: alignEndsType applied at finalize
                     )
                 } else {
                     zero_ext
@@ -2576,6 +2690,7 @@ pub(crate) fn stitch_seeds_with_jdb_debug(
             stitch_is_reverse,
             false,
             false,
+            0, // single-end read is mate 0
         ) {
             // Restore original reverse-strand flag and read sequence for SAM output.
             if stitch_is_reverse {
@@ -2873,6 +2988,7 @@ pub(crate) fn stitch_seeds_core(
                         scorer.p_mm_max,
                         index,
                         false,
+                        false, // pre-ext scoring: alignEndsType applied at finalize
                     )
                 } else {
                     zero_ext.clone()
@@ -2891,6 +3007,7 @@ pub(crate) fn stitch_seeds_core(
                         scorer.p_mm_max,
                         index,
                         false,
+                        false, // pre-ext scoring: alignEndsType applied at finalize
                     )
                 } else {
                     zero_ext.clone()
@@ -2911,6 +3028,7 @@ pub(crate) fn stitch_seeds_core(
                         scorer.p_mm_max,
                         index,
                         false,
+                        false, // pre-ext scoring: alignEndsType applied at finalize
                     )
                 } else {
                     zero_ext.clone()
@@ -2929,6 +3047,7 @@ pub(crate) fn stitch_seeds_core(
                         scorer.p_mm_max,
                         index,
                         false,
+                        false, // pre-ext scoring: alignEndsType applied at finalize
                     )
                 } else {
                     zero_ext.clone()
@@ -3213,7 +3332,7 @@ mod tests {
             0,   // no previous length
             10,  // n_mm_max
             0.3, // p_mm_max
-            &index, false, // forward strand
+            &index, false, false, // forward strand, local
         );
 
         assert_eq!(result.extend_len, 5);
@@ -3238,7 +3357,7 @@ mod tests {
             0,   // no previous length
             10,  // n_mm_max
             0.3, // p_mm_max
-            &index, false,
+            &index, false, false,
         );
 
         assert_eq!(result.extend_len, 5);
@@ -3263,7 +3382,7 @@ mod tests {
             0,   // no previous length
             10,  // n_mm_max
             0.3, // p_mm_max
-            &index, false,
+            &index, false, false,
         );
 
         // Should extend 4 bases (perfect match), then mismatches drag score down
@@ -3285,7 +3404,7 @@ mod tests {
             0, // genome_start
             1, // rightward
             5, // max_extend
-            0, 0, 10, 0.3, &index, false,
+            0, 0, 10, 0.3, &index, false, false,
         );
 
         // Should stop at 3 bases (genome boundary)
@@ -3301,7 +3420,7 @@ mod tests {
         // Read: A A C G (matches at 0, N skip at 1, matches at 2-3)
         let read_seq: Vec<u8> = vec![0, 0, 1, 2];
 
-        let result = extend_alignment(&read_seq, 0, 0, 1, 4, 0, 0, 10, 0.3, &index, false);
+        let result = extend_alignment(&read_seq, 0, 0, 1, 4, 0, 0, 10, 0.3, &index, false, false);
 
         // Should extend all 4 bases: match + N(skip) + match + match = score 3
         assert_eq!(result.extend_len, 4);
@@ -3317,7 +3436,7 @@ mod tests {
         // Read: T T T T (all 3, complete mismatch)
         let read_seq: Vec<u8> = vec![3, 3, 3, 3];
 
-        let result = extend_alignment(&read_seq, 0, 0, 1, 4, 0, 0, 10, 0.3, &index, false);
+        let result = extend_alignment(&read_seq, 0, 0, 1, 4, 0, 0, 10, 0.3, &index, false, false);
 
         // Score never goes positive, so extend_len should be 0
         assert_eq!(result.extend_len, 0);
@@ -3333,7 +3452,7 @@ mod tests {
         //       M M M X M M M M M M M M M M
         let read_seq: Vec<u8> = vec![0, 1, 2, 0, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1];
 
-        let result = extend_alignment(&read_seq, 0, 0, 1, 14, 0, 0, 10, 0.3, &index, false);
+        let result = extend_alignment(&read_seq, 0, 0, 1, 14, 0, 0, 10, 0.3, &index, false, false);
 
         // Should extend past the mismatch: 3M + 1X + 10M
         // Score: +3 -1 +10 = 12, best at position 14
@@ -3350,11 +3469,49 @@ mod tests {
 
         let result = extend_alignment(
             &read_seq, 0, 0, 1, 0, // max_extend = 0
-            0, 0, 10, 0.3, &index, false,
+            0, 0, 10, 0.3, &index, false, false,
         );
 
         assert_eq!(result.extend_len, 0);
         assert_eq!(result.max_score, 0);
+    }
+
+    #[test]
+    fn test_extend_to_end_forces_full_extension() {
+        // Genome: A C G T A C G T A C (10 bases)
+        let genome_seq = vec![0, 1, 2, 3, 0, 1, 2, 3, 0, 1];
+        let index = make_index_with_seq(&genome_seq);
+        // Read: A C G X X (2 trailing mismatches vs genome T A -> C C).
+        // Local would stop after 3 matches (soft-clip 2); EndToEnd forces all 5.
+        let read_seq: Vec<u8> = vec![0, 1, 2, 1, 1];
+
+        // Local: stops at the score peak (3M), soft-clipping the 2 mismatches.
+        let local = extend_alignment(&read_seq, 0, 0, 1, 5, 0, 0, 10, 0.3, &index, false, false);
+        assert_eq!(local.extend_len, 3, "local extension stops at score peak");
+        assert_eq!(local.max_score, 3);
+
+        // EndToEnd: forces all 5 bases; score = 3 matches - 2 mismatches = 1.
+        let e2e = extend_alignment(&read_seq, 0, 0, 1, 5, 0, 0, 10, 0.3, &index, false, true);
+        assert_eq!(e2e.extend_len, 5, "end-to-end forces full read extension");
+        assert_eq!(e2e.max_score, 1);
+        assert_eq!(e2e.n_mismatch, 2);
+    }
+
+    #[test]
+    fn test_extend_to_end_chromosome_boundary_kills() {
+        // Genome: A C G (3 bases, then padding). Read is 5 bases.
+        let genome_seq = vec![0, 1, 2];
+        let index = make_index_with_seq(&genome_seq);
+        let read_seq: Vec<u8> = vec![0, 1, 2, 3, 0];
+
+        // EndToEnd cannot reach the read end without crossing the chr boundary,
+        // so it returns the kill sentinel (extend_len 0, hugely negative score).
+        let e2e = extend_alignment(&read_seq, 0, 0, 1, 5, 0, 0, 10, 0.3, &index, false, true);
+        assert_eq!(e2e.extend_len, 0);
+        assert!(
+            e2e.max_score < -1_000_000,
+            "boundary hit kills the transcript"
+        );
     }
 
     #[test]
@@ -3386,6 +3543,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         // Left overhang (prev.length) = 3, below min of 5
@@ -3429,6 +3587,7 @@ mod tests {
             align_spliced_mate_map_lmin: 0,
             align_spliced_mate_map_lmin_over_lmate: 0.66,
             out_filter_score_min_over_lread: 0.66,
+            align_ends_type: crate::params::AlignEndsType::default(),
         };
 
         // Both overhangs >= 5

--- a/src/chimeric/detect.rs
+++ b/src/chimeric/detect.rs
@@ -662,6 +662,32 @@ pub fn detect_chimeric_old(
     params: &Parameters,
     index: &GenomeIndex,
 ) -> Result<Vec<ChimericAlignment>, Error> {
+    // SE / per-mate PE pool: no combined-read mate boundary, so diffMates never applies.
+    detect_chimeric_old_impl(
+        all_transcripts,
+        tr_best,
+        read_seq,
+        read_name,
+        params,
+        index,
+        None,
+    )
+}
+
+/// `detect_chimeric_old` with an optional combined-read mate boundary (`read_length[0]`
+/// in ro-space). When a candidate segment lies in a different mate than the primary
+/// segment (STAR's `diffMates`), the read-gap check is waived — matching
+/// `ReadAlign_chimericDetectionOld.cpp` lines 67-71.
+#[allow(clippy::too_many_arguments)]
+pub fn detect_chimeric_old_impl(
+    all_transcripts: &[Transcript],
+    tr_best: &Transcript,
+    read_seq: &[u8],
+    read_name: &str,
+    params: &Parameters,
+    index: &GenomeIndex,
+    mate_boundary: Option<usize>,
+) -> Result<Vec<ChimericAlignment>, Error> {
     let read_len = read_seq.len();
     let min_seg = params.chim_segment_min as usize;
     let score_min = params.chim_score_min;
@@ -786,10 +812,15 @@ pub fn detect_chimeric_old(
             continue;
         }
 
-        // Read gap check: the two segments must be close enough in read space
-        // (or come from different mates in PE, handled by diffMates).
-        // For SE, diffMates is never true.
-        let gap_ok = (ro_end1 + gap_max + 1 >= ro_start2) && (ro_end2 + gap_max + 1 >= ro_start1);
+        // Read gap check: the two segments must be close enough in read space —
+        // UNLESS they come from different mates (STAR's `diffMates`), in which case
+        // the inter-mate fragment gap is expected and the check is waived
+        // (ReadAlign_chimericDetectionOld.cpp:67-71). `diffMates` requires a combined
+        // read with a known mate boundary; it is always false for SE / per-mate pools.
+        let diff_mates = mate_boundary
+            .is_some_and(|b| (ro_end1 < b && ro_start2 >= b) || (ro_end2 < b && ro_start1 >= b));
+        let gap_ok = diff_mates
+            || ((ro_end1 + gap_max + 1 >= ro_start2) && (ro_end2 + gap_max + 1 >= ro_start1));
         if !gap_ok {
             continue;
         }
@@ -841,6 +872,10 @@ pub fn detect_chimeric_old(
     if chim_score_best < score_min {
         return Ok(vec![]);
     }
+    // Score-drop gate (STAR chimericDetectionOld.cpp:99, `readLength[0]+readLength[1]`).
+    // `read_len` is the length of the read passed in, so this scales correctly for both
+    // modes: per-mate length for the per-mate PE pools (an intra-mate chimera spans one
+    // mate), and the combined length when a combined read is supplied via `mate_boundary`.
     if chim_score_best + score_drop_max < read_len as i32 {
         return Ok(vec![]);
     }
@@ -1417,5 +1452,44 @@ mod tests {
                 .unwrap();
         // Score drop filter: 100 + 5 >= 100 → passes; uniqueness: score_separation=200, next=-inf → passes
         assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_detect_chimeric_old_diff_mates_waives_gap() {
+        // Combined read len 100, mate boundary at 50: mate1=[0..50), mate2=[50..100).
+        // Primary covers read[0..40] (mate1, chr0); partner covers read[60..100] (mate2, chr1).
+        // The 20bp inter-segment gap exceeds chimSegmentReadGapMax (0), so the standard
+        // gap check fails — but the segments are in different mates, so STAR's diffMates
+        // waives it. Without a mate boundary the chimera is rejected; with one it is found.
+        let params = params(&[
+            "--chimSegmentMin",
+            "15",
+            "--chimScoreDropMax",
+            "100",
+            "--chimScoreSeparation",
+            "200",
+            "--chimJunctionOverhangMin",
+            "10",
+        ]);
+        let index = make_test_index();
+        let read_len = 100usize;
+        let t_main = make_clipped_transcript(0, 0, false, read_len, 0, 60); // read[0..40], mate1
+        let t_partner = make_clipped_transcript(1, 0, false, read_len, 60, 0); // read[60..100], mate2
+        let all = vec![t_main.clone(), t_partner];
+        let read_seq = read_seq_n(read_len);
+
+        // No boundary (SE / per-mate pool): gap check enforced → rejected.
+        let without = detect_chimeric_old(&all, &t_main, &read_seq, "r", &params, &index).unwrap();
+        assert!(
+            without.is_empty(),
+            "gap check should reject without diffMates"
+        );
+
+        // Combined read with mate boundary at 50: diffMates waives the gap → chimera found.
+        let with =
+            detect_chimeric_old_impl(&all, &t_main, &read_seq, "r", &params, &index, Some(50))
+                .unwrap();
+        assert_eq!(with.len(), 1, "diffMates should waive the inter-mate gap");
+        assert_ne!(with[0].donor.chr_idx, with[0].acceptor.chr_idx);
     }
 }

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -106,6 +106,54 @@ impl std::fmt::Display for IntronMotifFilter {
 }
 
 // ---------------------------------------------------------------------------
+// Read-end alignment type (alignEndsType)
+// ---------------------------------------------------------------------------
+
+/// Read-end extension policy (`--alignEndsType`). Mirrors STAR's
+/// `alignEndsType.ext[iMate][iEnd]` boolean matrix, where `iEnd == 0` is the
+/// read 5' end and `iEnd == 1` the 3' end. `true` forces full end-to-end
+/// extension of that end (no terminal soft-clip); `false` is local alignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlignEndsType {
+    /// `ext[iMate][iEnd]`: force full extension of mate `iMate`'s `iEnd` end.
+    pub ext: [[bool; 2]; 2],
+}
+
+impl Default for AlignEndsType {
+    /// `Local` — no forced extension on any end.
+    fn default() -> Self {
+        Self {
+            ext: [[false; 2]; 2],
+        }
+    }
+}
+
+impl std::str::FromStr for AlignEndsType {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // STAR Parameters.cpp: ext[iMate][iEnd], iEnd 0 = 5', 1 = 3'.
+        let mut ext = [[false; 2]; 2];
+        match s {
+            "Local" => {}
+            "EndToEnd" => ext = [[true, true], [true, true]],
+            "Extend5pOfRead1" => ext[0][0] = true,
+            "Extend5pOfReads12" => {
+                ext[0][0] = true;
+                ext[1][0] = true;
+            }
+            "Extend3pOfRead1" => ext[0][1] = true,
+            other => {
+                return Err(format!(
+                    "unknown/unimplemented value for --alignEndsType: '{other}'; expected \
+                     'Local', 'EndToEnd', 'Extend5pOfRead1', 'Extend5pOfReads12', or 'Extend3pOfRead1'"
+                ));
+            }
+        }
+        Ok(Self { ext })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Intron strand filter enum
 // ---------------------------------------------------------------------------
 
@@ -587,6 +635,12 @@ pub struct Parameters {
     #[arg(long = "outSAMstrandField", default_value = "None")]
     pub out_sam_strand_field: String,
 
+    /// SAM output order: `Paired` (default) or `PairedKeepInputOrder`. rustar-aligner
+    /// always emits records in input (FASTQ) order regardless of thread count, so both
+    /// values behave identically; the flag is accepted for STAR/pipeline compatibility.
+    #[arg(long = "outSAMorder", default_value = "Paired")]
+    pub out_sam_order: String,
+
     /// SAM optional-tag set (`Standard`, `All`, `None`, or any combination
     /// of NH HI AS NM nM MD jM jI XS RG). Parsed into a bitflags struct.
     #[command(flatten)]
@@ -728,6 +782,12 @@ pub struct Parameters {
     /// Max genomic distance between mates; 0 = auto
     #[arg(long = "alignMatesGapMax", default_value_t = 0)]
     pub align_mates_gap_max: u32,
+
+    /// Read-end alignment mode: `Local` (default, soft-clip allowed),
+    /// `EndToEnd` (force full extension, no soft-clip), `Extend5pOfRead1`,
+    /// `Extend5pOfReads12`, or `Extend3pOfRead1`.
+    #[arg(long = "alignEndsType", default_value = "Local")]
+    pub align_ends_type: String,
 
     /// Min overlap (bases) between mates required to trigger merge-and-realign; 0 = off
     #[arg(long = "peOverlapNbasesMin", default_value_t = 0)]
@@ -1456,6 +1516,23 @@ impl Parameters {
             params.out_sam_attributes |= SamAttributes::XS;
         } else {
             params.out_sam_attributes.remove(SamAttributes::XS);
+        }
+
+        // --alignEndsType: reject unknown/unimplemented values up front.
+        if let Err(msg) = params.align_ends_type.parse::<AlignEndsType>() {
+            return Err(command.error(ErrorKind::InvalidValue, msg));
+        }
+
+        // --outSAMorder: rustar-aligner always preserves input order, so both STAR
+        // values are accepted and behave identically. Reject anything else.
+        if params.out_sam_order != "Paired" && params.out_sam_order != "PairedKeepInputOrder" {
+            return Err(command.error(
+                ErrorKind::InvalidValue,
+                format!(
+                    "unknown --outSAMorder '{}'; expected 'Paired' or 'PairedKeepInputOrder'",
+                    params.out_sam_order
+                ),
+            ));
         }
 
         // quantMode TranscriptomeSAM requires transcript annotations —
@@ -2466,6 +2543,53 @@ mod tests {
         assert!(parse_mem_bytes("1X").is_err());
         assert!(parse_mem_bytes("").is_err());
         assert!(parse_mem_bytes("-1G").is_err());
+    }
+
+    #[test]
+    fn align_ends_type_parses_ext_matrix() {
+        use std::str::FromStr;
+        assert_eq!(
+            AlignEndsType::from_str("Local").unwrap().ext,
+            [[false; 2]; 2]
+        );
+        assert_eq!(
+            AlignEndsType::from_str("EndToEnd").unwrap().ext,
+            [[true, true], [true, true]]
+        );
+        assert_eq!(
+            AlignEndsType::from_str("Extend5pOfRead1").unwrap().ext,
+            [[true, false], [false, false]]
+        );
+        assert_eq!(
+            AlignEndsType::from_str("Extend5pOfReads12").unwrap().ext,
+            [[true, false], [true, false]]
+        );
+        assert_eq!(
+            AlignEndsType::from_str("Extend3pOfRead1").unwrap().ext,
+            [[false, true], [false, false]]
+        );
+        assert!(AlignEndsType::from_str("Bogus").is_err());
+    }
+
+    #[test]
+    fn out_sam_order_accepts_star_values_rejects_others() {
+        assert!(try_parse(&["--readFilesIn", "r.fq", "--outSAMorder", "Paired"]).is_ok());
+        assert!(
+            try_parse(&[
+                "--readFilesIn",
+                "r.fq",
+                "--outSAMorder",
+                "PairedKeepInputOrder"
+            ])
+            .is_ok()
+        );
+        assert!(try_parse(&["--readFilesIn", "r.fq", "--outSAMorder", "Nope"]).is_err());
+    }
+
+    #[test]
+    fn align_ends_type_rejected_at_cli() {
+        assert!(try_parse(&["--readFilesIn", "r.fq", "--alignEndsType", "EndToEnd"]).is_ok());
+        assert!(try_parse(&["--readFilesIn", "r.fq", "--alignEndsType", "Bogus"]).is_err());
     }
 
     #[test]

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -2184,6 +2184,56 @@ mod tests {
     }
 
     #[test]
+    fn project_two_exon_align_onto_reverse_strand_transcript() {
+        // Regression coverage for the multi-exon minus-strand projection flip
+        // (STAR canonSJ == -999 branch): exon order must reverse, t-space and read
+        // coords must invert relative to transcript/read length, and N ops drop.
+        use cigar::op::{Kind, Op};
+        let genome = make_genome();
+        // Reverse transcript T1: chr1 [100,200) + [300,400) - strand. tr_length = 200.
+        let gtf = vec![
+            make_exon("chr1", 101, 200, '-', "G1", "T1"),
+            make_exon("chr1", 301, 400, '-', "G1", "T1"),
+        ];
+        let idx = TranscriptomeIndex::from_gtf_exons(&gtf, &genome).unwrap();
+
+        // Spliced align (forward on genome), junction matches the transcript junction:
+        // genome [150,200) + [300,350); read [0,50) + [50,100).
+        let align = make_align(
+            0,
+            false,
+            vec![(150, 200, 0, 50), (300, 350, 50, 100)],
+            vec![
+                Op::new(Kind::Match, 50),
+                Op::new(Kind::Skip, 100),
+                Op::new(Kind::Match, 50),
+            ],
+        );
+        let results = align_to_transcripts(&align, &idx, 100);
+        assert_eq!(results.len(), 1);
+        let r = &results[0];
+
+        // Strand flips (tr_strand == 2, align.is_reverse == false → projected true).
+        assert!(r.is_reverse);
+        assert_eq!(r.exons.len(), 2);
+        // Pre-flip t-space exons: [50,100) r[0,50) and [100,150) r[50,100).
+        // Flip (tr_len=200, lread=100) then reverse exon order:
+        //   old exon1 [100,150) → g 200-(100+50)=50 → [50,100),  r 100-(50+50)=0 → [0,50)
+        //   old exon0 [50,100)  → g 200-(50+50)=100 → [100,150), r 100-(0+50)=50 → [50,100)
+        assert_eq!(r.exons[0].genome_start, 50);
+        assert_eq!(r.exons[0].genome_end, 100);
+        assert_eq!(r.exons[0].read_start, 0);
+        assert_eq!(r.exons[0].read_end, 50);
+        assert_eq!(r.exons[1].genome_start, 100);
+        assert_eq!(r.exons[1].genome_end, 150);
+        assert_eq!(r.exons[1].read_start, 50);
+        assert_eq!(r.exons[1].read_end, 100);
+        // N stripped, two M blocks remain.
+        assert!(r.cigar.iter().all(|op| op.kind() != Kind::Skip));
+        assert_eq!(r.cigar.len(), 2);
+    }
+
+    #[test]
     fn project_multi_exon_align_onto_longer_transcript() {
         use cigar::op::{Kind, Op};
         let genome = make_genome();


### PR DESCRIPTION
# STAR-compat batch (`--alignEndsType`, `--outSAMorder`, chimeric/transcriptome) + PGO CI fix

Works through five STAR-faithfulness items surfaced in an older deep-dive review, plus fixes the flaky `linux-x86_64-v4` release build. Two logically independent changesets on one branch — split into two commits if you'd rather land the CI fix on its own.

**Gate (whole branch):** 560 lib + 26 integration = **586 tests pass** · `clippy --all-targets` **0 warnings** · `fmt` clean. Yeast **SE Local 8788/8926** and **PE 8390 both-mapped / 0 half-mapped** — identical to baseline.

---

## Part 1 — STAR-compatibility batch

### 1. `--alignEndsType` (read-end extension mode)
Implements `Local` (default), `EndToEnd`, `Extend5pOfRead1`, `Extend5pOfReads12`, `Extend3pOfRead1` — STAR's `alignEndsType.ext[iMate][iEnd]` boolean matrix (`Parameters.cpp`, `extendAlign.cpp`, `stitchWindowAligns.cpp`).

- `extend_alignment` gains an `extend_to_end` branch that forces extension over the full remaining read (no max-score tracking, no mismatch-limit break; chromosome-boundary hit kills the transcript), matching STAR's `extendToEnd` path.
- `finalize_transcript` derives per-end flags from `ext[imate][iEnd]`. Because it runs per-mate-slice, `original_is_reverse` equals STAR's `(Str != iMate)`, so the mapping reduces to `ext[imate][is_reverse]` (start) / `ext[imate][!is_reverse]` (end). Internal stitch extensions stay Local; forcing is applied only at the read-end extension (additive scoring makes deferring to `finalize` equivalent to STAR's in-stitch forcing).

**Validation:** Local default **byte-identical to baseline** (SE 8788/8926, PE 8390/0). `--alignEndsType EndToEnd` vs STAR `--alignEndsType EndToEnd` on 10k yeast: **98.4% position agreement** (7924/8054), rustar 8821 vs STAR 8817 mapped — at parity with Local's tie character. +2 unit tests (`test_extend_to_end_*`).

### 2. `--outSAMorder`
**`--outSAMorder`** (`Paired` | `PairedKeepInputOrder`). rustar's align pipeline already emits records in **exact input (FASTQ) order regardless of thread count** (verified empirically on a 4-thread run — identical ordering). The flag is now accepted (both values, effectively a no-op) for STAR/pipeline compatibility; unknown values are rejected. +3 param tests.

### 3. PE chimeric `diffMates` gap relaxation
The specific "gap check wrongly filters inter-mate chimeras" claim doesn't hold under rustar's architecture: `detect_chimeric_old` runs strictly **per-mate**, and inter-mate is handled by `detect_inter_mate_chimeric`, which imposes **no** inter-mate read-gap. Still made the function STAR-faithful: `detect_chimeric_old_impl` gains an optional `mate_boundary` and waives the read-gap across it (STAR `ReadAlign_chimericDetectionOld.cpp:67-71`). The public `detect_chimeric_old` and all per-mate callers pass `None` — **zero behavior change**. +1 unit test asserting the gap is enforced without a boundary and waived with one.

### 4. Chimeric score-drop `read_len` (verify)
Verified self-consistent, no fix needed: the score-drop gate uses the length of the read passed in, so it scales correctly for both modes — per-mate length for rustar's PE pools (an intra-mate chimera spans one mate) and combined length for a combined read (matching STAR's `readLength[0]+readLength[1]`). Added a clarifying comment.

### 5. Multi-exon minus-strand transcriptome projection (test gap)
Added the missing regression test for a 2-exon reverse-strand transcript projection (`align_to_one_transcript` `tr_strand==2` branch): exon-order reversal, t-space/read-coord inversion relative to transcript/read length, and N-op stripping. **Passes first try — the projection code was already correct.**

---

## Part 2 — CI fix: flaky `linux-x86_64-v4` (and preventive `neoverse-v1`)

**Symptom:** the `linux-x86_64-v4` release job intermittently died with `Illegal instruction (core dumped)` / exit **132** in the PGO training run; re-running sometimes passed.

**Cause:** the PGO *instrumented* binary was built at the shipped ISA (`-Ctarget-cpu=x86-64-v4`, AVX-512) and then **executed** to collect the profile. GitHub's `ubuntu-latest` runners don't reliably have AVX-512, so on a non-AVX-512 runner the training run hit an AVX-512 instruction and SIGILL'd — flaky by which runner the job landed on.

**Fix:** decouple the training ISA from the shipped ISA. `scripts/pgo-build.sh` gains `PGO_TRAIN_EXTRA_RUSTFLAGS` (defaults to `PGO_EXTRA_RUSTFLAGS`), applied to the instrumented build only. The release matrix trains at a runner-safe ISA and ships at the optimized one:

| target | train ISA | ship ISA |
|--------|-----------|----------|
| `linux-x86_64-v4` | `x86-64-v3` (AVX2) | `x86-64-v4` (AVX-512) |
| `linux-aarch64-neoverse-v1` | `generic` (armv8-a) | `neoverse-v1` (SVE) |

PGO profiles are behavioral (block/branch frequencies) and transfer across `-Ctarget-cpu` levels, so the shipped binaries remain fully optimized. The `neoverse-v1` entry gets the same split preventively — identical failure mode on any non-SVE aarch64 runner.

**Validation:** ran a full local `train=v3 / ship=v4` PGO cycle — completes, ships a working v4-optimized binary (the `-pgo-warn-missing-function` notices are the expected benign cross-ISA function mismatches). `rustc` confirmed to accept `-Ctarget-cpu=generic` for aarch64; workflow re-validated as valid YAML.

---

## Files
- `src/params/mod.rs` — `AlignEndsType` type + `--alignEndsType`/`--outSAMorder` params, validation, tests
- `src/align/score.rs` — `align_ends_type` on `AlignmentScorer`
- `src/align/stitch.rs` — `extend_to_end` branch, `finalize_transcript` ext-flag wiring, tests
- `src/align/read_align.rs` — per-mate `imate` args to `finalize_transcript`
- `src/chimeric/detect.rs` — `detect_chimeric_old_impl` + `diffMates`, score-drop comment, test
- `src/quant/transcriptome.rs` — multi-exon minus-strand projection test
- `scripts/pgo-build.sh`, `.github/workflows/release.yml` — PGO train/ship ISA split
- `README.md` — `--alignEndsType` and input-order/`--outSAMorder` feature bullets