### PR TITLE
fix: --runThreadN 1 ran on every core, not on one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Bug fixes
 
+- `--runThreadN 1` ran on every logical core instead of on one. The
+  rayon pool was configured only above 1, and skipping it leaves rayon's
+  default of one worker per core. Output is unchanged; the run now uses
+  the thread count asked for.
+
 - **STARsolo `Gene` assignment now requires exon concordance**, matching
   STARsolo: a read counts toward a gene only when every aligned block
   lies within the gene's exons, rather than merely overlapping one. This

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,11 +68,13 @@ pub fn run(params: &Parameters) -> anyhow::Result<()> {
     // RSS for nothing. `build_global` errors if called twice; we
     // ignore the error so the in-process tests that already
     // initialised the pool still work.
-    if usize::from(params.run_thread_n) > 1 {
-        let _ = rayon::ThreadPoolBuilder::new()
-            .num_threads(params.run_thread_n.into())
-            .build_global();
-    }
+    //
+    // Configured at every value, `1` included. Skipping the build at 1 does not
+    // yield one thread: it leaves rayon's default of one worker per logical
+    // core, so `--runThreadN 1` ran on the whole machine.
+    let _ = rayon::ThreadPoolBuilder::new()
+        .num_threads(params.run_thread_n.into())
+        .build_global();
 
     match params.run_mode {
         RunMode::GenomeGenerate => genome_generate(params),


### PR DESCRIPTION
`--runThreadN 1` ran on every logical core. One line, and it was hiding in plain sight.

## What was wrong

The rayon global pool was configured only when `--runThreadN` was greater than 1:

```rust
if usize::from(params.run_thread_n) > 1 {
    let _ = rayon::ThreadPoolBuilder::new()
        .num_threads(params.run_thread_n.into())
        .build_global();
}
```

Skipping the build at 1 does not give one thread. It leaves rayon's default, which is one worker per logical core. So the single value a user is most likely to pass when they mean "use one core" was the one value that used all of them.

Measured on 200 000 real reads, 16-core machine:

| | wall | CPU |
|---|---|---|
| before | 2.44 s | **1300%** |
| after | 26.23 s | 100% |

The old 2.44 s was not a fast single-threaded run. It was a sixteen-way run wearing the wrong flag, which is also why a scaling curve taken with it looked absurd: `--runThreadN 2` was *slower* than `--runThreadN 1`, because 2 actually meant 2 and 1 meant 16.

## Why it matters beyond the flag reading falsely

- A scheduler or a container allotted one CPU still spawns one worker per core.
- On a shared machine the run oversubscribes every other job on it, silently.
- With a thread-caching allocator each of those threads keeps its own heap. That is the precise cost the comment directly above this code says the pool sizing exists to avoid, so the guard defeated the stated purpose of the block it was guarding.
- The thread-invariance checks were weaker than they read. A `--runThreadN 1` leg that runs sixteen-wide is not a one-thread leg, so comparing it against `--runThreadN 16` compared sixteen against sixteen.

## Verification

Output-neutral, checked two ways on 200 000 real reads:

- the new binary at `--runThreadN 1` is byte-identical to the old binary at `--runThreadN 1`,
- and with the fix in place, `--runThreadN 1` and `--runThreadN 8` produce **identical records**. The only differing byte is in the `@PG` `CL:` line, which records the command line and therefore the thread count itself.

That second check is the one the guard was preventing anyone from running. It passes.

With `--runThreadN 1` now meaning one thread, the real scaling on this machine is 26.2 s at 1 thread against 2.42 s at 16, about 10.8×.

Gate: 560 lib + 26 integration tests, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, all green. No new dependency, no flag change, no output change.

## Related

Found while taking a thread-scaling curve for #167, which is why the numbers there are trustworthy only after this: with the bug in place `--runThreadN 2` measured *slower* than `--runThreadN 1`, because 2 meant 2 and 1 meant sixteen. #168 carries the allocation measurements from the same session.
