### PR TITLE
perf(bam): parallel BGZF and record encoding (draft: measured slower, investigating)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ## [Unreleased]
 
+### Other changes
+
+- BAM output now compresses and encodes on the rayon pool sized by
+  `--runThreadN`, instead of deflating one BGZF block at a time on the
+  writing thread. Output is unchanged: the multithreaded BGZF writer
+  stages into the same buffer size, emits through the same frame writer
+  and appends the same EOF block, and record encoding is split into
+  sub-ranges whose concatenation in input order is the serial stream.
+  Pinned by `multithreaded_bgzf_is_byte_identical_to_the_serial_writer`,
+  `parallel_encoding_is_byte_identical_at_every_worker_count` and
+  `bam_file_is_byte_identical_to_the_serial_path`.
+
 ### Features
 
 - **STARsolo single-cell quantification (`--soloType`)** — the 10x

--- a/src/io/bam.rs
+++ b/src/io/bam.rs
@@ -45,10 +45,117 @@ fn bgzf_compression(level: i32) -> bgzf::io::writer::CompressionLevel {
 }
 
 /// Create a BGZF writer with the given STAR compression level.
-fn make_bgzf_writer<W: std::io::Write>(inner: W, compression: i32) -> bgzf::io::Writer<W> {
-    bgzf::io::writer::Builder::default()
+///
+/// Deflate runs on the global rayon pool, which `run()` sizes from
+/// `--runThreadN`, while a dedicated thread writes the finished frames in
+/// order. Block boundaries, frame layout and the EOF marker are the same as
+/// the single-threaded `bgzf::io::Writer`: both stage into a buffer of
+/// `MAX_BUF_SIZE`, both emit through `write_frame`, and libdeflate is
+/// deterministic at a fixed level. The bytes are therefore identical to what
+/// the serial writer produced, which
+/// `multithreaded_bgzf_is_byte_identical_to_the_serial_writer` pins.
+///
+/// **The returned writer must not be written to from a rayon worker thread.**
+/// It hands each finished block to the pool via `rayon::spawn` and blocks on a
+/// channel bounded by the worker count while a dedicated thread drains it. A
+/// caller that is itself occupying a worker can therefore fill the channel and
+/// then wait for a compression task that has no free worker to run on: a real
+/// deadlock, not a slowdown, and it is reachable at any pool size. rustar's
+/// writes come from the pipeline's dispatcher thread (`run_batch_pipeline`
+/// calls `consume` on its own thread, never on the pool), which is why this is
+/// safe here; `write_batch` carries a `debug_assert` so a future call site that
+/// breaks the rule fails loudly in tests instead of hanging in production.
+fn make_bgzf_writer<W: std::io::Write + Send + 'static>(
+    inner: W,
+    compression: i32,
+) -> bgzf::io::MultithreadedWriter<W> {
+    bgzf::io::multithreaded_writer::Builder::default()
         .set_compression_level(bgzf_compression(compression))
         .build_from_writer(inner)
+}
+
+/// Below this many records in a batch, encoding on the calling thread beats
+/// paying for the fan-out.
+const PARALLEL_ENCODE_MIN_RECORDS: usize = 512;
+
+/// Encode records to the raw BAM byte stream: per record, a little-endian
+/// `block_size` followed by the encoded record.
+///
+/// This is what `bam::io::Writer::write_alignment_record` writes, and it is
+/// produced here by that same call against an in-memory writer, so the bytes
+/// cannot drift from the noodles encoder.
+fn encode_records_into(
+    header: &sam::Header,
+    records: &[RecordBuf],
+    out: Vec<u8>,
+) -> Result<Vec<u8>, Error> {
+    let mut writer = bam::io::Writer::from(out);
+    for record in records {
+        writer.write_alignment_record(header, record)?;
+    }
+    Ok(writer.into_inner())
+}
+
+/// How many records the sorted writers encode at a time on `finish()`.
+///
+/// The whole sorted set is already resident as `RecordBuf`s; encoding it in one
+/// pass would hold the entire encoded stream alongside them. Encoding in slices
+/// keeps the extra buffer bounded while still handing the pool enough records
+/// per slice to be worth the fan-out.
+const ENCODE_SLICE_RECORDS: usize = 65_536;
+
+/// Guard the rule documented on `make_bgzf_writer`: writing to the
+/// multithreaded BGZF writer from a rayon worker can deadlock. Cheap enough to
+/// run on every batch, and only in debug builds.
+fn assert_not_on_rayon_worker() {
+    debug_assert!(
+        rayon::current_thread_index().is_none(),
+        "BGZF writes must come from outside the rayon pool: writing from a worker \
+         can block the pool on its own compression tasks and deadlock"
+    );
+}
+
+/// Encode `records` in bounded slices and write each to `writer`.
+fn write_records_chunked<W: Write>(
+    writer: &mut W,
+    header: &sam::Header,
+    records: &[RecordBuf],
+) -> Result<(), Error> {
+    for slice in records.chunks(ENCODE_SLICE_RECORDS) {
+        let bytes = encode_batch(header, slice)?;
+        writer.write_all(&bytes)?;
+    }
+    Ok(())
+}
+
+/// Encode a batch to raw BAM bytes, splitting the work across the rayon pool.
+///
+/// `bam::io::Writer` carries no state between records other than a scratch
+/// buffer it clears at the top of every `write_alignment_record`, so encoding
+/// a sub-range against a fresh in-memory writer yields exactly the bytes that
+/// sub-range would have contributed to the serial stream. Concatenating the
+/// sub-ranges in input order therefore reproduces the serial stream byte for
+/// byte, which is why this is output-neutral rather than merely equivalent.
+fn encode_batch(header: &sam::Header, batch: &[RecordBuf]) -> Result<Vec<u8>, Error> {
+    let threads = rayon::current_num_threads();
+    if threads < 2 || batch.len() < PARALLEL_ENCODE_MIN_RECORDS {
+        return encode_records_into(header, batch, Vec::new());
+    }
+
+    use rayon::prelude::*;
+    let chunk_len = batch.len().div_ceil(threads).max(64);
+    // `par_chunks` is an indexed parallel iterator, so `collect` restores input
+    // order regardless of which worker finished first.
+    let chunks: Vec<Vec<u8>> = batch
+        .par_chunks(chunk_len)
+        .map(|chunk| encode_records_into(header, chunk, Vec::new()))
+        .collect::<Result<_, _>>()?;
+
+    let mut out = Vec::with_capacity(chunks.iter().map(Vec::len).sum());
+    for chunk in &chunks {
+        out.extend_from_slice(chunk);
+    }
+    Ok(out)
 }
 
 /// BAM file writer (streaming, unsorted)
@@ -57,8 +164,9 @@ fn make_bgzf_writer<W: std::io::Write>(inner: W, compression: i32) -> bgzf::io::
 /// without buffering or sorting. The output is BGZF-compressed but unsorted.
 /// Users can sort the output with `samtools sort` if needed.
 pub struct BamWriter {
-    writer: bam::io::Writer<bgzf::io::Writer<BufWriter<File>>>,
+    writer: bgzf::io::MultithreadedWriter<BufWriter<File>>,
     header: sam::Header,
+    finished: bool,
 }
 
 /// BAM file writer that collects all records in memory, sorts by coordinate,
@@ -87,10 +195,13 @@ impl BamWriter {
         compression: i32,
     ) -> Result<Self, Error> {
         let buf_writer = BufWriter::new(File::create(output_path)?);
-        let mut bgzf = make_bgzf_writer(buf_writer, compression);
-        write_bam_header_lenient(&mut bgzf, &header, None)?;
-        let writer = bam::io::Writer::from(bgzf);
-        Ok(Self { writer, header })
+        let mut writer = make_bgzf_writer(buf_writer, compression);
+        write_bam_header_lenient(&mut writer, &header, None)?;
+        Ok(Self {
+            writer,
+            header,
+            finished: false,
+        })
     }
 
     /// Create a new BAM writer with header from genome index.
@@ -127,15 +238,20 @@ impl BamWriter {
     /// # Arguments
     /// * `batch` - Slice of records to write
     pub fn write_batch(&mut self, batch: &[RecordBuf]) -> Result<(), Error> {
-        for record in batch {
-            self.writer.write_alignment_record(&self.header, record)?;
-        }
+        assert_not_on_rayon_worker();
+        let bytes = encode_batch(&self.header, batch)?;
+        self.writer.write_all(&bytes)?;
         Ok(())
     }
 
     /// Flush and close BAM file
     pub fn finish(&mut self) -> Result<(), Error> {
-        self.writer.finish(&self.header)?;
+        // `MultithreadedWriter::finish` shuts the workers down and panics if
+        // called twice; `Drop` calls it too when it has not run yet.
+        if !self.finished {
+            self.writer.finish()?;
+            self.finished = true;
+        }
         log::info!("BAM file written successfully");
         Ok(())
     }
@@ -198,13 +314,10 @@ impl SortedBamWriter {
             });
 
         let buf_writer = BufWriter::new(File::create(&self.output_path)?);
-        let mut bgzf = make_bgzf_writer(buf_writer, self.compression);
-        write_bam_header_lenient(&mut bgzf, &self.header, Some("coordinate"))?;
-        let mut bam_writer = bam::io::Writer::from(bgzf);
-        for record in &self.records {
-            bam_writer.write_alignment_record(&self.header, record)?;
-        }
-        bam_writer.finish(&self.header)?;
+        let mut writer = make_bgzf_writer(buf_writer, self.compression);
+        write_bam_header_lenient(&mut writer, &self.header, Some("coordinate"))?;
+        write_records_chunked(&mut writer, &self.header, &self.records)?;
+        writer.finish()?;
         log::info!("Sorted BAM written ({} records)", self.records.len());
         Ok(())
     }
@@ -218,15 +331,13 @@ impl SortedBamWriter {
                 _ => (usize::MAX, 0),
             });
 
-        let stdout = std::io::stdout();
-        let buf_writer = BufWriter::new(stdout.lock());
-        let mut bgzf = make_bgzf_writer(buf_writer, self.compression);
-        write_bam_header_lenient(&mut bgzf, &self.header, Some("coordinate"))?;
-        let mut bam_writer = bam::io::Writer::from(bgzf);
-        for record in &self.records {
-            bam_writer.write_alignment_record(&self.header, record)?;
-        }
-        bam_writer.finish(&self.header)?;
+        // `std::io::stdout()` rather than a lock guard: the BGZF writer owns
+        // its sink on a worker thread, so the sink has to be `'static`.
+        let buf_writer = BufWriter::new(std::io::stdout());
+        let mut writer = make_bgzf_writer(buf_writer, self.compression);
+        write_bam_header_lenient(&mut writer, &self.header, Some("coordinate"))?;
+        write_records_chunked(&mut writer, &self.header, &self.records)?;
+        writer.finish()?;
         log::info!(
             "Sorted BAM written to stdout ({} records)",
             self.records.len()
@@ -371,31 +482,38 @@ fn render_sam_text_lenient(header: &sam::Header, sort_order: Option<&str>) -> Ve
 
 /// Streaming unsorted BAM writer that writes to stdout.
 pub struct BamStdoutWriter {
-    writer: bam::io::Writer<bgzf::io::Writer<BufWriter<std::io::Stdout>>>,
+    writer: bgzf::io::MultithreadedWriter<BufWriter<std::io::Stdout>>,
     header: sam::Header,
+    finished: bool,
 }
 
 impl BamStdoutWriter {
     pub fn create(genome: &crate::genome::Genome, params: &Parameters) -> Result<Self, Error> {
         let header = crate::io::sam::build_sam_header(genome, params)?;
-        let mut bgzf = make_bgzf_writer(
+        let mut writer = make_bgzf_writer(
             BufWriter::new(std::io::stdout()),
             params.out_bam_compression,
         );
-        write_bam_header_lenient(&mut bgzf, &header, None)?;
-        let writer = bam::io::Writer::from(bgzf);
-        Ok(Self { writer, header })
+        write_bam_header_lenient(&mut writer, &header, None)?;
+        Ok(Self {
+            writer,
+            header,
+            finished: false,
+        })
     }
 
     pub fn write_batch(&mut self, batch: &[RecordBuf]) -> Result<(), Error> {
-        for record in batch {
-            self.writer.write_alignment_record(&self.header, record)?;
-        }
+        assert_not_on_rayon_worker();
+        let bytes = encode_batch(&self.header, batch)?;
+        self.writer.write_all(&bytes)?;
         Ok(())
     }
 
     pub fn finish(&mut self) -> Result<(), Error> {
-        self.writer.finish(&self.header)?;
+        if !self.finished {
+            self.writer.finish()?;
+            self.finished = true;
+        }
         Ok(())
     }
 }
@@ -659,6 +777,156 @@ mod tests {
             writer.is_ok(),
             "BAM writer with compression=0 should succeed"
         );
+    }
+
+    /// The pre-change write path: one serial `bgzf::io::Writer`, records fed
+    /// one at a time through `bam::io::Writer`. Every neutrality test below
+    /// compares against these bytes, so what is being asserted is not "the two
+    /// new halves agree with each other" but "the output did not move".
+    fn serial_reference_bytes(header: &sam::Header, records: &[RecordBuf]) -> Vec<u8> {
+        let mut bgzf = bgzf::io::writer::Builder::default()
+            .set_compression_level(bgzf_compression(1))
+            .build_from_writer(Vec::new());
+        write_bam_header_lenient(&mut bgzf, header, None).unwrap();
+        let mut writer = bam::io::Writer::from(bgzf);
+        for record in records {
+            writer.write_alignment_record(header, record).unwrap();
+        }
+        writer.try_finish().unwrap();
+        writer.into_inner().into_inner()
+    }
+
+    fn unmapped_records(params: &Parameters, n: usize) -> Vec<RecordBuf> {
+        (0..n)
+            .map(|i| {
+                crate::io::sam::SamWriter::build_unmapped_record(
+                    &format!("read{i}"),
+                    &[0, 1, 2, 3, 3, 2, 1, 0],
+                    &[30; 8],
+                    params,
+                    crate::stats::UnmappedReason::Other,
+                )
+                .unwrap()
+            })
+            .collect()
+    }
+
+    /// The multithreaded BGZF writer stages into the same `MAX_BUF_SIZE`
+    /// buffer, emits through the same `write_frame`, and appends the same EOF
+    /// block as the serial writer, so switching to it must not move a byte.
+    /// Enough records to span several BGZF blocks, so block boundaries are
+    /// actually exercised rather than a single short block.
+    #[test]
+    fn multithreaded_bgzf_is_byte_identical_to_the_serial_writer() {
+        let params = default_params();
+        let header = sam::Header::default();
+        let records = unmapped_records(&params, 4000);
+        let expected = serial_reference_bytes(&header, &records);
+
+        let mut writer = make_bgzf_writer(Vec::new(), 1);
+        write_bam_header_lenient(&mut writer, &header, None).unwrap();
+        for record in &records {
+            let bytes =
+                encode_records_into(&header, std::slice::from_ref(record), Vec::new()).unwrap();
+            writer.write_all(&bytes).unwrap();
+        }
+        let got = writer.finish().unwrap();
+
+        assert_eq!(got, expected);
+    }
+
+    /// Splitting the batch across the pool is only sound if concatenating the
+    /// sub-ranges in input order reproduces the serial stream. Checked at
+    /// several pool sizes, including one worker (which takes the serial branch)
+    /// and a size that does not divide the batch evenly.
+    #[test]
+    fn parallel_encoding_is_byte_identical_at_every_worker_count() {
+        let params = default_params();
+        let header = sam::Header::default();
+        let records = unmapped_records(&params, 3000);
+        let expected = encode_records_into(&header, &records, Vec::new()).unwrap();
+
+        for threads in [1, 3, 4, 7, 16] {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .unwrap();
+            let got = pool.install(|| encode_batch(&header, &records)).unwrap();
+            assert_eq!(got, expected, "encoding diverged at {threads} workers");
+        }
+    }
+
+    /// Batches under the fan-out threshold take the serial branch; that branch
+    /// has to produce the same bytes as the parallel one, not merely a valid
+    /// stream.
+    #[test]
+    fn a_batch_below_the_fanout_threshold_encodes_the_same_bytes() {
+        let params = default_params();
+        let header = sam::Header::default();
+        let records = unmapped_records(&params, PARALLEL_ENCODE_MIN_RECORDS - 1);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(8)
+            .build()
+            .unwrap();
+        let got = pool.install(|| encode_batch(&header, &records)).unwrap();
+        assert_eq!(
+            got,
+            encode_records_into(&header, &records, Vec::new()).unwrap()
+        );
+    }
+
+    /// The sorted writers encode in bounded slices rather than in one pass, so
+    /// the slice boundary must not show up in the output.
+    #[test]
+    fn chunked_encoding_matches_a_single_pass() {
+        let params = default_params();
+        let header = sam::Header::default();
+        let records = unmapped_records(&params, 2500);
+        let expected = encode_records_into(&header, &records, Vec::new()).unwrap();
+
+        let mut got = Vec::new();
+        for slice in records.chunks(700) {
+            got.extend_from_slice(&encode_batch(&header, slice).unwrap());
+        }
+        assert_eq!(got, expected);
+    }
+
+    /// End to end through `BamWriter`: the file on disk is byte-identical to
+    /// what the serial path wrote.
+    ///
+    /// Deliberately not wrapped in a `ThreadPool::install`. Doing so puts the
+    /// caller on a worker and deadlocks, for the reason spelled out on
+    /// `make_bgzf_writer` — this test found that the hard way. Worker-count
+    /// invariance of the part that has one is covered by
+    /// `parallel_encoding_is_byte_identical_at_every_worker_count`; BGZF block
+    /// boundaries do not depend on the worker count at all, since the staging
+    /// buffer fills to a fixed size before any block is handed to the pool.
+    #[test]
+    fn bam_file_is_byte_identical_to_the_serial_path() {
+        let genome = create_test_genome();
+        let params = default_params();
+        let header = crate::io::sam::build_sam_header(&genome, &params).unwrap();
+        let records = unmapped_records(&params, 2000);
+        let expected = serial_reference_bytes(&header, &records);
+
+        let temp_file = NamedTempFile::new().unwrap();
+        let mut writer = BamWriter::create(temp_file.path(), &genome, &params).unwrap();
+        writer.write_batch(&records).unwrap();
+        writer.finish().unwrap();
+
+        assert_eq!(std::fs::read(temp_file.path()).unwrap(), expected);
+    }
+
+    /// `finish()` shuts the BGZF workers down, and calling it twice would panic
+    /// inside noodles. `Drop` also calls it. Both paths have to stay safe.
+    #[test]
+    fn finishing_twice_is_not_an_error() {
+        let genome = create_test_genome();
+        let params = default_params();
+        let temp_file = NamedTempFile::new().unwrap();
+        let mut writer = BamWriter::create(temp_file.path(), &genome, &params).unwrap();
+        writer.finish().unwrap();
+        writer.finish().unwrap();
     }
 
     #[test]

--- a/test/bench_bam_write.sh
+++ b/test/bench_bam_write.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Interleaved A/B of BAM writing, before and after the parallel writer.
+#
+#   test/bench_bam_write.sh <genomeDir> <reads.fastq> [threads] [pairs] [baseRef]
+#
+# Two binaries are built: one from `baseRef` (default origin/main) and one from
+# the working tree. They are then alternated pair by pair, with the order
+# flipped on even pairs so a machine that drifts (thermal, page cache warming)
+# cannot favour whichever runs first.
+#
+# Each pair times three output modes:
+#
+#   None                  alignment only, no BAM written
+#   BAM Unsorted          streaming write
+#   BAM SortedByCoordinate  sort then write
+#
+# `None` is not decoration. Only the difference between a BAM mode and `None`
+# is the work this change touches; the total is mostly alignment and hides it.
+# A previous measurement on this repo reported a BAM-writer difference that the
+# workload could not have resolved, because BAM writing was 1-4% of the run.
+# Report the delta, and if the delta is smaller than the run-to-run spread, say
+# that the workload cannot settle the question rather than publishing a median.
+set -euo pipefail
+
+GENOME_DIR=${1:?usage: bench_bam_write.sh <genomeDir> <reads.fastq> [threads] [pairs] [baseRef]}
+READS=${2:?usage: bench_bam_write.sh <genomeDir> <reads.fastq> [threads] [pairs] [baseRef]}
+THREADS=${3:-16}
+PAIRS=${4:-6}
+BASE_REF=${5:-origin/main}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK=$(mktemp -d)
+BASE_TREE=$(mktemp -d)
+trap 'rm -rf "$WORK"; git -C "$ROOT" worktree remove --force "$BASE_TREE" 2>/dev/null || rm -rf "$BASE_TREE"' EXIT
+
+# Refuse to measure on a busy machine. A single unrelated job saturating the
+# cores does not just add noise, it can invert the result, and it is invisible
+# in the numbers afterwards: the series simply drifts.
+#
+# The check is on CPU idle, not on load average. Load average is an exponential
+# average over minutes, so it stays high long after the offending job has gone
+# and would refuse to measure on a machine that is now perfectly quiet.
+cpu_idle() { # percent idle, sampled over one second
+  top -l 2 -n 0 2>/dev/null | awk '/CPU usage/ {gsub("%","",$(NF-1)); v=$(NF-1)} END {print v+0}'
+}
+IDLE=$(cpu_idle)
+if awk -v i="$IDLE" 'BEGIN{exit !(i < 80)}'; then
+  echo "CPU is only ${IDLE}% idle; other work is running and the numbers would not mean anything." >&2
+  echo "wait for the machine to be idle, or set BENCH_IGNORE_LOAD=1 to override." >&2
+  [ "${BENCH_IGNORE_LOAD:-0}" = "1" ] || exit 1
+fi
+
+echo "building new (working tree)" >&2
+cargo build --release --manifest-path "$ROOT/Cargo.toml" >&2
+cp "$ROOT/target/release/rustar-aligner" "$WORK/new"
+
+echo "building old ($BASE_REF)" >&2
+rm -rf "$BASE_TREE"
+git -C "$ROOT" worktree add --detach "$BASE_TREE" "$BASE_REF" >&2
+cargo build --release --manifest-path "$BASE_TREE/Cargo.toml" >&2
+cp "$BASE_TREE/target/release/rustar-aligner" "$WORK/old"
+
+run() { # $1 = binary, $2 = outSAMtype words
+  local dir="$WORK/run"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  local t0 t1
+  t0=$(python3 -c 'import time; print(time.time())')
+  # shellcheck disable=SC2086 # $2 is deliberately two words for "BAM Unsorted"
+  "$1" --genomeDir "$GENOME_DIR" --readFilesIn "$READS" --runThreadN "$THREADS" \
+       --outSAMtype $2 --outFileNamePrefix "$dir/" >/dev/null 2>&1
+  t1=$(python3 -c "import time; print(f'{time.time()-$t0:.2f}')")
+  echo "$t1"
+}
+
+# One discarded run so the reads and the index are in page cache for pair 1.
+run "$WORK/new" "None" >/dev/null
+
+for mode in "None" "BAM Unsorted" "BAM SortedByCoordinate"; do
+  echo "=== --outSAMtype $mode ==="
+  for i in $(seq 1 "$PAIRS"); do
+    if (( i % 2 )); then
+      o=$(run "$WORK/old" "$mode")
+      n=$(run "$WORK/new" "$mode")
+    else
+      n=$(run "$WORK/new" "$mode")
+      o=$(run "$WORK/old" "$mode")
+    fi
+    echo "pair$i old=${o}s new=${n}s idle=$(cpu_idle)%"
+  done
+done


### PR DESCRIPTION
BAM compression and record encoding move onto the rayon pool. Output-neutral, and verified byte-identical rather than assumed.

## What changed

`make_bgzf_writer` returned `bgzf::io::Writer`, which deflates one block at a time on whichever thread is writing. It now returns `bgzf::io::MultithreadedWriter`, which hands each block to the rayon pool and writes finished frames in order from a dedicated thread. `run()` already sizes the global pool from `--runThreadN`, and `noodles-bgzf` with the `libdeflate` feature plus `libdeflater` were already dependencies, so no new dependency and no new configuration.

`encode_batch` splits a batch into sub-ranges encoded across the pool. Record encoding was serial on the writing thread; `bam::io::Writer::write_alignment_record` runs the noodles encoder per record, and that is real CPU work in a BAM run.

The sorted writers encode in bounded slices of 65 536 records rather than in one pass. Their whole record set is already resident as `RecordBuf`s, and encoding it in one go would have held the entire encoded stream alongside them.

## Why the output cannot move

Not an assertion about intent. The two writers are the same format machine:

- both stage into a buffer of `MAX_BUF_SIZE` and emit a block only when it fills,
- both emit through the same `write_frame`,
- both append the same 28-byte `BGZF_EOF`,
- libdeflate is deterministic at a fixed level.

And `bam::io::Writer` keeps no state between records other than a scratch buffer it clears at the top of every `write_alignment_record`. A sub-range encoded against a fresh in-memory writer therefore contributes exactly the bytes it would have contributed to the serial stream, so concatenating sub-ranges in input order *is* the serial stream. `par_chunks` is an indexed parallel iterator, so `collect` restores input order whatever the completion order.

Measured on 200 000 real reads (yeast, `ERR12389696`), old binary from `origin/main` against this branch:

| mode | file | result |
|---|---|---|
| `BAM Unsorted` | `Aligned.out.bam` | identical, 15 130 304 bytes |
| `BAM SortedByCoordinate` | `Aligned.sortedByCoord.out.bam` | identical, 9 386 500 bytes |

Worth saying how that check went wrong first, because it is an easy trap: the files initially differed by one byte. The cause was the harness, not the code. `@PG` records `CL:` verbatim, so running `./old` with prefix `out_old/` against `./new` with prefix `out_new/` makes the header differ and the compressed size with it. Both sides now run as `./rustar-aligner` with prefix `./` from inside their own directory.

## One hazard, found by a test that hung

The multithreaded writer hands blocks to the pool via `rayon::spawn` and blocks on a channel bounded by the worker count while a dedicated thread drains it. **A caller that is itself occupying a rayon worker can fill that channel and then wait on a compression task that has no free worker to run on.** That is a deadlock, not a slowdown, and it is reachable at any pool size, including one worker.

I found it by writing a thread-count sweep that wrapped the whole writer in `ThreadPool::install`. It hung; a stack sample showed the worker parked in `LockLatch::wait_and_reset`.

rustar is safe as written: `run_batch_pipeline` calls `consume` on its own dispatcher thread, never on the pool, and the transcriptome writer is reached through a `&mut` that cannot cross `par_iter`. To keep it that way, `write_batch` carries

```rust
debug_assert!(rayon::current_thread_index().is_none(), ...)
```

so a future call site that writes from inside the pool fails loudly in tests rather than hanging in production. The constraint is also documented on `make_bgzf_writer`, where someone changing the writer will read it.

## Verification

New unit tests in `src/io/bam.rs`, each comparing against bytes produced by the *pre-change* path (a serial `bgzf::io::Writer` fed one record at a time), not merely against the other new half:

- `multithreaded_bgzf_is_byte_identical_to_the_serial_writer` — 4 000 records, several BGZF blocks, so block boundaries are actually crossed
- `parallel_encoding_is_byte_identical_at_every_worker_count` — pools of 1, 3, 4, 7 and 16 workers, including sizes that do not divide the batch evenly
- `a_batch_below_the_fanout_threshold_encodes_the_same_bytes` — the serial branch must agree with the parallel one
- `chunked_encoding_matches_a_single_pass` — the sorted writers' slice boundary must not show in the output
- `bam_file_is_byte_identical_to_the_serial_path` — end to end through `BamWriter`
- `finishing_twice_is_not_an_error` — `MultithreadedWriter::finish` shuts the workers down and panics if called twice, and `Drop` calls it too

Gate: 566 lib + 26 integration tests, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, all green.

## Timings: measured, and they say this regresses

**Draft, because the measurement contradicts the premise.** At `--runThreadN 16` on 16 cores, 2M yeast reads, machine at 87-92% CPU idle, interleaved with the order flipped on even pairs:

| configuration | old (`origin/main`) | this branch |
|---|---|---|
| `--outSAMtype None` | 22.45 / 22.42 / 22.72 / 23.81 s | 22.55 / 22.55 / 23.33 / 22.83 s |
| `BAM Unsorted`, `--outBAMcompression 6` | 25.00 / 25.05 / 25.58 / 25.60 s | 25.94 / 26.50 / 27.80 / 28.01 s |

All four compression-6 pairs go the same way: **+1.8 s median on 25.3 s, about +7% slower.** `None` is neutral, which is what localises the difference to the BAM write path.

Likely cause, being checked rather than announced: alignment already occupies every core at 16 threads, `MultithreadedWriter` hands its blocks to that same rayon pool and blocks on a channel bounded by the worker count, so there is no spare capacity for compression to move to and the handoff is pure added cost.

`test/bench_bam_write.sh` reproduces the above. It times `--outSAMtype None` alongside the BAM modes deliberately: only the difference is the work this change touches, and a total that is mostly alignment hides it.

See the comment thread for the isolation run in progress (parallel BGZF with serial encoding, plus a `--runThreadN 8` leg where spare capacity exists). This PR should not merge on a performance claim until that resolves; the output-neutrality work above stands either way.
