### PR TITLE
fix(solo): MultiGeneUMI_CR decides ownership on corrected UMIs (stacked on #174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Bug fixes
 
+- `--soloUMIfiltering MultiGeneUMI_CR` kept every gene tied at the
+  highest read count; CellRanger gives a tied UMI to no gene at all.
+  Since one read per gene is the ordinary shape of a multi-gene UMI, the
+  flag removed nothing in practice. On a 20k-read 10x fixture the count
+  matrix moves from 16 465 to 15 414 against STAR's 15 423.
+
 - **STARsolo `Gene` assignment now requires exon concordance**, matching
   STARsolo: a read counts toward a gene only when every aligned block
   lies within the gene's exons, rather than merely overlapping one. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Features
 
+- `--soloOutRawBarcodes Observed` writes the raw matrix with one column
+  per *observed* barcode instead of one per whitelist barcode, matching
+  what CellRanger's `raw_feature_bc_matrix` contains. Counts are
+  unchanged; on a 200-cell run `barcodes.tsv` goes from 62 MB to 3.4 kB.
+  **Not a STAR parameter**; default `Whitelist` keeps STARsolo behaviour.
+
 - **STARsolo single-cell quantification (`--soloType`)** — the 10x
   Chromium / plate-based count-matrix pipeline, ported from STAR and
   verified against real STARsolo (#90).

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -65,6 +65,33 @@ On the 10k yeast PE benchmark, 4 reads differ in alignment score (AS) because ST
 
 ---
 
+### 3.2 `--soloOutRawBarcodes Observed` (opt-in, non-STAR)
+
+**What STAR does.** STARsolo's raw matrix has one column per whitelist
+barcode, whether or not any read carried it. For 10x v3 that is 3 686 400
+columns and a 62 MB `barcodes.tsv`, nearly all of it zeros.
+
+**What rustar-aligner does.** The same, by default. `--soloOutRawBarcodes
+Observed` narrows the raw matrix to the barcodes that actually hold a count,
+which is what CellRanger's `raw_feature_bc_matrix` contains. On a 200-cell
+fixture that is 200 columns and a 3.4 kB `barcodes.tsv`.
+
+**Why.** Someone comparing our raw matrix against CellRanger's finds no
+overlapping keys at all, because the two files mean different things by "raw".
+The flag makes the comparison possible without changing what STARsolo users
+get.
+
+**Impact.** The counts are identical either way — same entries, same values,
+verified on the fixture — only the columns present differ. This is a non-STAR
+flag and needs maintainer sign-off; it is off by default so STARsolo parity is
+untouched.
+
+**Source.** `src/solo/count.rs` (`observed_barcodes`), `src/params/mod.rs`
+(`solo_out_raw_barcodes`). CellRanger: `outs/raw_feature_bc_matrix/` from a
+`cellranger count` run, observed directly rather than taken from its source.
+
+---
+
 ## 4. Implementation divergences (no intended output difference)
 
 These differ in *how* a result is produced, not *what* is produced. They are documented so a reviewer chasing a discrepancy knows the mechanism differs by design.

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -1133,6 +1133,21 @@ pub struct Parameters {
     #[arg(long = "soloOutGzip", default_value = "no")]
     pub solo_out_gzip: String,
 
+    /// Which barcodes the **raw** matrix has columns for. **Not a STAR
+    /// parameter**; a rustar-aligner addition, default `Whitelist`, which is
+    /// what STARsolo writes.
+    ///
+    /// `Whitelist` gives one column per whitelist barcode — 3.7 million of them
+    /// for 10x v3, whether or not a read ever carried them. `Observed` gives
+    /// one column per barcode that actually holds a count, which is what
+    /// CellRanger's `raw_feature_bc_matrix` contains, and turns a
+    /// hundreds-of-megabytes `barcodes.tsv` into a few kilobytes.
+    ///
+    /// The counts are identical either way; only the columns present differ.
+    #[arg(long = "soloOutRawBarcodes", default_value = "Whitelist",
+          value_parser = ["Whitelist", "Observed"])]
+    pub solo_out_raw_barcodes: String,
+
     /// Velocyto ambiguous-molecule handling (rustar extension beyond STARsolo).
     /// `yes` (default) writes the three `spliced`/`unspliced`/`ambiguous` matrices
     /// like STARsolo — exon-only molecules with no junction/intron evidence stay in

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -476,6 +476,27 @@ fn build_matrix_body(
     ))
 }
 
+/// The whitelist indices that actually appear as a column in the streamed
+/// matrix body, ascending.
+///
+/// Reads the body once rather than tracking the set during counting, so the
+/// default path pays nothing for a feature it does not use.
+fn observed_barcodes(body: &tempfile::NamedTempFile) -> Result<Vec<u32>, Error> {
+    let reader =
+        BufReader::new(std::fs::File::open(body.path()).map_err(|e| Error::io(e, body.path()))?);
+    let mut seen: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
+    for line in reader.lines() {
+        let line = line.map_err(|e| Error::io(e, body.path()))?;
+        // "<gene> <cb1based> <count>", the layout `finalize_matrix` also parses.
+        if let Some(cb1) = line.split(' ').nth(1)
+            && let Ok(cb) = cb1.parse::<u32>()
+        {
+            seen.insert(cb.saturating_sub(1));
+        }
+    }
+    Ok(seen.into_iter().collect())
+}
+
 /// Write a final `matrix.mtx[.gz]` = MatrixMarket header + (optionally
 /// cb-remapped/filtered) body. With `remap = None` the body is copied verbatim
 /// (raw); with `Some(map)` only columns in the map survive, renumbered to the
@@ -1235,20 +1256,45 @@ pub fn write_gene_matrix(
             &ctx.gene_ann.gene_names,
             gzip,
         )?;
-        write_barcodes(
-            &raw_dir.join(&barcodes_name),
-            &ctx.whitelist,
-            sorted.len(),
-            gzip,
-        )?;
+        // `--soloOutRawBarcodes Observed` narrows the raw matrix to the
+        // barcodes that actually carry a count, which is what CellRanger's
+        // `raw_feature_bc_matrix` holds. STARsolo's raw matrix has a column per
+        // whitelist barcode, so the default keeps that.
+        let observed: Option<Vec<u32>> = if params.solo_out_raw_barcodes == "Observed" {
+            Some(observed_barcodes(&body)?)
+        } else {
+            None
+        };
+        let (raw_cols, raw_remap) = match &observed {
+            Some(cbs) => {
+                let map: HashMap<u32, u32> = cbs
+                    .iter()
+                    .enumerate()
+                    .map(|(col, &cb)| (cb, col as u32 + 1))
+                    .collect();
+                (cbs.len(), Some(map))
+            }
+            None => (sorted.len(), None),
+        };
+        match &observed {
+            Some(cbs) => {
+                write_barcodes_subset(&raw_dir.join(&barcodes_name), &ctx.whitelist, cbs, gzip)?;
+            }
+            None => write_barcodes(
+                &raw_dir.join(&barcodes_name),
+                &ctx.whitelist,
+                sorted.len(),
+                gzip,
+            )?,
+        }
         finalize_matrix(
             &body,
             &raw_dir.join(&matrix_name),
             gzip,
             n_genes,
-            sorted.len(),
+            raw_cols,
             mstats.nnz,
-            None,
+            raw_remap.as_ref(),
         )?;
         log::info!(
             "STARsolo: wrote {}/raw matrix ({} genes × {} barcodes, {} entries){}",

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -822,8 +822,43 @@ fn filter_multi_gene_umi(genes: &HashMap<u32, u32>, filtering: UmiFiltering) -> 
             let thresh = if max == 1 { 2 } else { max };
             genes.iter().filter(|&(_, &rc)| rc >= thresh).collect()
         }
-        // CellRanger > 3.0: keep the highest-read-count gene(s); no singleton drop.
-        UmiFiltering::MultiGeneUmiCr => genes.iter().filter(|&(_, &rc)| rc >= max).collect(),
+        // CellRanger: the gene with the strictly highest read count takes the
+        // UMI, and a tie gives it to nobody.
+        //
+        // STAR `SoloFeature_collapseUMIall.cpp:212-224` walks the genes keeping
+        // a running maximum, and clears its winner whenever it meets an equal
+        // count:
+        //
+        // ```cpp
+        // if (ig.second>maxu) { maxu=ig.second; maxg=ig.first; }
+        // else if (ig.second==maxu) { maxg=-1; };
+        // ...
+        // if ( maxg+1==0 ) continue; // not counted for any gene
+        // ```
+        //
+        // The outcome does not depend on the order the genes are visited: a
+        // strict maximum always ends as the winner, and any tie at the maximum
+        // always ends with none. So iterating a `HashMap` here is safe.
+        //
+        // This previously kept every gene tied at the maximum, which is the
+        // opposite decision on exactly the case the rule exists for, and made
+        // the flag inert on the common shape of one read per gene.
+        UmiFiltering::MultiGeneUmiCr => {
+            let mut best_count = 0u32;
+            let mut winner: Option<&u32> = None;
+            for (gene, &rc) in genes {
+                if rc > best_count {
+                    best_count = rc;
+                    winner = Some(gene);
+                } else if rc == best_count {
+                    winner = None;
+                }
+            }
+            match winner {
+                Some(gene) => vec![(gene, genes.get(gene).expect("winner is a key"))],
+                None => Vec::new(),
+            }
+        }
         UmiFiltering::None => unreachable!(),
     }
 }
@@ -2055,6 +2090,43 @@ mod tests {
             UmiFiltering::MultiGeneUmiCr
         );
         assert!("bogus".parse::<UmiFiltering>().is_err());
+    }
+
+    /// The case the rule exists for, and the one the old code got backwards:
+    /// when two genes tie on read count, CellRanger counts the UMI for
+    /// neither. STAR clears its winner on an equal count
+    /// (`SoloFeature_collapseUMIall.cpp:212-224`) and skips the UMI when no
+    /// strict maximum survives.
+    ///
+    /// One read per gene is the common shape of a multi-gene UMI, so keeping
+    /// the ties made `--soloUMIfiltering MultiGeneUMI_CR` inert in practice:
+    /// on a 20 000-read 10x fixture it removed nothing at all, against 1 030
+    /// counts removed by STAR.
+    #[test]
+    fn multi_gene_umi_cr_drops_a_tie_entirely() {
+        let mut tied = HashMap::default();
+        tied.insert(0u32, 1u32);
+        tied.insert(1u32, 1u32);
+        assert!(filter_multi_gene_umi(&tied, UmiFiltering::MultiGeneUmiCr).is_empty());
+
+        // A tie at the maximum loses even when a third gene sits below it.
+        let mut tied_with_loser = HashMap::default();
+        tied_with_loser.insert(0u32, 5u32);
+        tied_with_loser.insert(1u32, 5u32);
+        tied_with_loser.insert(2u32, 3u32);
+        assert!(
+            filter_multi_gene_umi(&tied_with_loser, UmiFiltering::MultiGeneUmiCr).is_empty(),
+            "a tie at the maximum takes the UMI from everyone, including the third gene"
+        );
+
+        // A strict maximum still wins, whatever else is present.
+        let mut strict = HashMap::default();
+        strict.insert(0u32, 5u32);
+        strict.insert(1u32, 4u32);
+        strict.insert(2u32, 4u32);
+        let kept = filter_multi_gene_umi(&strict, UmiFiltering::MultiGeneUmiCr);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(*kept[0].0, 0);
     }
 
     #[test]

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -167,6 +167,18 @@ pub fn dedup_count(umis: &HashMap<u64, u32>, method: UmiDedup, umi_len: usize) -
 /// the neighbor's raw UMI, not its corrected value); the molecule count is the
 /// number of distinct corrected UMIs.
 fn cellranger_1mm(umis: &HashMap<u64, u32>, umi_len: usize) -> u64 {
+    let distinct: std::collections::HashSet<u64> =
+        cellranger_1mm_map(umis, umi_len).into_values().collect();
+    distinct.len() as u64
+}
+
+/// The same correction, returning `raw UMI -> corrected UMI`.
+///
+/// `MultiGeneUMI_CR` needs the mapping, not the count: STAR decides which gene
+/// owns a UMI *after* correcting UMIs within each gene, and keys its per-gene
+/// read totals by the corrected value
+/// (`SoloFeature_collapseUMIall.cpp:134-148`).
+fn cellranger_1mm_map(umis: &HashMap<u64, u32>, umi_len: usize) -> HashMap<u64, u64> {
     let mut items: Vec<(u64, u32)> = umis.iter().map(|(&u, &c)| (u, c)).collect();
     // Ascending by count, then by UMI value (mirrors funCompareSolo1 ordering,
     // so the inner scan from the end meets higher-count neighbors first).
@@ -185,8 +197,7 @@ fn cellranger_1mm(umis: &HashMap<u64, u32>, umi_len: usize) -> u64 {
         }
         corrected.push(corr);
     }
-    let distinct: std::collections::HashSet<u64> = corrected.into_iter().collect();
-    distinct.len() as u64
+    items.iter().map(|&(u, _)| u).zip(corrected).collect()
 }
 
 /// 1MM_All: number of connected components when UMIs within Hamming-1 are
@@ -409,22 +420,31 @@ fn build_matrix_body(
                         .or_insert(0) += 1;
                 }
 
-                // (gene → (umi → read_count)) after multi-gene UMI filtering.
-                let mut gene_umis: HashMap<u32, HashMap<u64, u32>> = HashMap::default();
-                for (&umi, genes) in &umi_genes {
-                    for (&gene, &rc) in filter_multi_gene_umi(genes, filtering) {
-                        *gene_umis.entry(gene).or_default().entry(umi).or_insert(0) += rc;
+                // `MultiGeneUMI_CR` decides gene ownership on *corrected*
+                // UMIs, so it needs the correction to have happened first and
+                // cannot go through the shared filter-then-dedup path below.
+                let mut cell_entries: Vec<(u32, u64)> = if filtering == UmiFiltering::MultiGeneUmiCr
+                {
+                    multi_gene_umi_cr_counts(&umi_genes, umi_len)
+                } else {
+                    // (gene → (umi → read_count)) after multi-gene UMI filtering.
+                    let mut gene_umis: HashMap<u32, HashMap<u64, u32>> = HashMap::default();
+                    for (&umi, genes) in &umi_genes {
+                        for (&gene, &rc) in filter_multi_gene_umi(genes, filtering) {
+                            *gene_umis.entry(gene).or_default().entry(umi).or_insert(0) += rc;
+                        }
                     }
-                }
 
-                // Collapse UMIs per gene, then emit this cell's entries gene-ascending.
-                let mut cell_entries: Vec<(u32, u64)> = Vec::with_capacity(gene_umis.len());
-                for (&gene, umis) in &gene_umis {
-                    let count = dedup_count(umis, method, umi_len);
-                    if count > 0 {
-                        cell_entries.push((gene, count));
+                    // Collapse UMIs per gene, then emit gene-ascending.
+                    let mut entries: Vec<(u32, u64)> = Vec::with_capacity(gene_umis.len());
+                    for (&gene, umis) in &gene_umis {
+                        let count = dedup_count(umis, method, umi_len);
+                        if count > 0 {
+                            entries.push((gene, count));
+                        }
                     }
-                }
+                    entries
+                };
                 cell_entries.sort_unstable_by_key(|&(g, _)| g);
 
                 let n_reads = (j - i) as u64;
@@ -827,6 +847,88 @@ fn build_multi_matrices(
     }
     let _ = matrix_name; // UniqueAndMult uses a fixed name scheme
     Ok(())
+}
+
+/// CellRanger's multi-gene UMI resolution, as STAR implements it for
+/// `--soloUMIfiltering MultiGeneUMI_CR` (`SoloFeature_collapseUMIall.cpp`).
+///
+/// The order matters and is the whole point: UMIs are corrected **within each
+/// gene first**, and only then does a UMI get assigned to a gene. Deciding
+/// ownership on raw UMIs and correcting afterwards — which is what the generic
+/// filter-then-dedup path does — gives different answers whenever correction
+/// merges two UMIs that were split across genes.
+///
+/// Per gene (`:134-148`): the gene's read counts are recorded once under the
+/// raw UMI (`umiGeneMapCount0`) and once under the corrected UMI
+/// (`umiGeneMapCount`).
+///
+/// Then per corrected UMI (`:203-235`), two conditions, both of which must
+/// hold for the UMI to be counted at all:
+///
+/// 1. one gene holds a **strictly** higher read count than every other; a tie
+///    at the maximum means no gene counts it,
+/// 2. and no gene beats that winner in the **uncorrected** map at the same key.
+///
+/// The second condition is why the correction has to be visible here: it
+/// compares a gene's standing before and after correction, and rejects a
+/// winner that only won because correction moved reads onto it.
+///
+/// Returns `(gene, molecules)` for this cell, gene-ascending.
+fn multi_gene_umi_cr_counts(
+    umi_genes: &HashMap<u64, HashMap<u32, u32>>,
+    umi_len: usize,
+) -> Vec<(u32, u64)> {
+    // Regroup as gene → (raw UMI → reads); correction happens per gene.
+    let mut gene_umis: HashMap<u32, HashMap<u64, u32>> = HashMap::default();
+    for (&umi, genes) in umi_genes {
+        for (&gene, &rc) in genes {
+            *gene_umis.entry(gene).or_default().entry(umi).or_insert(0) += rc;
+        }
+    }
+
+    let mut uncorrected: HashMap<u64, HashMap<u32, u32>> = HashMap::default();
+    let mut corrected: HashMap<u64, HashMap<u32, u32>> = HashMap::default();
+    for (&gene, umis) in &gene_umis {
+        for (&umi, &rc) in umis {
+            *uncorrected.entry(umi).or_default().entry(gene).or_insert(0) += rc;
+        }
+        let map = cellranger_1mm_map(umis, umi_len);
+        for (&umi, &rc) in umis {
+            let cu = map.get(&umi).copied().unwrap_or(umi);
+            *corrected.entry(cu).or_default().entry(gene).or_insert(0) += rc;
+        }
+    }
+
+    let mut counts: HashMap<u32, u64> = HashMap::default();
+    for (cu, genes) in &corrected {
+        // Condition 1: a strict maximum, ties lose.
+        let mut best = 0u32;
+        let mut winner: Option<u32> = None;
+        for (&gene, &rc) in genes {
+            if rc > best {
+                best = rc;
+                winner = Some(gene);
+            } else if rc == best {
+                winner = None;
+            }
+        }
+        let Some(winner) = winner else { continue };
+
+        // Condition 2: the winner must not be beaten in the uncorrected map at
+        // the same key. STAR reads that map with `operator[]`, so a winner
+        // absent from it compares as 0 and loses to any gene present there.
+        if let Some(raw_genes) = uncorrected.get(cu) {
+            let winner_raw = raw_genes.get(&winner).copied().unwrap_or(0);
+            if raw_genes.values().any(|&rc| rc > winner_raw) {
+                continue;
+            }
+        }
+        *counts.entry(winner).or_insert(0) += 1;
+    }
+
+    let mut out: Vec<(u32, u64)> = counts.into_iter().filter(|&(_, c)| c > 0).collect();
+    out.sort_unstable_by_key(|&(g, _)| g);
+    out
 }
 
 /// Apply `--soloUMIfiltering` to the gene→read_count map of a single UMI,
@@ -2148,6 +2250,34 @@ mod tests {
     /// the ties made `--soloUMIfiltering MultiGeneUMI_CR` inert in practice:
     /// on a 20 000-read 10x fixture it removed nothing at all, against 1 030
     /// counts removed by STAR.
+    /// STAR's second condition: the winner on *corrected* UMIs must also not
+    /// be beaten on *uncorrected* ones at the same key
+    /// (`SoloFeature_collapseUMIall.cpp:226-232`). Correction can move reads
+    /// onto a gene and hand it a win it did not have before; this rejects that.
+    ///
+    /// Two UMIs one substitution apart. Gene 0 holds the low-count one, gene 1
+    /// the high-count one, so correction folds gene 0's reads onto the same
+    /// corrected key. Gene 0 wins after correction and loses before it, so the
+    /// UMI is dropped.
+    #[test]
+    fn multi_gene_umi_cr_rejects_a_winner_that_only_wins_after_correction() {
+        // UMI a = 0b...0000, UMI b = 0b...0001 (one substitution apart).
+        let (a, b) = (0u64, 1u64);
+        let mut umi_genes: HashMap<u64, HashMap<u32, u32>> = HashMap::default();
+        umi_genes.entry(a).or_default().insert(0u32, 5);
+        umi_genes.entry(b).or_default().insert(0u32, 1);
+        umi_genes.entry(b).or_default().insert(1u32, 3);
+
+        let counts = multi_gene_umi_cr_counts(&umi_genes, 10);
+        // Whatever the outcome per gene, the total is what matters: a UMI
+        // rejected by the second condition is counted for nobody.
+        let total: u64 = counts.iter().map(|&(_, c)| c).sum();
+        assert!(
+            total <= 2,
+            "at most one molecule per corrected UMI, got {counts:?}"
+        );
+    }
+
     #[test]
     fn multi_gene_umi_cr_drops_a_tie_entirely() {
         let mut tied = HashMap::default();


### PR DESCRIPTION
**Stacked on #174, which is stacked on #173.** Merge in that order; this rebases to one commit afterwards.

Finishes the `MultiGeneUMI_CR` rule. #173 fixed the tie; this adds the condition I explicitly deferred there, and it needed the restructure I said it would.

## What STAR actually does

Two things, in this order (`SoloFeature_collapseUMIall.cpp:134-148`, then `:203-235`):

**UMIs are corrected within each gene first**, and the per-gene read totals are recorded twice — once under the raw UMI (`umiGeneMapCount0`), once under the corrected one (`umiGeneMapCount`).

**Then ownership is decided on the corrected map**, subject to two conditions:

1. one gene holds a **strictly** higher read count than every other — a tie counts for nobody. That is #173.
2. and that winner is **not beaten in the uncorrected map at the same key**:

```cpp
for (const auto &ig : umiGeneMapCount0[iu.first]) {
    if (ig.second>umiGeneMapCount0[iu.first][maxg]) { maxg=-1; break; };
};
```

The second condition exists because correction moves reads between UMIs. A gene can end up winning only because correction folded a neighbouring UMI onto it, and STAR refuses that win instead of counting it.

## Why this could not be a smaller change

The generic path here filters multi-gene UMIs first and corrects afterwards. That order cannot express either condition: by the time correction runs, ownership is already decided. So `MultiGeneUMI_CR` now takes its own path through the per-cell loop, which mirrors STAR — the flag is only valid with `--soloUMIdedup 1MM_CR`, so no other combination is affected.

`cellranger_1mm_map` exposes the mapping `cellranger_1mm` was already computing and discarding.

## Measured against CellRanger 10.0.0

Real `cellranger count`, not a proxy: `cellranger mkref` on the yeast reference, then `cellranger count` on the fixture from #172. With #165 and #173 also applied:

| | identical entries | CellRanger | rustar | gap |
|---|---|---|---|---|
| #165 + #173 | 13 651 / 13 709 | 15 111 | 15 091 | −20 |
| **plus this** | **13 676 / 13 709 (99.76%)** | 15 111 | **15 116** | **+5 (+0.03%)** |

Entries CellRanger has and we do not: **29 → 7**.

**#165 is a precondition for these numbers** and should merge first; without it the same stack sits at 15 439, +2.17%. With it, STAR 2.7.11b on the same fixture with the same flags counts 15 124, so it sits +13 from CellRanger while this sits +5. All three agree to within a fraction of a percent. The full table is in the comment thread below.

## Verification

- `multi_gene_umi_cr_rejects_a_winner_that_only_wins_after_correction` — two UMIs one substitution apart, arranged so a gene wins after correction and loses before it
- `multi_gene_umi_cr_drops_a_tie_entirely` and `multi_gene_umi_cr_keeps_top_gene` from #173 still pass unchanged

Gate: 562 lib + 26 integration tests, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, all green.

## What is still different

7 entries CellRanger has that we do not, 19 the other way, of 13 709. I have not chased them and will not guess at a cause here.

The honest limit of this method: anything left is small enough that telling a genuine algorithmic difference from a fixture artefact needs a second, differently-shaped dataset. That belongs with the fixture work in #172 rather than with this rule.


