### PR TITLE
solo: EmptyDrops_CR on CellRanger's actual statistics (SGT ambient profile, libc++ sampler)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,16 @@ Sections commonly used: Features, Bug fixes, Other changes.
   glibc's malloc and per-thread heaps that return whole segments to
   the OS when abandoned, so allocator cache size stays bounded.
 
+- **`--soloCellFilter EmptyDrops_CR` now uses CellRanger's actual
+  statistics.** The ambient profile is smoothed with Simple Good-Turing,
+  as CellRanger and STAR do, instead of an approximation that reserved
+  unseen mass from the singleton rate and spread the remainder in
+  proportion to raw counts. The Monte-Carlo null is drawn with libc++'s
+  `std::mt19937` and `std::discrete_distribution`, seeded
+  `19760110 * (isim + 1)` per simulation as STAR seeds it, replacing a
+  SplitMix64 stream that could not agree with STAR's over an arbitrary
+  number of draws. Cell calls move as a result.
+
 ### Bug fixes
 
 - **STARsolo `Gene` assignment now requires exon concordance**, matching

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -79,6 +79,18 @@ For `--quantMode TranscriptomeSAM`, rustar-aligner builds the per-transcript exo
 
 rustar-aligner uses an in-tree splitmix64 (`src/rng.rs`) rather than the `rand` crate, avoiding the `getrandom`/`zerocopy`/`ppv-lite86` dependency chain. This is the generator underlying §1.1; it is called out separately because it is a dependency/implementation choice independent of the tie-break policy.
 
+### 1.2 `EmptyDrops_CR` Simple-Good-Turing with fewer than five distinct frequencies
+
+**What STAR does.** The ambient profile for `--soloCellFilter EmptyDrops_CR` is smoothed with Simple Good-Turing (Elworthy's `SimpleGoodTuring/sgt.h`). `analyse()` returns early, doing nothing, when the frequency spectrum has fewer than five distinct counts — Elworthy's `MinInput` guard. `PZero`, the mass reserved for genes unseen in the ambient droplets, is neither assigned in that case nor initialised at construction, so a caller that asks for it reads whatever the stack held.
+
+**What rustar-aligner does.** `PZero` is zero from construction.
+
+**Why.** There is nothing to reproduce: the value STAR reads is not a decision it made. With fewer than five distinct frequencies there is no basis for reserving unseen mass, and zero says so. Reproducing STAR would mean writing code whose correct behaviour is to emit an uninitialised value, and a test asserting it.
+
+**Impact.** Degenerate inputs only — any dataset large enough to reach the significance test has far more than five distinct frequencies. On those inputs an uninitialised read can place arbitrary mass on unseen genes, which makes the multinomial log-probabilities meaningless; zero keeps them defined.
+
+**Source.** `src/solo/sgt.rs`, locked by `solo::sgt::tests::too_few_frequencies_leaves_the_unseen_mass_at_zero` (asserting the exact bit pattern, since the point is that nothing was written). STAR: `SoloFeature_emptyDrops_CR.cpp`, `SimpleGoodTuring/sgt.h`.
+
 ---
 
 ## 5. Known residual single-read differences

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -959,20 +959,60 @@ fn emptydrops_called(
         return Ok(called);
     }
 
-    // Ambient probabilities with a Good-Turing P0 unseen-mass correction.
-    let n1 = ambient.iter().filter(|&&x| (x - 1.0).abs() < 0.5).count() as f64;
-    let p0 = (n1 / amb_total).clamp(1e-12, 0.5);
-    let n_zero = ambient.iter().filter(|&&x| x == 0.0).count().max(1) as f64;
-    let amb_p: Vec<f64> = ambient
-        .iter()
-        .map(|&x| {
-            if x > 0.0 {
-                (1.0 - p0) * x / amb_total
-            } else {
-                p0 / n_zero
+    // Ambient probabilities, smoothed by Simple Good-Turing as CellRanger's
+    // EmptyDrops_CR does. The raw ambient counts are a small sample, so a gene
+    // seen twice there is not twice as likely as one seen once; SGT fits the
+    // frequency spectrum and reserves mass for genes the sample missed
+    // entirely. The previous approximation here reserved mass from the
+    // singleton rate alone and spread the rest in proportion to raw counts,
+    // which is the right shape but the wrong numbers.
+    let amb_p: Vec<f64> = {
+        // Frequency of frequencies over the integer ambient counts.
+        let counts: Vec<u32> = ambient.iter().map(|&x| x as u32).collect();
+        let mut fof: std::collections::BTreeMap<u32, u32> = std::collections::BTreeMap::new();
+        for &c in &counts {
+            *fof.entry(c).or_insert(0) += 1;
+        }
+        let n_zero = fof.get(&0).copied().unwrap_or(0);
+
+        let mut sgt = crate::solo::sgt::Sgt::new();
+        for (&freq, &n) in &fof {
+            if freq != 0 {
+                sgt.add(freq, n);
             }
-        })
-        .collect();
+        }
+        let fitted = sgt.analyse();
+
+        // Per-gene probability. A gene absent from the ambient set shares the
+        // reserved unseen mass; one present takes its smoothed estimate. When
+        // the spectrum is too small to fit (D17), there is no reserved mass and
+        // the raw proportions are all that is left.
+        let unseen_each = if n_zero > 0 {
+            sgt.pzero() / f64::from(n_zero)
+        } else {
+            0.0
+        };
+        let raw: Vec<f64> = counts
+            .iter()
+            .map(|&c| {
+                if c == 0 {
+                    unseen_each
+                } else if fitted {
+                    sgt.estimate(c).unwrap_or(f64::from(c) / amb_total)
+                } else {
+                    f64::from(c) / amb_total
+                }
+            })
+            .collect();
+        // Renormalise: the smoothed estimates are per-event probabilities and
+        // only sum to one over the whole spectrum, not over this gene set.
+        let total: f64 = raw.iter().sum();
+        if total > 0.0 {
+            raw.into_iter().map(|p| p / total).collect()
+        } else {
+            raw
+        }
+    };
     let amb_logp: Vec<f64> = amb_p.iter().map(|&p| p.max(1e-300).ln()).collect();
 
     // Observed multinomial log-prob per candidate.
@@ -1004,17 +1044,17 @@ fn emptydrops_called(
     // log-prob at each count; compare each candidate against sim[*][its total].
     let nonzero: Vec<usize> = (0..n_features).filter(|&g| amb_p[g] > 0.0).collect();
     let weights: Vec<f64> = nonzero.iter().map(|&g| amb_p[g]).collect();
-    // Ambient categorical sampler: cumulative weights + splitmix64 (crate::rng).
-    // WeightedIndex-equivalent; empirically byte-identical EmptyDrops cell calls.
-    let cumulative = crate::rng::cumulative_weights(&weights);
-    // Each simulation is an independent ambient random walk. Seed a dedicated RNG
-    // per simulation (splitmix-derived from the base seed) so the result is
-    // deterministic regardless of how the work is scheduled across threads, then
-    // run the simulations in parallel. Each walk records the running log-prob at
-    // every count level; `walks[s][k]` is the log-prob of simulation `s` after `k`
-    // draws. (This matches STAR's per-thread-RNG approach; the per-sim seeding
-    // gives different draws than a single sequential stream, but the same
-    // distribution — p-values are stable to Monte-Carlo error.)
+    // The ambient sampler is STAR's, which is libc++'s: `std::mt19937` drawn
+    // through `std::discrete_distribution`. Both are implementation-defined in
+    // the parts that decide which category a draw lands in, so "a correct
+    // categorical sampler" is not enough to reproduce STAR's cell calls —
+    // it has to be that one. See `solo::libcxx_rng`.
+    let dist = crate::solo::libcxx_rng::DiscreteDistribution::new(&weights);
+    // A fresh generator per simulation, seeded `19760110 * (isim + 1)` as STAR
+    // seeds it. No shared state, so the walks can run in any order and on any
+    // number of threads and still produce the same p-values. Each walk records
+    // the running log-prob at every count level; `walks[s][k]` is simulation
+    // `s` after `k` draws.
     use rayon::prelude::*;
     const BASE_SEED: u64 = 19_760_110;
     let walks: Vec<Vec<f64>> = (0..sim_n)
@@ -1022,14 +1062,14 @@ fn emptydrops_called(
         .map_init(
             || (vec![0u32; n_features], Vec::<usize>::new()),
             |(curr, touched), s| {
-                let seed = BASE_SEED ^ (s as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
-                let mut rng = crate::rng::SplitMix64::seed(seed);
+                let seed = BASE_SEED.wrapping_mul(s as u64 + 1) as u32;
+                let mut rng = crate::solo::libcxx_rng::Mt19937::new(seed);
                 touched.clear();
                 let mut walk = Vec::with_capacity(max_count + 1);
                 walk.push(0.0);
                 let mut lp = 0f64;
                 for ic in 1..=max_count {
-                    let gi = nonzero[crate::rng::sample_cumulative(&cumulative, &mut rng)];
+                    let gi = nonzero[dist.sample(&mut rng)];
                     if curr[gi] == 0 {
                         touched.push(gi);
                     }

--- a/src/solo/libcxx_rng.rs
+++ b/src/solo/libcxx_rng.rs
@@ -1,0 +1,219 @@
+//! Bit-exact ports of the three libc++ random facilities STARsolo's
+//! `EmptyDrops_CR` depends on.
+//!
+//! STAR's Monte-Carlo rescue draws from `std::mt19937`, converts to doubles
+//! with `std::generate_canonical<double, 53>`, and samples categories with
+//! `std::discrete_distribution`. All three are implementation-defined in the
+//! parts that matter: the standard fixes `mt19937`'s output but not how
+//! `generate_canonical` consumes it, and says nothing about how
+//! `discrete_distribution` maps a uniform draw onto categories. So "port the
+//! algorithm" is not enough — it has to be *libc++'s* algorithm, because that
+//! is what STAR was built against and what its numbers come out of.
+//!
+//! Every value asserted in the tests below was produced by compiling a C++
+//! program against the real libc++ and printing the results, not derived from
+//! reading the source. That is the only way to be sure.
+//!
+//! `solo::count` currently samples with a `SplitMix64` stream, under a comment
+//! calling it "WeightedIndex-equivalent; empirically byte-identical EmptyDrops
+//! cell calls". That claim cannot hold in general: two unrelated generators
+//! cannot agree on an arbitrary number of draws, so it is true of the cases
+//! that happened to be checked and unknown everywhere else. These types remove
+//! the guesswork. Wiring them into the EmptyDrops path is the next step and is
+//! deliberately separate, since it moves cell calls.
+
+/// libc++'s `std::mt19937`.
+///
+/// The standard Mersenne Twister, whose output sequence is fixed by the
+/// standard, so this part is portable rather than libc++-specific. It is here
+/// because the two facilities that follow are not.
+#[derive(Debug, Clone)]
+pub struct Mt19937 {
+    state: [u32; Self::N],
+    index: usize,
+}
+
+impl Mt19937 {
+    const N: usize = 624;
+    const M: usize = 397;
+    const MATRIX_A: u32 = 0x9908_b0df;
+    const UPPER_MASK: u32 = 0x8000_0000;
+    const LOWER_MASK: u32 = 0x7fff_ffff;
+
+    /// Seed exactly as `std::mt19937(seed)` does.
+    pub fn new(seed: u32) -> Self {
+        let mut state = [0u32; Self::N];
+        state[0] = seed;
+        for i in 1..Self::N {
+            state[i] = 1_812_433_253u32
+                .wrapping_mul(state[i - 1] ^ (state[i - 1] >> 30))
+                .wrapping_add(i as u32);
+        }
+        Self {
+            state,
+            index: Self::N,
+        }
+    }
+
+    /// One draw, equivalent to `operator()`.
+    pub fn next_u32(&mut self) -> u32 {
+        if self.index >= Self::N {
+            self.twist();
+        }
+        let mut y = self.state[self.index];
+        self.index += 1;
+        y ^= y >> 11;
+        y ^= (y << 7) & 0x9d2c_5680;
+        y ^= (y << 15) & 0xefc6_0000;
+        y ^= y >> 18;
+        y
+    }
+
+    fn twist(&mut self) {
+        for i in 0..Self::N {
+            let y = (self.state[i] & Self::UPPER_MASK)
+                | (self.state[(i + 1) % Self::N] & Self::LOWER_MASK);
+            let mut next = self.state[(i + Self::M) % Self::N] ^ (y >> 1);
+            if y & 1 != 0 {
+                next ^= Self::MATRIX_A;
+            }
+            self.state[i] = next;
+        }
+        self.index = 0;
+    }
+
+    /// libc++'s `std::generate_canonical<double, 53>`.
+    ///
+    /// This is where implementations diverge. libc++ computes
+    /// `k = max(1, ceil(53 / log2(2^32)))`, which is 2, then accumulates two
+    /// draws in *ascending* significance and divides by `2^64`. A
+    /// most-significant-first accumulation, or a single draw scaled to 53 bits,
+    /// both give plausible uniforms and neither reproduces STAR.
+    pub fn canonical_f64(&mut self) -> f64 {
+        // r = 2^32, k = 2, so the base is r^k = 2^64.
+        let base = 2f64.powi(64);
+        let mut sum = 0f64;
+        let mut factor = 1f64;
+        for _ in 0..2 {
+            sum += f64::from(self.next_u32()) * factor;
+            factor *= 2f64.powi(32);
+        }
+        sum / base
+    }
+}
+
+/// libc++'s `std::discrete_distribution`.
+///
+/// Stores the cumulative distribution normalised to 1, draws a uniform via
+/// [`Mt19937::canonical_f64`], and returns the first index whose cumulative
+/// probability exceeds it. The final category is the fallback, so a draw of
+/// exactly 1.0 cannot fall off the end.
+#[derive(Debug, Clone)]
+pub struct DiscreteDistribution {
+    /// Cumulative probabilities, excluding the final 1.0.
+    cumulative: Vec<f64>,
+}
+
+impl DiscreteDistribution {
+    /// Build from unnormalised weights, as `discrete_distribution(w)` does.
+    pub fn new(weights: &[f64]) -> Self {
+        let total: f64 = weights.iter().sum();
+        let mut cumulative = Vec::with_capacity(weights.len().saturating_sub(1));
+        let mut acc = 0f64;
+        // libc++ stores n-1 boundaries: the last category needs none.
+        for w in weights.iter().take(weights.len().saturating_sub(1)) {
+            acc += w;
+            cumulative.push(if total > 0.0 { acc / total } else { 0.0 });
+        }
+        Self { cumulative }
+    }
+
+    /// One sample.
+    pub fn sample(&self, rng: &mut Mt19937) -> usize {
+        let u = rng.canonical_f64();
+        self.cumulative.partition_point(|&c| c <= u)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Every expected value here came out of a C++ program compiled against the
+    // real libc++ (`clang++ -stdlib=libc++`), not from reading its source.
+
+    #[test]
+    fn mt19937_matches_libcxx_stream() {
+        let mut g = Mt19937::new(19_760_110);
+        let got: Vec<u32> = (0..10).map(|_| g.next_u32()).collect();
+        assert_eq!(
+            got,
+            vec![
+                2_116_612_583,
+                978_492_435,
+                3_413_959_089,
+                853_152_524,
+                3_057_288_333,
+                81_846_811,
+                724_235_003,
+                450_930_519,
+                3_920_508_463,
+                4_192_617_403,
+            ]
+        );
+    }
+
+    #[test]
+    fn generate_canonical_matches_libcxx_bit_for_bit() {
+        let mut g = Mt19937::new(19_760_110);
+        // Bit patterns rather than decimal literals: the decimal forms carry
+        // more digits than an f64 holds, and the point is that the double is
+        // identical down to the last place. A difference there changes which
+        // category a sample lands in.
+        let expected: [u64; 5] = [
+            0x3fcd_294e_09bf_1479, // 0.22782302356623399
+            0x3fc9_6d09_8665_be71, // 0.19864005148291455
+            0x3f93_8388_6ed8_ea12, // 0.019056445851882549
+            0x3fba_e0a7_572b_2af3, // 0.10499044302120435
+            0x3fef_3cc8_777d_35c7, // 0.97616980874743653
+        ];
+        for (i, &want) in expected.iter().enumerate() {
+            let got = g.canonical_f64();
+            assert_eq!(
+                got.to_bits(),
+                want,
+                "draw {i}: got {got:.17}, libc++ gives {:.17}",
+                f64::from_bits(want)
+            );
+        }
+    }
+
+    #[test]
+    fn discrete_distribution_matches_libcxx_integer_weights() {
+        let mut g = Mt19937::new(19_760_110);
+        let d = DiscreteDistribution::new(&[1.0, 2.0, 3.0, 4.0]);
+        let got: Vec<usize> = (0..20).map(|_| d.sample(&mut g)).collect();
+        assert_eq!(
+            got,
+            vec![1, 1, 0, 1, 3, 3, 0, 3, 3, 3, 2, 1, 1, 3, 3, 1, 3, 0, 3, 2]
+        );
+    }
+
+    #[test]
+    fn a_single_category_always_wins() {
+        let mut g = Mt19937::new(1);
+        let d = DiscreteDistribution::new(&[5.0]);
+        for _ in 0..8 {
+            assert_eq!(d.sample(&mut g), 0);
+        }
+    }
+
+    #[test]
+    fn zero_weight_categories_are_never_drawn() {
+        let mut g = Mt19937::new(42);
+        let d = DiscreteDistribution::new(&[0.0, 1.0, 0.0]);
+        for _ in 0..64 {
+            assert_eq!(d.sample(&mut g), 1);
+        }
+    }
+}

--- a/src/solo/mod.rs
+++ b/src/solo/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod count;
 pub mod gene;
+pub mod libcxx_rng;
 pub mod smartseq;
 pub mod whitelist;
 

--- a/src/solo/mod.rs
+++ b/src/solo/mod.rs
@@ -12,6 +12,7 @@
 pub mod count;
 pub mod gene;
 pub mod libcxx_rng;
+pub mod sgt;
 pub mod smartseq;
 pub mod whitelist;
 

--- a/src/solo/sgt.rs
+++ b/src/solo/sgt.rs
@@ -1,0 +1,273 @@
+//! Simple Good-Turing frequency estimation, as CellRanger's `EmptyDrops_CR`
+//! and STAR's port of it use for the ambient profile.
+//!
+//! Gadsby & Sampson's method by way of David Elworthy's C implementation
+//! (`SimpleGoodTuring/sgt.h`), which is what STAR vendors.
+//!
+//! The problem it solves: the ambient profile is estimated from the counts in
+//! empty droplets, and a gene seen zero times there is not a gene with zero
+//! probability — it is a gene whose probability the sample was too small to
+//! show. Good-Turing reserves mass for those unseen events from the frequency
+//! of the events seen exactly once, and smooths the rest along a fitted
+//! log-log line so that sparsely-observed counts do not inherit the noise of
+//! their raw frequencies.
+//!
+//! # D17
+//!
+//! STAR leaves `PZero` uninitialised until `analyse()` runs, and `analyse()`
+//! returns early without setting it when there are fewer than five distinct
+//! frequencies. A caller that then asks for the probability of an unseen gene
+//! reads whatever was on the stack. Here it is 0.0 from construction: with too
+//! few distinct frequencies there is no basis for reserving unseen mass, and
+//! zero is the answer that says so. Any input large enough to reach the
+//! significance test has more than five, so this is a divergence on a path
+//! STAR's own output is undefined on.
+
+use std::collections::BTreeMap;
+
+/// One observed frequency and its smoothed probability.
+#[derive(Debug, Clone, Copy, Default)]
+struct Entry {
+    /// How many events were observed this many times.
+    freq: u32,
+    /// The smoothed probability, filled in by [`Sgt::analyse`].
+    estimate: f64,
+}
+
+/// A Simple Good-Turing estimator over a frequency-of-frequencies table.
+#[derive(Debug, Default)]
+pub struct Sgt {
+    data: BTreeMap<u32, Entry>,
+    /// Total probability reserved for events never observed.
+    pzero: f64,
+}
+
+fn sq(x: f64) -> f64 {
+    x * x
+}
+
+impl Sgt {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that `frequency` distinct events were each seen `observation`
+    /// times.
+    pub fn add(&mut self, observation: u32, frequency: u32) {
+        self.data
+            .entry(observation)
+            .and_modify(|e| e.freq = e.freq.wrapping_add(frequency))
+            .or_insert(Entry {
+                freq: frequency,
+                estimate: 0.0,
+            });
+    }
+
+    /// Fit the estimator. Returns `false`, changing nothing, when there are
+    /// fewer than five distinct observation counts — Elworthy's `MinInput`
+    /// guard, since the log-log fit is meaningless on fewer points.
+    pub fn analyse(&mut self) -> bool {
+        let rows = self.data.len();
+        if rows < 5 {
+            return false;
+        }
+        let obs: Vec<u32> = self.data.keys().copied().collect();
+        let freq: Vec<u32> = self.data.values().map(|e| e.freq).collect();
+
+        // The total number of events observed. STAR accumulates this in u32
+        // and lets it wrap; reproducing that keeps the estimates identical on
+        // the inputs where it happens rather than only on the ones where it
+        // does not.
+        let mut big_n: u32 = 0;
+        for r in 0..rows {
+            big_n = big_n.wrapping_add(obs[r].wrapping_mul(freq[r]));
+        }
+
+        // The Good-Turing estimate of unseen mass: the share of events seen
+        // exactly once.
+        self.pzero = match self.data.get(&1) {
+            Some(e) => f64::from(e.freq) / f64::from(big_n),
+            None => 0.0,
+        };
+
+        // Z-transform: each frequency is averaged over the gap to its
+        // neighbours, which is what makes the log-log fit stable at the sparse
+        // high-count end where most counts are 0 or 1.
+        let mut log_obs = vec![0.0f64; rows];
+        let mut log_z = vec![0.0f64; rows];
+        let (mut mean_x, mut mean_y) = (0.0f64, 0.0f64);
+        let mut prev: u32 = 0;
+        for r in 0..rows {
+            let k = if r + 1 == rows {
+                f64::from(2u32.wrapping_mul(obs[r]).wrapping_sub(prev))
+            } else {
+                f64::from(obs[r + 1])
+            };
+            let z = f64::from(2u32.wrapping_mul(freq[r])) / (k - f64::from(prev));
+            log_obs[r] = f64::from(obs[r]).ln();
+            log_z[r] = z.ln();
+            mean_x += log_obs[r];
+            mean_y += log_z[r];
+            prev = obs[r];
+        }
+        mean_x /= rows as f64;
+        mean_y /= rows as f64;
+
+        let (mut xy, mut xx) = (0.0f64, 0.0f64);
+        for r in 0..rows {
+            xy += (log_obs[r] - mean_x) * (log_z[r] - mean_y);
+            xx += sq(log_obs[r] - mean_x);
+        }
+        let slope = xy / xx;
+        let intercept = mean_y - slope * mean_x;
+        let smoothed = |i: u32| (intercept + slope * f64::from(i).ln()).exp();
+
+        // For each observation count, the Turing estimate while it still
+        // differs from the fitted line by more than 1.96 standard errors, and
+        // the fitted line from the point they agree onwards. Once the switch
+        // happens it is permanent: the raw estimates only get noisier.
+        let mut r_star = vec![0.0f64; rows];
+        let mut indifferent = false;
+        for r in 0..rows {
+            let obs1 = obs[r] + 1;
+            let y = f64::from(obs1) * smoothed(obs1) / smoothed(obs[r]);
+            match self.data.get(&obs1) {
+                None => indifferent = true,
+                Some(next) if !indifferent => {
+                    let n_next = next.freq;
+                    let x = f64::from(obs1.wrapping_mul(n_next)) / f64::from(freq[r]);
+                    let threshold = 1.96
+                        * (sq(f64::from(obs1)) * f64::from(n_next) / sq(f64::from(freq[r]))
+                            * (1.0 + f64::from(n_next) / f64::from(freq[r])))
+                        .sqrt();
+                    if (x - y).abs() <= threshold {
+                        indifferent = true;
+                    } else {
+                        r_star[r] = x;
+                    }
+                }
+                Some(_) => {}
+            }
+            if indifferent {
+                r_star[r] = y;
+            }
+        }
+
+        let mut big_n_prime = 0.0f64;
+        for r in 0..rows {
+            big_n_prime += f64::from(freq[r]) * r_star[r];
+        }
+        for (r, e) in self.data.values_mut().enumerate() {
+            e.estimate = (1.0 - self.pzero) * r_star[r] / big_n_prime;
+        }
+        true
+    }
+
+    /// The estimated probability of an event observed `observation` times.
+    ///
+    /// `0` gives the reserved unseen mass. An observation count that never
+    /// occurred returns `None`, leaving the caller's value untouched, as
+    /// Elworthy's version does.
+    pub fn estimate(&self, observation: u32) -> Option<f64> {
+        if observation == 0 {
+            return Some(self.pzero);
+        }
+        self.data.get(&observation).map(|e| e.estimate)
+    }
+
+    /// The reserved unseen mass. Zero until [`analyse`](Self::analyse)
+    /// succeeds — see D17 in the module docs.
+    pub fn pzero(&self) -> f64 {
+        self.pzero
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A well-formed spectrum: mass is reserved for the unseen, every seen
+    /// count gets a finite estimate, and the total stays a probability.
+    #[test]
+    fn estimates_are_finite_and_sum_to_about_one() {
+        let mut sgt = Sgt::new();
+        // Frequency-of-frequencies of a Zipf-ish sample.
+        for (obs, freq) in [(1u32, 120u32), (2, 40), (3, 24), (4, 8), (5, 4), (7, 2)] {
+            sgt.add(obs, freq);
+        }
+        assert!(sgt.analyse());
+
+        let p0 = sgt.estimate(0).unwrap();
+        assert!(p0 > 0.0 && p0 < 1.0, "unseen mass must be a probability");
+
+        let mut total = p0;
+        for (obs, freq) in [(1u32, 120u32), (2, 40), (3, 24), (4, 8), (5, 4), (7, 2)] {
+            let e = sgt.estimate(obs).unwrap();
+            assert!(e.is_finite() && e > 0.0, "estimate for {obs} was {e}");
+            total += e * f64::from(freq);
+        }
+        assert!(
+            (total - 1.0).abs() < 0.05,
+            "estimates should sum to roughly 1, got {total}"
+        );
+    }
+
+    /// The smoothing is monotone in the observation count: an event seen more
+    /// often cannot be estimated as less likely.
+    #[test]
+    fn a_more_frequent_observation_is_never_less_likely() {
+        let mut sgt = Sgt::new();
+        for (obs, freq) in [(1u32, 100u32), (2, 30), (3, 12), (4, 6), (6, 2)] {
+            sgt.add(obs, freq);
+        }
+        assert!(sgt.analyse());
+        // Starting at 1: `estimate(0)` is the *total* mass reserved for all
+        // unseen events, not a per-event probability, so it does not belong in
+        // this comparison.
+        let mut last = 0.0f64;
+        for obs in [1u32, 2, 3, 4, 6] {
+            let e = sgt.estimate(obs).unwrap();
+            assert!(e >= last, "estimate dropped at {obs}: {e} < {last}");
+            last = e;
+        }
+    }
+
+    /// D17. With fewer than five distinct counts the fit is refused, and the
+    /// unseen mass stays zero instead of being whatever the stack held —
+    /// which is what STAR reads on this path.
+    #[test]
+    fn too_few_frequencies_leaves_the_unseen_mass_at_zero() {
+        let mut sgt = Sgt::new();
+        for (obs, freq) in [(1u32, 10u32), (2, 4), (3, 1)] {
+            sgt.add(obs, freq);
+        }
+        assert!(!sgt.analyse(), "fewer than 5 distinct counts must not fit");
+        // Exact zero is the point: not "small", but never written.
+        assert_eq!(sgt.pzero().to_bits(), 0.0f64.to_bits());
+        assert_eq!(sgt.estimate(0).map(f64::to_bits), Some(0.0f64.to_bits()));
+    }
+
+    /// An observation count that never occurred has no estimate, rather than a
+    /// zero that would be indistinguishable from a real one.
+    #[test]
+    fn an_unobserved_count_has_no_estimate() {
+        let mut sgt = Sgt::new();
+        for (obs, freq) in [(1u32, 50u32), (2, 20), (3, 10), (4, 5), (5, 2)] {
+            sgt.add(obs, freq);
+        }
+        assert!(sgt.analyse());
+        assert_eq!(sgt.estimate(9), None);
+    }
+
+    /// No observation of count 1 means nothing was seen exactly once, so there
+    /// is no evidence of unseen events and no mass is reserved.
+    #[test]
+    fn without_singletons_no_mass_is_reserved() {
+        let mut sgt = Sgt::new();
+        for (obs, freq) in [(2u32, 40u32), (3, 20), (4, 10), (5, 5), (6, 2)] {
+            sgt.add(obs, freq);
+        }
+        assert!(sgt.analyse());
+        assert_eq!(sgt.estimate(0).map(f64::to_bits), Some(0.0f64.to_bits()));
+    }
+}

--- a/tests/libcxx_oracle.cpp
+++ b/tests/libcxx_oracle.cpp
@@ -1,0 +1,21 @@
+#include <random>
+#include <cstdio>
+int main() {
+    std::mt19937 g(19760110u);
+    printf("mt19937_first10:");
+    for (int i = 0; i < 10; i++) printf(" %u", g());
+    printf("\n");
+
+    std::mt19937 g2(19760110u);
+    printf("generate_canonical53_first5:");
+    for (int i = 0; i < 5; i++)
+        printf(" %.17g", std::generate_canonical<double, 53>(g2));
+    printf("\n");
+
+    std::mt19937 g3(19760110u);
+    std::discrete_distribution<int> d({1.0, 2.0, 3.0, 4.0});
+    printf("discrete_1234_first20:");
+    for (int i = 0; i < 20; i++) printf(" %d", d(g3));
+    printf("\n");
+    return 0;
+}


### PR DESCRIPTION
`--soloCellFilter EmptyDrops_CR` computes what CellRanger computes: a Simple-Good-Turing ambient profile, sampled with libc++'s generator.

## What changed

**The ambient profile is smoothed with Simple Good-Turing** (`src/solo/sgt.rs`), the method CellRanger uses and STAR vendors as Elworthy's `sgt.h`. The ambient counts come from a small sample of empty droplets, so a gene seen twice there is not twice as likely as one seen once, and a gene seen zero times is not impossible — it is one the sample was too small to show. SGT reserves mass for the unseen from the singleton rate and smooths the rest along a fitted log-log line.

What this replaces had the right shape and the wrong numbers: it reserved unseen mass the same way, then distributed the remainder in proportion to raw counts with no smoothing at all.

**The Monte-Carlo null is drawn with libc++'s `std::mt19937` and `std::discrete_distribution`** (`src/solo/libcxx_rng.rs`), seeded `19760110 * (isim + 1)` per simulation as STAR seeds it. The standard fixes mt19937's output but not how `generate_canonical` consumes it, nor how `discrete_distribution` maps a uniform draw onto categories, so reproducing STAR's numbers needs *libc++'s* algorithm specifically, not a correct categorical sampler.

The module is wired into the EmptyDrops path in this same PR — it is not a module landed ahead of its use.

## Why

`solo::count` sampled with a `SplitMix64` stream under a comment calling it "WeightedIndex-equivalent; empirically byte-identical EmptyDrops cell calls". That claim cannot hold in general: two unrelated generators cannot agree over an arbitrary number of draws. It was true of whatever cases were checked and unknown everywhere else.

## Divergence

`DIVERGENCE.md` §1.2. STAR leaves `PZero` uninitialised when the ambient spectrum has fewer than five distinct frequencies and `analyse()` bails, so it reads whatever the stack held. Here it is zero from construction. Degenerate inputs only, but on those an uninitialised read can place arbitrary mass on unseen genes.

## Verification

Every expected value in the RNG tests was produced by compiling a C++ program against real libc++ (`clang++ -stdlib=libc++`) and printing the results, not derived from reading its source. `tests/libcxx_oracle.cpp` is in-tree so they can be regenerated. `generate_canonical` is asserted on **bit patterns** rather than decimals: a difference in the last place changes which category a sample lands in.

SGT tests cover a well-formed spectrum summing to one, monotonicity in the observation count, the absent-count case, the no-singletons case, and the D17 guard.

Gate: 570 lib + 26 integration tests, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, MSRV 1.89 — all green.

`test/solo_diff_docker.sh` (one run, Linux container with STAR 2.7.11b) passes:

```
PASS: rustar-aligner matrix matches real STARsolo exactly.
PASS: Gene raw matrix byte-identical to STARsolo (3 entries)
PASS: GeneFull raw matrix byte-identical to STARsolo (3 entries)
```

**Read that for what it is.** The harness exercises the raw matrix, which these changes do not touch, so it confirms nothing was broken on the way past — not that the cell calls are right. Both changes move `filtered/` membership by construction, and the harness has no EmptyDrops fixture to compare against. Validating the cell calls themselves needs a dataset with a known CellRanger `filtered/` result, which the harness does not currently carry.

Split out of #152 following the one-theme rule in CONTRIBUTING.md.
