### PR TITLE
fix(solo): MultiGeneUMI_CR was inert — a tied UMI goes to nobody, not everybody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Bug fixes
 
+- `--soloUMIfiltering MultiGeneUMI_CR` kept every gene tied at the
+  highest read count; CellRanger gives a tied UMI to no gene at all.
+  Since one read per gene is the ordinary shape of a multi-gene UMI, the
+  flag removed nothing in practice. On a 20k-read 10x fixture the count
+  matrix moves from 16 465 to 15 414 against STAR's 15 423.
+
 - **STARsolo `Gene` assignment now requires exon concordance**, matching
   STARsolo: a read counts toward a gene only when every aligned block
   lies within the gene's exons, rather than merely overlapping one. This

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -822,8 +822,43 @@ fn filter_multi_gene_umi(genes: &HashMap<u32, u32>, filtering: UmiFiltering) -> 
             let thresh = if max == 1 { 2 } else { max };
             genes.iter().filter(|&(_, &rc)| rc >= thresh).collect()
         }
-        // CellRanger > 3.0: keep the highest-read-count gene(s); no singleton drop.
-        UmiFiltering::MultiGeneUmiCr => genes.iter().filter(|&(_, &rc)| rc >= max).collect(),
+        // CellRanger: the gene with the strictly highest read count takes the
+        // UMI, and a tie gives it to nobody.
+        //
+        // STAR `SoloFeature_collapseUMIall.cpp:212-224` walks the genes keeping
+        // a running maximum, and clears its winner whenever it meets an equal
+        // count:
+        //
+        // ```cpp
+        // if (ig.second>maxu) { maxu=ig.second; maxg=ig.first; }
+        // else if (ig.second==maxu) { maxg=-1; };
+        // ...
+        // if ( maxg+1==0 ) continue; // not counted for any gene
+        // ```
+        //
+        // The outcome does not depend on the order the genes are visited: a
+        // strict maximum always ends as the winner, and any tie at the maximum
+        // always ends with none. So iterating a `HashMap` here is safe.
+        //
+        // This previously kept every gene tied at the maximum, which is the
+        // opposite decision on exactly the case the rule exists for, and made
+        // the flag inert on the common shape of one read per gene.
+        UmiFiltering::MultiGeneUmiCr => {
+            let mut best_count = 0u32;
+            let mut winner: Option<&u32> = None;
+            for (gene, &rc) in genes {
+                if rc > best_count {
+                    best_count = rc;
+                    winner = Some(gene);
+                } else if rc == best_count {
+                    winner = None;
+                }
+            }
+            match winner {
+                Some(gene) => vec![(gene, genes.get(gene).expect("winner is a key"))],
+                None => Vec::new(),
+            }
+        }
         UmiFiltering::None => unreachable!(),
     }
 }
@@ -2055,6 +2090,43 @@ mod tests {
             UmiFiltering::MultiGeneUmiCr
         );
         assert!("bogus".parse::<UmiFiltering>().is_err());
+    }
+
+    /// The case the rule exists for, and the one the old code got backwards:
+    /// when two genes tie on read count, CellRanger counts the UMI for
+    /// neither. STAR clears its winner on an equal count
+    /// (`SoloFeature_collapseUMIall.cpp:212-224`) and skips the UMI when no
+    /// strict maximum survives.
+    ///
+    /// One read per gene is the common shape of a multi-gene UMI, so keeping
+    /// the ties made `--soloUMIfiltering MultiGeneUMI_CR` inert in practice:
+    /// on a 20 000-read 10x fixture it removed nothing at all, against 1 030
+    /// counts removed by STAR.
+    #[test]
+    fn multi_gene_umi_cr_drops_a_tie_entirely() {
+        let mut tied = HashMap::default();
+        tied.insert(0u32, 1u32);
+        tied.insert(1u32, 1u32);
+        assert!(filter_multi_gene_umi(&tied, UmiFiltering::MultiGeneUmiCr).is_empty());
+
+        // A tie at the maximum loses even when a third gene sits below it.
+        let mut tied_with_loser = HashMap::default();
+        tied_with_loser.insert(0u32, 5u32);
+        tied_with_loser.insert(1u32, 5u32);
+        tied_with_loser.insert(2u32, 3u32);
+        assert!(
+            filter_multi_gene_umi(&tied_with_loser, UmiFiltering::MultiGeneUmiCr).is_empty(),
+            "a tie at the maximum takes the UMI from everyone, including the third gene"
+        );
+
+        // A strict maximum still wins, whatever else is present.
+        let mut strict = HashMap::default();
+        strict.insert(0u32, 5u32);
+        strict.insert(1u32, 4u32);
+        strict.insert(2u32, 4u32);
+        let kept = filter_multi_gene_umi(&strict, UmiFiltering::MultiGeneUmiCr);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(*kept[0].0, 0);
     }
 
     #[test]


### PR DESCRIPTION
`--soloUMIfiltering MultiGeneUMI_CR` removed nothing at all. It kept every gene tied at the highest read count; CellRanger's rule gives a tied UMI to no gene.

Fixes the first of the two inert flags in #172.

## The rule

STAR walks the genes for a UMI keeping a running maximum, and clears its winner whenever it meets an equal count (`SoloFeature_collapseUMIall.cpp:212-224`):

```cpp
uint32 maxu=0, maxg=-1;
for (const auto &ig : iu.second) {
    if (ig.second>maxu) { maxu=ig.second; maxg=ig.first; }
    else if (ig.second==maxu) { maxg=-1; };
};
if ( maxg+1==0 )
    continue; //this umi is not counted for any gene, because two genes have the same read count for this UMI
```

Strict maximum takes the UMI; a tie takes it from everyone. The code here kept `rc >= max`, which on a tie keeps *all* the tied genes — the opposite decision on precisely the case the rule exists to settle.

That is why the flag was inert rather than merely inaccurate: one read per gene is the ordinary shape of a multi-gene UMI, and it is always a tie.

## Measured

20 000-read 10x fixture: 200 cells drawn from the real `3M-february-2018` whitelist, 400 yeast genes, 720 UMIs deliberately shared between two genes in the same cell. STAR 2.7.11b against this branch, same flags, raw `Gene` matrix compared entry by entry.

| | identical entries | STAR counts | rustar counts |
|---|---|---|---|
| before | 13 749 / 14 806 | 15 423 | 16 465 |
| **after** | **13 902 / 13 967** | 15 423 | **15 414** |

The gap goes from **+1 042 counts to −9**. STAR removes 1 030 counts with this flag; before this change rustar removed zero.

With the full CellRanger-matching flag set, the total gap drops from +1 341 (+8.9%) to +290 (+1.9%). The remainder is `--soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts`, the second inert flag in #172, which is a separate change.

## Determinism

The rule is order-independent: a strict maximum always ends as the winner whatever order the genes are visited in, and a tie at the maximum always ends with none. Iterating a `HashMap` here therefore stays deterministic, and the comment says so at the site.

## What is still missing, said plainly

STAR applies a second condition I have **not** implemented: the winning gene must also hold the top count among *uncorrected* UMIs (`umiGeneMapCount0`, same file, lines 226-232). That needs the counts from before UMI correction, which this code does not retain, so it is a larger change. The 65 entries still differing out of 13 967 are where to look for its effect — 30 STAR-only, 23 rustar-only, 12 differing.

I would rather land the 1 030-count fix now and treat the second condition as its own change than bundle a restructure into it.

## Verification

- `multi_gene_umi_cr_drops_a_tie_entirely` — a two-gene tie, a tie at the maximum with a third gene below it, and a strict maximum that still wins. The existing `multi_gene_umi_cr_keeps_top_gene` only covered 3 reads against 1, where both rules agree, which is why the defect survived.

Gate: 561 lib + 26 integration tests, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, all green.

The fixture generator and matrix comparison are not in this PR; they belong with the replacement of the three-entry differential (item 4 of #172), so that the numbers above become a test rather than a claim.
