### PR TITLE
refactor: drop Transcript::read_seq, a public field nothing reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,3 +131,9 @@ Sections commonly used: Features, Bug fixes, Other changes.
   needs random access to the SA in RAM.
 
 Initial release of Rust rewrite of STAR.
+### Other changes
+
+- Removed `Transcript::read_seq`, a public field that was filled with a
+  copy of the read at every finalised alignment and never read. **API
+  removal.** Output is unchanged.
+

--- a/src/align/pe_overlap.rs
+++ b/src/align/pe_overlap.rs
@@ -364,7 +364,6 @@ pub fn convert_merged_transcript_to_pe(
             n_junction,
             junction_motifs: out_junctions[i].iter().map(|(m, _)| *m).collect(),
             junction_annotated: out_junctions[i].iter().map(|(_, a)| *a).collect(),
-            read_seq: mate_seqs[i].to_vec(),
         });
     }
 
@@ -479,7 +478,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: merge.merged.clone(),
         };
 
         let scorer = AlignmentScorer::from_params_minimal();
@@ -552,7 +550,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: merge.merged.clone(),
         };
 
         let scorer = AlignmentScorer::from_params_minimal();

--- a/src/align/read_align.rs
+++ b/src/align/read_align.rs
@@ -114,7 +114,6 @@ impl PairedAlignment {
             n_junction: m1.n_junction + m2.n_junction,
             junction_motifs: Vec::new(),
             junction_annotated: Vec::new(),
-            read_seq: Vec::new(),
         }
     }
 }
@@ -889,8 +888,6 @@ pub fn align_paired_read(
                     t1.is_reverse = false;
                     t2.is_reverse = true;
                 }
-                t1.read_seq = mate1_seq.to_vec();
-                t2.read_seq = mate2_seq.to_vec();
 
                 if params.chim_segment_min > 0 {
                     all_m1_transcripts.push(t1.clone());
@@ -934,7 +931,6 @@ pub fn align_paired_read(
                         0, // mate1
                     ) {
                         t.is_reverse = stitch_is_reverse;
-                        t.read_seq = mate1_seq.to_vec();
                         if params.chim_segment_min > 0 {
                             all_m1_transcripts.push(t.clone());
                         }
@@ -958,7 +954,6 @@ pub fn align_paired_read(
                         1, // mate2
                     ) {
                         t.is_reverse = !stitch_is_reverse;
-                        t.read_seq = mate2_seq.to_vec();
                         if params.chim_segment_min > 0 {
                             all_m2_transcripts.push(t.clone());
                         }
@@ -1641,7 +1636,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
         let pair = PairedAlignment {
             mate1_transcript: make_tr(1000, 1100, 0, 100),
@@ -1803,7 +1797,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         let t2 = Transcript {
@@ -1825,7 +1818,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         // Distance = 300bp, within default limit (auto mode = unlimited)
@@ -1859,7 +1851,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         let t2 = Transcript {
@@ -1881,7 +1872,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         // Distance = 400bp, exceeds limit of 100bp
@@ -1913,7 +1903,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         let t2 = Transcript {
@@ -1935,7 +1924,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         let tlen = calculate_insert_size(&t1, &t2);
@@ -1968,7 +1956,6 @@ mod tests {
             n_junction: 2,
             junction_motifs: vec![SpliceMotif::GtAg, SpliceMotif::CtAc], // +strand and -strand
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         // Create a transcript with consistent strand motifs (all + strand)
@@ -1991,7 +1978,6 @@ mod tests {
             n_junction: 2,
             junction_motifs: vec![SpliceMotif::GtAg, SpliceMotif::GcAg], // both + strand
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         // Note: STAR's RemoveInconsistentStrands filters transcripts where
@@ -2070,7 +2056,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         let t2 = Transcript {
@@ -2092,7 +2077,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         let tlen = calculate_insert_size(&t1, &t2);
@@ -2133,7 +2117,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         // Case 1: NonCanonical + unannotated → should be filtered
@@ -2219,7 +2202,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         // Test BothMapped variant

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -2155,7 +2155,6 @@ pub(crate) fn finalize_transcript(
         n_junction: wt.n_junction,
         junction_motifs: wt.junction_motifs.clone(),
         junction_annotated: wt.junction_annotated.clone(),
-        read_seq: read_seq.to_vec(),
     })
 }
 
@@ -2695,7 +2694,6 @@ pub(crate) fn stitch_seeds_with_jdb_debug(
             // Restore original reverse-strand flag and read sequence for SAM output.
             if stitch_is_reverse {
                 transcript.is_reverse = true;
-                transcript.read_seq = read_seq.to_vec();
             }
             transcripts.push(transcript);
         }

--- a/src/align/transcript.rs
+++ b/src/align/transcript.rs
@@ -29,8 +29,6 @@ pub struct Transcript {
     pub junction_motifs: Vec<crate::align::score::SpliceMotif>,
     /// Whether each junction is annotated in the GTF (for jM +20 offset)
     pub junction_annotated: Vec<bool>,
-    /// Original read sequence
-    pub read_seq: Vec<u8>,
 }
 
 /// An exon segment in a transcript.
@@ -182,7 +180,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         assert_eq!(transcript.cigar_string(), "50M100N50M");
@@ -230,7 +227,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 100],
         };
 
         // Query: 45 + 3 + 2 + 50 = 100
@@ -279,7 +275,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         let [left, right] = transcript.count_soft_clips();
@@ -303,7 +298,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         let [left, right] = transcript.count_soft_clips();
@@ -327,7 +321,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         let [left, right] = transcript.count_soft_clips();

--- a/src/chimeric/detect.rs
+++ b/src/chimeric/detect.rs
@@ -1090,7 +1090,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0u8; read_len],
         }
     }
 
@@ -1210,7 +1209,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
         assert!(transcript_to_segment(&t).is_err());
     }
@@ -1354,7 +1352,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0u8; read_len],
         }
     }
 

--- a/src/io/bam.rs
+++ b/src/io/bam.rs
@@ -550,7 +550,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         let read_name = "read1";

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -1828,7 +1828,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         writer
@@ -1971,7 +1970,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3]; // ACGT
@@ -2027,7 +2025,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![0, 1, 2, 3],
             },
             Transcript {
                 chr_idx: 0,
@@ -2042,7 +2039,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![0, 1, 2, 3],
             },
         ];
 
@@ -2091,7 +2087,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         }];
 
         let records = SamWriter::build_transcriptome_records(
@@ -2182,7 +2177,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let mate2_transcript = Transcript {
@@ -2204,7 +2198,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2],
         };
 
         let mate_seq = vec![0, 1, 2, 3];
@@ -2300,7 +2293,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 4],
         };
 
         // Mate2 at position 4 (chr_start=0, so per-chr pos = 5)
@@ -2323,7 +2315,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 3],
         };
 
         let mate_seq = vec![0; 4];
@@ -2400,7 +2391,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         let t2 = Transcript {
@@ -2422,7 +2412,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         let mut rec1 = RecordBuf::default();
@@ -2480,7 +2469,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         let t2 = Transcript {
@@ -2502,7 +2490,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         let mut rec1 = RecordBuf::default();
@@ -2540,7 +2527,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -2659,7 +2645,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -2713,7 +2698,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![0; 4],
             },
             Transcript {
                 chr_idx: 0,
@@ -2728,7 +2712,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![0; 4],
             },
             Transcript {
                 chr_idx: 0,
@@ -2743,7 +2726,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![0; 4],
             },
         ];
 
@@ -2802,7 +2784,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 4],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -2853,7 +2834,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 4],
         };
         // Two alignments tied for the best score (100), one strictly worse (98).
         let transcripts = vec![mk(0, 100), mk(2, 98), mk(4, 100)];
@@ -2912,7 +2892,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![0; 4],
             },
             Transcript {
                 chr_idx: 0,
@@ -2927,7 +2906,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![0; 4],
             },
         ];
 
@@ -2981,7 +2959,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 4],
         };
         let mate2 = Transcript {
             genome_start: 120,
@@ -3037,7 +3014,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![SpliceMotif::GtAg],
             junction_annotated: vec![false],
-            read_seq: vec![0; 4],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -3083,7 +3059,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0; 4],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -3133,7 +3108,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![SpliceMotif::CtAc],
             junction_annotated: vec![false],
-            read_seq: vec![0; 4],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -3185,7 +3159,6 @@ mod tests {
             n_junction: 2,
             junction_motifs: vec![SpliceMotif::GtAg, SpliceMotif::CtAc], // +strand and -strand
             junction_annotated: vec![false, false],
-            read_seq: vec![0; 4],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -3235,7 +3208,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![SpliceMotif::GtAg],
             junction_annotated: vec![false],
-            read_seq: vec![0; 4],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -3289,7 +3261,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![0; 4],
             })
             .collect();
 
@@ -3362,7 +3333,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![SpliceMotif::GtAg],
             junction_annotated: vec![false],
-            read_seq: vec![],
         };
 
         let jm = build_jm_tag(&transcript);
@@ -3391,7 +3361,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![SpliceMotif::GtAg],
             junction_annotated: vec![true],
-            read_seq: vec![],
         };
 
         let jm = build_jm_tag(&transcript);
@@ -3416,7 +3385,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         assert!(build_jm_tag(&transcript).is_none());
@@ -3444,7 +3412,6 @@ mod tests {
             n_junction: 2,
             junction_motifs: vec![SpliceMotif::GtAg, SpliceMotif::CtAc],
             junction_annotated: vec![true, false],
-            read_seq: vec![],
         };
 
         let jm = build_jm_tag(&transcript);
@@ -3473,7 +3440,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![SpliceMotif::GtAg],
             junction_annotated: vec![false],
-            read_seq: vec![],
         };
 
         // chr_start=0, genome_start=100, intron starts at 125, ends at 324
@@ -3499,7 +3465,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         };
 
         assert!(build_ji_tag(&transcript, 0).is_none());
@@ -3523,7 +3488,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         // Read exactly matches genome[0..4] = ACGT
@@ -3550,7 +3514,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 0, 2, 0], // A,A,G,A vs genome A,C,G,T
         };
 
         // Position 1: read=A, ref=C → mismatch (C in MD)
@@ -3582,7 +3545,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 0, 1], // AC + AC (genome AC^GT AC)
         };
 
         // Read: A,C,[del G,T],A,C
@@ -3613,7 +3575,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 3, 3, 2, 3], // AC + TT(ins) + GT
         };
 
         // Insertions are invisible in MD — just match counts
@@ -3644,7 +3605,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 0, 2, 3, 0, 1, 0, 0], // XX + GTAC + XX
         };
 
         // Soft clips don't appear in MD
@@ -3672,7 +3632,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -3730,7 +3689,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         // Mate2: reverse, chr 0, pos 4
@@ -3753,7 +3711,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2],
         };
 
         let seq = vec![0, 1, 2, 3];
@@ -3839,7 +3796,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         // Mate2: score=80, 2 mismatches, 1 deletion
@@ -3866,7 +3822,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2],
         };
 
         let seq1 = vec![0, 1, 2, 3];
@@ -3968,7 +3923,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let mate2_trans = Transcript {
@@ -3990,7 +3944,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2],
         };
 
         let seq = vec![0, 1, 2, 3];
@@ -4063,7 +4016,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -4142,7 +4094,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -4218,7 +4169,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -4359,7 +4309,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -4414,7 +4363,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let read_seq = vec![0, 1, 2, 3];
@@ -4501,7 +4449,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let mate1_seq = vec![0, 1, 2, 3]; // ACGT
@@ -4574,7 +4521,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let mate1_seq = vec![0, 1, 2, 3];
@@ -4660,7 +4606,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![0, 1, 2, 3],
         };
 
         let mate1_seq = vec![0, 1, 2, 3];
@@ -4732,7 +4677,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![SpliceMotif::GtAg],
             junction_annotated: vec![false],
-            read_seq: vec![0; 4],
         }
     }
 

--- a/src/quant/mod.rs
+++ b/src/quant/mod.rs
@@ -629,7 +629,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         }
     }
 
@@ -745,7 +744,6 @@ mod tests {
                 n_junction: 0,
                 junction_motifs: vec![],
                 junction_annotated: vec![],
-                read_seq: vec![],
             };
             assert_eq!(
                 ann.overlapping_genes(&t),

--- a/src/quant/transcriptome.rs
+++ b/src/quant/transcriptome.rs
@@ -1133,7 +1133,6 @@ fn align_to_one_transcript(
         n_junction: 0,
         junction_motifs: Vec::new(),
         junction_annotated: Vec::new(),
-        read_seq: Vec::new(),
     })
 }
 
@@ -2054,7 +2053,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         }
     }
 

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -200,7 +200,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         }
     }
 

--- a/src/solo/gene.rs
+++ b/src/solo/gene.rs
@@ -382,7 +382,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: Vec::new(),
             junction_annotated: Vec::new(),
-            read_seq: Vec::new(),
         }
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -797,7 +797,6 @@ mod tests {
             n_junction: 1,
             junction_motifs: vec![SpliceMotif::GtAg],
             junction_annotated: vec![true],
-            read_seq: vec![0; 110],
         };
 
         stats.record_transcript_stats(&transcript);
@@ -918,7 +917,6 @@ mod tests {
                 SpliceMotif::NonCanonical, // motif[0]
             ],
             junction_annotated: vec![true, false, true, false],
-            read_seq: vec![0; 100],
         };
 
         stats.record_transcript_stats(&transcript);

--- a/src/wasp/mod.rs
+++ b/src/wasp/mod.rs
@@ -608,7 +608,6 @@ mod tests {
             n_junction: 0,
             junction_motifs: vec![],
             junction_annotated: vec![],
-            read_seq: vec![],
         }
     }
 


### PR DESCRIPTION
`Transcript::read_seq` is filled with a full copy of the read at every finalised alignment, and nothing in the crate reads it.

## How I know nothing reads it

Not from grepping. I deleted the field and asked the compiler. All 97 resulting errors are struct literals or assignments:

```
error[E0560]: struct `Transcript` has no field named `read_seq`
  --> src/align/stitch.rs:2158:9    read_seq: read_seq.to_vec(),
error[E0609]: no field `read_seq` on type `Transcript`
  --> src/align/stitch.rs:2698:28   transcript.read_seq = read_seq.to_vec();
  --> src/align/read_align.rs:892   t1.read_seq = mate1_seq.to_vec();
  ...
```

Not one read site, in `src` or in tests. The three places that looked like readers on a grep are something else: `io/sam.rs:265` uses a local parameter of the same name, and `chimeric/output.rs:148,157` read `ChimericAlignment::read_seq`, a different struct filled from its own parameter in `chimeric/detect.rs`.

## What it costs

Measured on 200 000 real reads (`ERR12389696`, yeast) at 8 threads, with the global allocator wrapped in a counter:

| | allocations | bytes |
|---|---|---|
| before | 200 093 070 | 401 267 330 431 |
| after | 184 966 576 | 397 400 813 793 |

**15.1 million allocations removed, 7.6% of the total, and 3.87 GB of copying.** About 50 transcripts are finalised per read, each copying the whole read.

## Wall clock: no change, and that is the interesting part

Six interleaved rounds, 2M reads, `--runThreadN 16`, 87-92% CPU idle:

| | median |
|---|---|
| before | 20.90 s |
| after | 20.65 s |

Direction mixed, inside the run-to-run spread. One round had a clear outlier which I have not excluded from the medians.

So removing 7.6% of all allocations moves nothing measurable. mimalloc is fast, and it is already tuned in `src/main.rs`. **That calibrates #168 downward**: I estimated an ~11% ceiling for allocation work from the profile's mimalloc share, and this says that estimate is too generous. I would not spend a new dependency on the rest of it without a workload that shows the cost, and I have updated #168 accordingly.

The reason to take this change is that the field is dead weight, which `CONTRIBUTING.md` rules out on its own terms. The allocations are a bonus, not the argument.

## One thing needing your call

`Transcript::read_seq` is `pub`, so this is an API removal. Nothing outside the crate can be relying on its *contents*, since it is only ever written, but the field disappearing is still a breaking change for anyone naming it. Say the word if you would rather keep it as a deprecated always-empty field for a release.

## Verification

Output-neutral: SAM byte-identical on 200 000 real reads against `origin/main`, whole file including header.

Gate: 560 lib + 26 integration tests, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, all green.
