### PR TITLE
perf(seed): batched prefetching MMP search — measured at 0.5%, not recommended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Features
 
+- On 10x geometry (`CB_UMI_Simple`, a whitelist, 16 bp CB, 10 or 12 bp
+  UMI), the five CellRanger-matching flags now **default** to their
+  CellRanger values. Any flag named on the command line wins, and the
+  substitution is logged. **This changes default output on 10x runs** and
+  diverges from STARsolo; see `DIVERGENCE.md` §1.3.
+
 - `--soloOutRawBarcodes Observed` writes the raw matrix with one column
   per *observed* barcode instead of one per whitelist barcode, matching
   what CellRanger's `raw_feature_bc_matrix` contains. Counts are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Features
 
+- Under `--soloOutLayout CellRanger`, `metrics_summary.csv` is written with
+  CellRanger 10.0.0's 20 metrics, in its order and value formats. STARsolo's
+  `Summary.csv` is unchanged and still written alongside. Twelve of the 20
+  match a real `cellranger count` run exactly on the test fixture; the
+  interpretation behind the other eight is in `DIVERGENCE.md` §3.4.
+
 - `--soloOutLayout CellRanger` writes the solo matrices in the shape
   `cellranger count` produces: `outs/raw_feature_bc_matrix/` and
   `outs/filtered_feature_bc_matrix/`, gzipped, with a `-1` GEM-well suffix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ## [Unreleased]
 
+### Other changes
+
+- `cluster_seeds` reuses its window-bin map across reads on a thread instead
+  of rebuilding it per read. Merging two windows re-keys every bin in the
+  merged span, so the per-read pre-sizing was only a floor and the map
+  rehashed; profiling a human 10x run put that rehash at 2.1% of on-CPU time.
+  Output-neutral, verified by an empty diff on 20 M read pairs.
+
 ### Features
 
 - On 10x geometry, `--soloFeatures` now defaults to `GeneFull` rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Bug fixes
 
+- `--soloUMIfiltering MultiGeneUMI_CR` kept every gene tied at the
+  highest read count; CellRanger gives a tied UMI to no gene at all.
+  Since one read per gene is the ordinary shape of a multi-gene UMI, the
+  flag removed nothing in practice. On a 20k-read 10x fixture the count
+  matrix moves from 16 465 to 15 414 against STAR's 15 423.
+
 - **STARsolo `Gene` assignment now requires exon concordance**, matching
   STARsolo: a read counts toward a gene only when every aligned block
   lies within the gene's exons, rather than merely overlapping one. This

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Features
 
+- On 10x geometry, `--soloFeatures` now defaults to `GeneFull` rather than
+  `Gene`: CellRanger has counted intronic reads toward the gene since v7.0.
+  Measured on 10x's `pbmc_1k_v3`, exonic-only counting is 30.5% below
+  CellRanger and `GeneFull` brings it to 1.6%. **This changes default counts
+  on 10x runs**; naming `--soloFeatures` explicitly still wins. See
+  `DIVERGENCE.md` §1.3.
+
 - `--soloCellFilter OrdMag` implements CellRanger's cell call: the same
   quantile-over-ratio rule as `CellRanger2.2`, but searching for the expected
   cell count by minimising `(OrdMag(x) - x)^2 / x` instead of fixing it at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Features
 
+- `--soloOutLayout CellRanger` writes the solo matrices in the shape
+  `cellranger count` produces: `outs/raw_feature_bc_matrix/` and
+  `outs/filtered_feature_bc_matrix/`, gzipped, with a `-1` GEM-well suffix
+  on every barcode and one raw column per observed barcode. It implies
+  `--soloOutGzip yes`, `--soloOutRawBarcodes Observed` and an `outs/`
+  output directory, each still overridable on the command line. Counts are
+  unchanged. It is the default on 10x geometry, which **changes where
+  output files are written** on those runs; see `DIVERGENCE.md` §3.3.
+
 - On 10x geometry (`CB_UMI_Simple`, a whitelist, 16 bp CB, 10 or 12 bp
   UMI), the five CellRanger-matching flags now **default** to their
   CellRanger values. Any flag named on the command line wins, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Features
 
+- `--soloOutRawBarcodes Observed` writes the raw matrix with one column
+  per *observed* barcode instead of one per whitelist barcode, matching
+  what CellRanger's `raw_feature_bc_matrix` contains. Counts are
+  unchanged; on a 200-cell run `barcodes.tsv` goes from 62 MB to 3.4 kB.
+  **Not a STAR parameter**; default `Whitelist` keeps STARsolo behaviour.
+
 - **STARsolo single-cell quantification (`--soloType`)** — the 10x
   Chromium / plate-based count-matrix pipeline, ported from STAR and
   verified against real STARsolo (#90).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ### Features
 
+- `--soloCellFilter OrdMag` implements CellRanger's cell call: the same
+  quantile-over-ratio rule as `CellRanger2.2`, but searching for the expected
+  cell count by minimising `(OrdMag(x) - x)^2 / x` instead of fixing it at
+  3 000. `EmptyDrops_CR` now uses it for its initial cell set, which is the
+  order CellRanger runs the two steps in; `CellRanger2.2` is unchanged and
+  remains the default. See `DIVERGENCE.md` §3.5.
+
 - Under `--soloOutLayout CellRanger`, `metrics_summary.csv` is written with
   CellRanger 10.0.0's 20 metrics, in its order and value formats. STARsolo's
   `Summary.csv` is unchanged and still written alongside. Twelve of the 20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ noodles-bgzf = { version = "0.49", features = ["libdeflate"] }
 
 [dev-dependencies]
 assert_cmd = "2"
+# Already a runtime dependency at the same version; listed here so the
+# integration tests can read the gzipped CellRanger-layout matrix files.
+flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
 predicates = "3"
 
 [build-dependencies]

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -191,8 +191,16 @@ denominators:
 * `Valid UMI Sequences` is measured over reads that reached the UMI check, i.e.
   those with a valid barcode.
 * `Sequencing Saturation` is `1 - molecules / reads` over the reads that
-  entered the matrix. This is the largest disagreement on the fixture: 12.8%
-  against CellRanger's 7.4%.
+  entered the matrix. This is the largest disagreement on the fixture: 12.7%
+  against CellRanger's 7.4%. 10x define it as
+  `1 - n_deduped_reads / n_reads`, with `n_deduped_reads` the number of unique
+  `(barcode, UMI, gene)` combinations among confidently mapped reads. Taking
+  that literally — counting distinct triples *before* UMI correction — gives
+  **0.0%** on this fixture, because no two reads here share an exact triple, so
+  the literal reading is ruled out and their numerator is the corrected
+  molecule count, as ours is. The residual is therefore the denominator: at
+  7.4% theirs implies about 16 300 reads where ours counts about 17 300. The
+  difference is which reads are "confidently mapped", not the formula.
 * `Mean Reads per Cell` is total reads over called cells, not reads-in-cells
   over called cells, which is what reproduces CellRanger's value.
 

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -158,6 +158,56 @@ taken from its source.
 
 ---
 
+### 3.4 `metrics_summary.csv` under the CellRanger layout (non-STAR)
+
+**What STAR does.** STARsolo writes `Summary.csv`, its own metric set with its
+own names. It has no `metrics_summary.csv`.
+
+**What rustar-aligner does.** The same, by default. Under
+`--soloOutLayout CellRanger` it *additionally* writes
+`metrics_summary.csv` with CellRanger 10.0.0's 20 metrics, in CellRanger's
+order and value formats. `Summary.csv` is written unchanged alongside it, so
+nothing STARsolo-faithful is altered. Under the CellRanger layout the older
+`CellRanger.summary.csv` is not written: its four rows are a subset of the
+metrics file.
+
+**Why.** The file is how a 10x pipeline reads run quality. Its 20 names are
+also the clearest public statement of what CellRanger measures, which makes it
+useful as a target even where our value differs.
+
+**Impact.** No count changes. It costs one extra gene-body overlap query per
+read, because the exonic/intronic split needs it and a `Gene`-only run does not
+otherwise do it.
+
+**Not all 20 are certainties.** Twelve match a real `cellranger count` 10.0.0
+run exactly on the 20 000-read fixture. The other eight follow from our own
+tallies under a stated interpretation, because CellRanger does not document the
+denominators:
+
+* `Reads Mapped Confidently to *` reads "confidently" as MAPQ 255, i.e. our
+  uniquely-mapped set.
+* `Reads Mapped Confidently to Transcriptome` is the `Gene` feature's own
+  uniquely-assigned read tally.
+* `Valid UMI Sequences` is measured over reads that reached the UMI check, i.e.
+  those with a valid barcode.
+* `Sequencing Saturation` is `1 - molecules / reads` over the reads that
+  entered the matrix. This is the largest disagreement on the fixture: 12.8%
+  against CellRanger's 7.4%.
+* `Mean Reads per Cell` is total reads over called cells, not reads-in-cells
+  over called cells, which is what reproduces CellRanger's value.
+
+The cell-count-dependent metrics (`Median Genes per Cell`,
+`Median UMI Counts per Cell`, `Total Genes Detected`) differ by 2-4 on the
+fixture, following the count differences recorded in §1.3 rather than a
+different definition.
+
+**Source.** `src/solo/count.rs` (`write_metrics_summary`, `metric_int`,
+`metric_pct`), `src/solo/mod.rs` (`Q30Stats`). CellRanger: the
+`metrics_summary.csv` of a `cellranger count` 10.0.0 run, observed directly
+rather than taken from its source.
+
+---
+
 ## 4. Implementation divergences (no intended output difference)
 
 These differ in *how* a result is produced, not *what* is produced. They are documented so a reviewer chasing a discrepancy knows the mechanism differs by design.

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -216,6 +216,44 @@ rather than taken from its source.
 
 ---
 
+### 3.5 `--soloCellFilter OrdMag`, and EmptyDrops_CR's initial cell set (non-STAR)
+
+**What STAR does.** STARsolo's cell calling is `CellRanger2.2`: take the
+`quantile` of the top `nExpectedCells` barcodes by UMI count and call every
+barcode holding at least that over `maxMinRatio`, with `nExpectedCells` fixed
+at 3 000. `EmptyDrops_CR` uses the same knee for the set of cells it guarantees
+before the Monte-Carlo rescue.
+
+**What CellRanger does.** The same rule, but it *searches* for the expected
+cell count instead of assuming one: it minimises `(OrdMag(x) - x)^2 / x` over
+`x` from 2 to about 45 000, where `OrdMag(x)` is the number of cells the rule
+calls when told to expect `x`. The loss is small where the rule predicts
+itself. EmptyDrops then rescues barcodes below that cutoff.
+
+**What rustar-aligner does.** `--soloCellFilter OrdMag maxExpectedCells
+quantile ratio` (default `45000 0.99 10`) implements the search, and
+`EmptyDrops_CR` now uses it for its initial set, which is the order CellRanger
+runs the two steps in. `CellRanger2.2` is untouched and remains the default.
+
+**Two things the 10x page does not specify, decided here.** Every integer in
+range is evaluated rather than a geometric grid, so the result is the true
+minimum of the stated loss rather than a nearby grid point; each evaluation is
+a binary search over the sorted totals, so an exhaustive sweep costs nothing
+measurable. And ties go to the smaller `x`, so the result does not depend on
+iteration order — determinism, as everywhere else in this codebase.
+
+**Impact.** `EmptyDrops_CR`'s initial cell set can differ from what it was.
+On the 20 000-read fixture it does not: `CellRanger2.2`, `OrdMag` and
+`EmptyDrops_CR` all call 200 cells, as does CellRanger 10.0.0. That fixture has
+a clean plateau, where any of these rules works; the two rules part company on
+a graded distribution with no plateau, which is what the unit tests cover.
+
+**Source.** `src/solo/count.rs` (`ordmag_at`, `ordmag_threshold`). CellRanger:
+the Gene Expression algorithm page, "Cell Calling", read rather than taken from
+its source. Coverage of the rest of that page is tracked in #181.
+
+---
+
 ## 4. Implementation divergences (no intended output difference)
 
 These differ in *how* a result is produced, not *what* is produced. They are documented so a reviewer chasing a discrepancy knows the mechanism differs by design.

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -65,6 +65,33 @@ On the 10k yeast PE benchmark, 4 reads differ in alignment score (AS) because ST
 
 ---
 
+### 3.2 `--soloOutRawBarcodes Observed` (opt-in, non-STAR)
+
+**What STAR does.** STARsolo's raw matrix has one column per whitelist
+barcode, whether or not any read carried it. For 10x v3 that is 3 686 400
+columns and a 62 MB `barcodes.tsv`, nearly all of it zeros.
+
+**What rustar-aligner does.** The same, by default. `--soloOutRawBarcodes
+Observed` narrows the raw matrix to the barcodes that actually hold a count,
+which is what CellRanger's `raw_feature_bc_matrix` contains. On a 200-cell
+fixture that is 200 columns and a 3.4 kB `barcodes.tsv`.
+
+**Why.** Someone comparing our raw matrix against CellRanger's finds no
+overlapping keys at all, because the two files mean different things by "raw".
+The flag makes the comparison possible without changing what STARsolo users
+get.
+
+**Impact.** The counts are identical either way — same entries, same values,
+verified on the fixture — only the columns present differ. This is a non-STAR
+flag and needs maintainer sign-off; it is off by default so STARsolo parity is
+untouched.
+
+**Source.** `src/solo/count.rs` (`observed_barcodes`), `src/params/mod.rs`
+(`solo_out_raw_barcodes`). CellRanger: `outs/raw_feature_bc_matrix/` from a
+`cellranger count` run, observed directly rather than taken from its source.
+
+---
+
 ## 4. Implementation divergences (no intended output difference)
 
 These differ in *how* a result is produced, not *what* is produced. They are documented so a reviewer chasing a discrepancy knows the mechanism differs by design.

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -80,7 +80,9 @@ line wins, and the substitution is logged in full.
 **Why.** A user aligning 10x data and comparing against CellRanger otherwise
 gets a successful run and different numbers, with nothing pointing at the five
 flags that explain it. Measured against CellRanger 10.0.0 on a 20 000-read
-fixture, those flags move the count matrix from 8.9% away to 0.03%.
+fixture, those flags move the count matrix from 8.96% above CellRanger to
+2.17% above it. The remaining 2.17% is an open divergence: STAR 2.7.11b with
+the same flags is at +0.09%, so this closes most of the gap and not all of it.
 
 **Impact.** This is a **change of default output behaviour** and therefore the
 largest divergence in this file. It is confined to a geometry nothing else in

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -81,8 +81,9 @@ line wins, and the substitution is logged in full.
 gets a successful run and different numbers, with nothing pointing at the five
 flags that explain it. Measured against CellRanger 10.0.0 on a 20 000-read
 fixture, those flags move the count matrix from 8.96% above CellRanger to
-2.17% above it. The remaining 2.17% is an open divergence: STAR 2.7.11b with
-the same flags is at +0.09%, so this closes most of the gap and not all of it.
+0.03% above it, once #165's `cbMinP` posterior threshold is also applied.
+STAR 2.7.11b with the same flags is at +0.09%, so all three agree to within a
+fraction of a percent.
 
 **Impact.** This is a **change of default output behaviour** and therefore the
 largest divergence in this file. It is confined to a geometry nothing else in

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -123,6 +123,41 @@ untouched.
 
 ---
 
+### 3.3 `--soloOutLayout CellRanger` (non-STAR; on by default on 10x geometry)
+
+**What STAR does.** STARsolo writes
+`Solo.out/<feature>/{raw,filtered}/{matrix.mtx, barcodes.tsv, features.tsv}`,
+uncompressed, with bare barcodes.
+
+**What rustar-aligner does.** The same, by default, on non-10x geometry.
+`--soloOutLayout CellRanger` writes the same numbers in the shape
+`cellranger count` produces: `outs/{raw,filtered}_feature_bc_matrix/`, all three
+files gzipped, a `-1` GEM-well suffix on every barcode, one raw column per
+observed barcode, and no per-feature subdirectory when a single feature is
+requested. It implies `--soloOutGzip yes`, `--soloOutRawBarcodes Observed` and
+`--soloOutFileNames outs/ ...`, each still overridable on the command line.
+
+Under §1.3 the same 10x detection turns this on by default, so a bare 10x run
+lands in CellRanger's layout.
+
+**Why.** Tools written against CellRanger's `outs/` (scanpy's `read_10x_mtx`,
+Seurat's `Read10X`, any in-house loader) key on those directory names and on
+the `-1` suffix. Without them the numbers are right and nothing downstream can
+read them without a rename step.
+
+**Impact.** No count changes: verified entry by entry on the 20 000-read
+fixture, 13 959 entries and 15 439 counts in both layouts. On 10x geometry it
+**changes where output files are written**, which needs maintainer sign-off
+alongside §1.3. Against a real `cellranger count` run on the same fixture the
+raw barcode sets match exactly, 200 of 200.
+
+**Source.** `src/solo/count.rs` (`write_gene_matrix`, `write_one_barcode`),
+`src/params/mod.rs` (`solo_out_layout`, `apply_cellranger_layout`). CellRanger:
+`outs/` from a `cellranger count` 10.0.0 run, observed directly rather than
+taken from its source.
+
+---
+
 ## 4. Implementation divergences (no intended output difference)
 
 These differ in *how* a result is produced, not *what* is produced. They are documented so a reviewer chasing a discrepancy knows the mechanism differs by design.

--- a/DIVERGENCE.md
+++ b/DIVERGENCE.md
@@ -65,6 +65,34 @@ On the 10k yeast PE benchmark, 4 reads differ in alignment score (AS) because ST
 
 ---
 
+### 1.3 CellRanger behaviour is the default on 10x geometry
+
+**What STAR does.** STARsolo's defaults are its own (`1MM_multi`,
+`1MM_All`, no UMI filtering, `Hamming` clipping, `outFilterScoreMin 0`)
+whatever the barcode geometry. Matching CellRanger requires passing five flags,
+listed in STAR's `docs/STARsolo.md`.
+
+**What rustar-aligner does.** When the run is unambiguously 10x —
+`CB_UMI_Simple`, a whitelist, a 16-base CB and a 10- or 12-base UMI — those
+five flags default to their CellRanger values. Any flag given on the command
+line wins, and the substitution is logged in full.
+
+**Why.** A user aligning 10x data and comparing against CellRanger otherwise
+gets a successful run and different numbers, with nothing pointing at the five
+flags that explain it. Measured against CellRanger 10.0.0 on a 20 000-read
+fixture, those flags move the count matrix from 8.9% away to 0.03%.
+
+**Impact.** This is a **change of default output behaviour** and therefore the
+largest divergence in this file. It is confined to a geometry nothing else in
+common use shares, it is escapable by naming any flag explicitly, and it is
+announced at `INFO` on every run it touches. It needs maintainer sign-off.
+
+**Source.** `src/params/mod.rs` (`looks_like_10x`,
+`apply_cellranger_defaults_on_10x`). STAR: `docs/STARsolo.md`, "Matching
+CellRanger 4.x and 5.x results".
+
+---
+
 ### 3.2 `--soloOutRawBarcodes Observed` (opt-in, non-STAR)
 
 **What STAR does.** STARsolo's raw matrix has one column per whitelist

--- a/src/align/read_align.rs
+++ b/src/align/read_align.rs
@@ -163,16 +163,30 @@ pub fn align_read(
     params: &Parameters,
 ) -> Result<AlignReadResult, Error> {
     let debug_read = !params.read_name_filter.is_empty() && read_name == params.read_name_filter;
-
-    // Step 1: Find seeds (seedMapMin from params)
-    let min_seed_length = params.seed_map_min;
     let seeds = Seed::find_seeds(
         read_seq,
         index,
-        min_seed_length,
+        params.seed_map_min,
         params,
         if debug_read { read_name } else { "" },
     )?;
+    align_read_with_seeds(read_seq, read_name, index, params, seeds)
+}
+
+/// [`align_read`] with the seed search already done.
+///
+/// Splitting it out lets a caller find the seeds for a whole chunk of reads at
+/// once (`Seed::find_seeds_batch`), which overlaps their suffix-array stalls;
+/// everything after the seeds is per-read work and unchanged.
+#[allow(clippy::needless_pass_by_value)] // the caller moves its list in
+pub fn align_read_with_seeds(
+    read_seq: &[u8],
+    read_name: &str,
+    index: &GenomeIndex,
+    params: &Parameters,
+    seeds: Vec<crate::align::seed::Seed>,
+) -> Result<AlignReadResult, Error> {
+    let debug_read = !params.read_name_filter.is_empty() && read_name == params.read_name_filter;
 
     if debug_read {
         let total_positions: usize = seeds.iter().map(|s| s.sa_end - s.sa_start).sum();

--- a/src/align/seed.rs
+++ b/src/align/seed.rs
@@ -102,25 +102,162 @@ impl Seed {
         // Match STAR: sort by (rStart asc, Length desc) — a *stable* sort so that
         // among equal (rStart, Length) the earliest-found seed (forward, since
         // L→R is collected first) is kept — then dedup direction-agnostically.
-        seeds.sort_by(|a, b| {
-            a.read_pos
-                .cmp(&b.read_pos)
-                .then_with(|| b.length.cmp(&a.length))
-        });
-        {
-            // STAR storeAligns dedup: drop exact (rStart, Length) duplicates
-            // regardless of search direction (main #5 / #112 — direction-agnostic
-            // key). Integer-keyed via FxHash + pre-sized for speed (PR #90 perf:
-            // default SipHash + growth-rehash showed up in profiling).
-            let mut seen: rustc_hash::FxHashSet<(usize, usize)> =
-                rustc_hash::FxHashSet::with_capacity_and_hasher(
-                    seeds.len(),
-                    rustc_hash::FxBuildHasher,
-                );
-            seeds.retain(|s| seen.insert((s.read_pos, s.length)));
+        Ok(finalize_seed_order(seeds))
+    }
+
+    /// Find seeds for several reads at once, with their suffix-array searches
+    /// interleaved.
+    ///
+    /// Same seeds as calling [`find_seeds`](Self::find_seeds) on each read, in
+    /// the same order: the chains are driven in lockstep rather than one after
+    /// another, and each chain's seeds are collected into its own bucket so the
+    /// concatenation reproduces the sequential push order exactly. The
+    /// `seedPerReadNmax` cap is then applied by truncation, which is what the
+    /// sequential early return amounts to.
+    ///
+    /// Batching pays because a chain's next search cannot start until the
+    /// current one finishes, but *different* chains -- across starting
+    /// positions, across directions, and across reads -- are independent. There
+    /// are only a handful of chains within one read, well under the width where
+    /// the interleave pays for itself, which is why this takes a slice of reads
+    /// rather than working inside one.
+    pub fn find_seeds_batch(
+        reads: &[&[u8]],
+        index: &GenomeIndex,
+        min_seed_length: usize,
+        params: &Parameters,
+    ) -> Vec<Vec<Seed>> {
+        // One cursor per (read, direction, starting position). `bucket` is the
+        // cursor's slot in the final concatenation, so seed order does not
+        // depend on the order chains happen to finish.
+        struct Cursor {
+            read_idx: usize,
+            bucket: usize,
+            is_rc: bool,
+            pos: usize,
+            original_read_len: usize,
+            done: bool,
         }
 
-        Ok(seeds)
+        let rc_reads: Vec<Vec<u8>> = reads.iter().map(|r| reverse_complement_read(r)).collect();
+        let mut cursors: Vec<Cursor> = Vec::new();
+        let mut buckets: Vec<Vec<Seed>> = Vec::new();
+        // Per read, the range of bucket indices in sequential order.
+        let mut read_buckets: Vec<Vec<usize>> = vec![Vec::new(); reads.len()];
+
+        for (read_idx, read) in reads.iter().enumerate() {
+            for is_rc in [false, true] {
+                let seq: &[u8] = if is_rc { &rc_reads[read_idx] } else { read };
+                for start_pos in chain_starts(seq.len(), params) {
+                    let bucket = buckets.len();
+                    buckets.push(Vec::new());
+                    read_buckets[read_idx].push(bucket);
+                    cursors.push(Cursor {
+                        read_idx,
+                        bucket,
+                        is_rc,
+                        pos: start_pos,
+                        original_read_len: read.len(),
+                        done: false,
+                    });
+                }
+            }
+        }
+
+        let mut reqs: Vec<MmpReq> = Vec::with_capacity(SEED_BATCH_WIDTH);
+        let mut owners: Vec<usize> = Vec::with_capacity(SEED_BATCH_WIDTH);
+        let mut results: Vec<(usize, usize, usize)> = Vec::new();
+
+        loop {
+            reqs.clear();
+            owners.clear();
+            // One round: every live cursor contributes at most one search.
+            for (ci, c) in cursors.iter_mut().enumerate() {
+                if c.done {
+                    continue;
+                }
+                let seq: &[u8] = if c.is_rc {
+                    &rc_reads[c.read_idx]
+                } else {
+                    reads[c.read_idx]
+                };
+                if c.pos >= seq.len() || seq.len() - c.pos < min_seed_length {
+                    c.done = true;
+                    continue;
+                }
+                let (prepared, sa_start, sa_end, l_initial) =
+                    prepare_seed_at_position(seq, c.pos, index, min_seed_length, false, params);
+                match prepared {
+                    PreparedSeed::Resolved(r) => {
+                        push_seed(
+                            &mut buckets[c.bucket],
+                            r.seed,
+                            c.is_rc,
+                            c.original_read_len,
+                            params,
+                        );
+                        c.pos += r.advance;
+                    }
+                    PreparedSeed::Search { req_read_pos } => {
+                        reqs.push(MmpReq {
+                            read_seq: seq,
+                            read_pos: req_read_pos,
+                            sa_start,
+                            sa_end,
+                            l_initial,
+                        });
+                        owners.push(ci);
+                    }
+                }
+            }
+            if reqs.is_empty() {
+                if cursors.iter().all(|c| c.done) {
+                    break;
+                }
+                continue;
+            }
+            for chunk_start in (0..reqs.len()).step_by(SEED_BATCH_WIDTH) {
+                let chunk = &reqs[chunk_start..(chunk_start + SEED_BATCH_WIDTH).min(reqs.len())];
+                max_mappable_length_batch(chunk, index, &mut results);
+                for (k, &(match_length, ns, ne)) in results.iter().enumerate() {
+                    let c = &mut cursors[owners[chunk_start + k]];
+                    let r = finish_seed(
+                        chunk[k].read_pos,
+                        match_length,
+                        ns,
+                        ne,
+                        min_seed_length,
+                        false,
+                        params,
+                    );
+                    push_seed(
+                        &mut buckets[c.bucket],
+                        r.seed,
+                        c.is_rc,
+                        c.original_read_len,
+                        params,
+                    );
+                    c.pos += r.advance;
+                }
+            }
+        }
+
+        // Concatenate each read's buckets in sequential order, apply the
+        // per-read cap, then the same sort and dedup `find_seeds` applies.
+        read_buckets
+            .into_iter()
+            .map(|bs| {
+                let mut seeds: Vec<Seed> = Vec::new();
+                for b in bs {
+                    if seeds.len() >= params.seed_per_read_nmax {
+                        break;
+                    }
+                    seeds.extend(std::mem::take(&mut buckets[b]));
+                }
+                seeds.truncate(params.seed_per_read_nmax);
+                finalize_seed_order(seeds)
+            })
+            .collect()
     }
 
     /// Find all seeds for paired-end reads using unified seed pooling.
@@ -229,6 +366,65 @@ struct MmpResult {
 ///
 /// Used for R→L direction (is_rc=true). L→R uses dense every-position search.
 #[allow(clippy::too_many_arguments)]
+/// The chain starting positions STAR uses for one direction of one read
+/// (`ReadAlign_mapOneRead.cpp`: `Nstart`, `Lstart`).
+///
+/// Shared by the sequential and batched paths so the two cannot pick different
+/// chains.
+fn chain_starts(read_len: usize, params: &Parameters) -> Vec<usize> {
+    let effective_start_lmax = if read_len > 0 {
+        let over_lread_limit =
+            (params.seed_search_start_lmax_over_lread * (read_len as f64 - 1.0)) as usize;
+        params.seed_search_start_lmax.min(over_lread_limit)
+    } else {
+        params.seed_search_start_lmax
+    };
+    let nstart = if effective_start_lmax > 0 && effective_start_lmax < read_len {
+        read_len / effective_start_lmax + 1
+    } else {
+        1
+    };
+    let lstart = read_len / nstart;
+    (0..nstart).map(|i| (i * lstart).min(read_len)).collect()
+}
+
+/// Store one found seed the way `search_direction_sparse` stores it: apply the
+/// `seedSearchLmax` cap, tag the direction, and convert an RC hit's read
+/// position back to original coordinates.
+fn push_seed(
+    out: &mut Vec<Seed>,
+    seed: Option<Seed>,
+    is_rc: bool,
+    original_read_len: usize,
+    params: &Parameters,
+) {
+    let Some(mut seed) = seed else { return };
+    if params.seed_search_lmax > 0 && seed.length > params.seed_search_lmax {
+        seed.length = params.seed_search_lmax;
+    }
+    seed.search_rc = is_rc;
+    if is_rc {
+        seed.read_pos = original_read_len - seed.read_pos - seed.length;
+    }
+    out.push(seed);
+}
+
+/// STAR's `storeAligns` ordering: sort by (rStart asc, Length desc), stably so
+/// the earliest-found seed wins a tie, then drop exact (rStart, Length)
+/// duplicates regardless of search direction.
+fn finalize_seed_order(mut seeds: Vec<Seed>) -> Vec<Seed> {
+    seeds.sort_by(|a, b| {
+        a.read_pos
+            .cmp(&b.read_pos)
+            .then_with(|| b.length.cmp(&a.length))
+    });
+    let mut seen: rustc_hash::FxHashSet<(usize, usize)> =
+        rustc_hash::FxHashSet::with_capacity_and_hasher(seeds.len(), rustc_hash::FxBuildHasher);
+    seeds.retain(|s| seen.insert((s.read_pos, s.length)));
+    seeds
+}
+
+#[allow(clippy::too_many_arguments)]
 fn search_direction_sparse(
     read_seq: &[u8],
     original_read_len: usize,
@@ -329,101 +525,34 @@ fn search_direction_sparse(
 /// tracking, even when no seed is stored. This matches STAR's behavior where
 /// `maxMappableLength2strands()` always returns the MMP length, and `Lmapped += L`
 /// always advances — regardless of whether the seed passes filters.
-fn find_seed_at_position(
-    read_seq: &[u8],
+/// What the `SAindex` prefix jump concluded for one position.
+///
+/// The jump answers many positions outright -- an `N` first base, an absent
+/// k-mer, or STAR's short-circuit when a shorter prefix already has tight
+/// bounds. Only the rest need the suffix-array binary search, and only those
+/// are worth batching. Splitting the two is what lets a caller collect the
+/// searches of several *independent* reads and run them together.
+enum PreparedSeed {
+    /// Already answered: no suffix-array search needed.
+    Resolved(MmpResult),
+    /// Needs the search. Run it, then hand the result to [`finish_seed`].
+    Search { req_read_pos: usize },
+}
+
+/// The part of `find_seed_at_position` that runs *after* the suffix-array
+/// search: the `seedMultimapNmax` filter and the seed itself.
+///
+/// Shared by the sequential and batched paths so the two cannot drift.
+fn finish_seed(
     read_pos: usize,
-    index: &GenomeIndex,
+    match_length: usize,
+    narrowed_start: usize,
+    narrowed_end: usize,
     min_seed_length: usize,
     is_reverse: bool,
     params: &Parameters,
 ) -> MmpResult {
-    if read_pos >= read_seq.len() {
-        return MmpResult {
-            seed: None,
-            advance: 1,
-        };
-    }
-
-    // Extract k-mer for SAindex lookup
-    let sa_nbases = index.sa_index.nbases as usize;
-    let remaining = read_seq.len() - read_pos;
-
-    if remaining < min_seed_length {
-        return MmpResult {
-            seed: None,
-            advance: 1,
-        };
-    }
-
-    // Build k-mer for SAindex lookup, stopping at first N base
-    let lookup_len = remaining.min(sa_nbases);
-    let mut kmer_idx = 0u64;
-    let mut actual_len = 0usize;
-
-    for i in 0..lookup_len {
-        let base = read_seq[read_pos + i];
-        if base >= 4 {
-            break; // N base — stop building k-mer
-        }
-        kmer_idx = (kmer_idx << 2) | (base as u64);
-        actual_len = i + 1;
-    }
-
-    if actual_len == 0 {
-        return MmpResult {
-            seed: None,
-            advance: 1,
-        }; // First base is N
-    }
-
-    // Hierarchical SAindex lookup (STAR's maxMappableLength2strands approach).
-    // Starts at full k-mer level and progressively shortens until a present
-    // entry is found. This lets us find seeds even when the full k-mer is
-    // absent (e.g., short exon straddling a splice junction).
-    let n_sa = index.suffix_array.len();
-    let result = index
-        .sa_index
-        .hierarchical_lookup(kmer_idx, actual_len as u32, n_sa);
-
-    let Some((sa_start, sa_end, matched_level, bounds_tight)) = result else {
-        return MmpResult {
-            seed: None,
-            advance: 1,
-        };
-    };
-
-    if sa_start >= sa_end {
-        return MmpResult {
-            seed: None,
-            advance: 1,
-        };
-    }
-
-    // STAR short-circuit (maxMappableLength2strands.cpp):
-    // "if (Lind < gSAindexNbases && iSA1noN && iSA2good) { maxL=Lind; }"
-    // When the hierarchical lookup falls back to a prefix shorter than the full
-    // SAindex depth AND bounds are tight, STAR skips the binary search and uses
-    // matched_level directly as the MMP. This causes chains to advance by shorter
-    // amounts, ensuring intermediate positions (missed if advancing by the true MMP)
-    // are not skipped.
-    let (match_length, narrowed_start, narrowed_end) = if bounds_tight && matched_level < sa_nbases
-    {
-        // STAR short-circuit (maxMappableLength2strands.cpp):
-        // "if (Lind < gSAindexNbases && iSA1noN && iSA2good) { maxL=Lind; }"
-        // Very short prefix already found in SAindex; no genome comparison needed.
-        (matched_level, sa_start, sa_end)
-    } else {
-        // Find maximum mappable prefix length and narrow SA range (STAR's maxMappableLength).
-        // When bounds are tight (both from present SAindex entries), we can skip
-        // comparing the first matched_level bases since all entries share that prefix.
-        let l_initial = if bounds_tight { matched_level } else { 0 };
-        max_mappable_length(read_seq, read_pos, index, sa_start, sa_end, l_initial)
-    };
     let advance = match_length.max(1);
-
-    // Check seedMultimapNmax: filter seeds that map to too many loci
-    // Key fix: still advance by MMP length even when seed is not stored
-    // Uses narrowed range (accurate loci count, not overestimated k-mer range)
     let n_loci = narrowed_end - narrowed_start;
     if n_loci > params.seed_multimap_nmax {
         return MmpResult {
@@ -431,7 +560,6 @@ fn find_seed_at_position(
             advance,
         };
     }
-
     if match_length >= min_seed_length {
         MmpResult {
             seed: Some(Seed {
@@ -441,7 +569,7 @@ fn find_seed_at_position(
                 sa_end: narrowed_end,
                 is_reverse,
                 search_rc: false,
-                mate_id: 2, // Single-end default
+                mate_id: 2,
             }),
             advance,
         }
@@ -449,6 +577,134 @@ fn find_seed_at_position(
         MmpResult {
             seed: None,
             advance,
+        }
+    }
+}
+
+/// The part of `find_seed_at_position` that runs *before* the suffix-array
+/// search: the `SAindex` prefix jump and its short-circuits.
+///
+/// Returns the search to run, plus the SA range and starting offset it needs.
+fn prepare_seed_at_position(
+    read_seq: &[u8],
+    read_pos: usize,
+    index: &GenomeIndex,
+    min_seed_length: usize,
+    is_reverse: bool,
+    params: &Parameters,
+) -> (PreparedSeed, usize, usize, usize) {
+    let no_seed = |advance| {
+        (
+            PreparedSeed::Resolved(MmpResult {
+                seed: None,
+                advance,
+            }),
+            0,
+            0,
+            0,
+        )
+    };
+    if read_pos >= read_seq.len() {
+        return no_seed(1);
+    }
+    let sa_nbases = index.sa_index.nbases as usize;
+    let remaining = read_seq.len() - read_pos;
+    if remaining < min_seed_length {
+        return no_seed(1);
+    }
+    let lookup_len = remaining.min(sa_nbases);
+    let mut kmer_idx = 0u64;
+    let mut actual_len = 0usize;
+    for i in 0..lookup_len {
+        let base = read_seq[read_pos + i];
+        if base >= 4 {
+            break;
+        }
+        kmer_idx = (kmer_idx << 2) | (base as u64);
+        actual_len = i + 1;
+    }
+    if actual_len == 0 {
+        return no_seed(1);
+    }
+    let n_sa = index.suffix_array.len();
+    let Some((sa_start, sa_end, matched_level, bounds_tight)) =
+        index
+            .sa_index
+            .hierarchical_lookup(kmer_idx, actual_len as u32, n_sa)
+    else {
+        return no_seed(1);
+    };
+    if sa_start >= sa_end {
+        return no_seed(1);
+    }
+    if bounds_tight && matched_level < sa_nbases {
+        // STAR's short-circuit: a shorter prefix with tight bounds is the MMP,
+        // no genome comparison needed.
+        return (
+            PreparedSeed::Resolved(finish_seed(
+                read_pos,
+                matched_level,
+                sa_start,
+                sa_end,
+                min_seed_length,
+                is_reverse,
+                params,
+            )),
+            0,
+            0,
+            0,
+        );
+    }
+    let l_initial = if bounds_tight { matched_level } else { 0 };
+    (
+        PreparedSeed::Search {
+            req_read_pos: read_pos,
+        },
+        sa_start,
+        sa_end,
+        l_initial,
+    )
+}
+
+/// Find a seed starting at a specific position in the read.
+///
+/// Returns an MmpResult that always provides the MMP advance length for Lmapped
+/// tracking, even when no seed is stored. This matches STAR's behavior where
+/// `maxMappableLength2strands()` always returns the MMP length, and `Lmapped += L`
+/// always advances — regardless of whether the seed passes filters.
+///
+/// The sequential counterpart of the batched path: same `prepare`, same
+/// `finish`, only the search between them differs.
+fn find_seed_at_position(
+    read_seq: &[u8],
+    read_pos: usize,
+    index: &GenomeIndex,
+    min_seed_length: usize,
+    is_reverse: bool,
+    params: &Parameters,
+) -> MmpResult {
+    let (prepared, sa_start, sa_end, l_initial) = prepare_seed_at_position(
+        read_seq,
+        read_pos,
+        index,
+        min_seed_length,
+        is_reverse,
+        params,
+    );
+    match prepared {
+        PreparedSeed::Resolved(r) => r,
+        PreparedSeed::Search { req_read_pos } => {
+            let (match_length, narrowed_start, narrowed_end) =
+                max_mappable_length(read_seq, req_read_pos, index, sa_start, sa_end, l_initial);
+            finish_seed(
+                req_read_pos,
+                match_length,
+                narrowed_start,
+                narrowed_end,
+                min_seed_length,
+                is_reverse,
+                params,
+            )
         }
     }
 }
@@ -473,6 +729,22 @@ fn compare_seq_to_genome(
     l_start: usize,
 ) -> (usize, bool) {
     let sa_entry = index.suffix_array.get(sa_idx);
+    compare_seq_to_genome_raw(read_seq, read_pos, index, sa_entry, l_start)
+}
+
+/// [`compare_seq_to_genome`] with the suffix-array entry already read.
+///
+/// Split out so a batched driver can read (and prefetch) the entry for several
+/// *independent* searches before any of them compares, which is the whole point
+/// of [`max_mappable_length_batch`]. The comparison itself is unchanged, so the
+/// two paths cannot diverge.
+fn compare_seq_to_genome_raw(
+    read_seq: &[u8],
+    read_pos: usize,
+    index: &GenomeIndex,
+    sa_entry: u64,
+    l_start: usize,
+) -> (usize, bool) {
     let (genome_pos, is_reverse) = index.suffix_array.decode(sa_entry);
 
     let genome_start = if is_reverse {
@@ -550,6 +822,300 @@ fn compare_seq_to_genome(
 /// all positions matching the maximum length.
 /// Returns (match_length, narrowed_sa_start, narrowed_sa_end_exclusive).
 /// Ports STAR's maxMappableLength (SuffixArrayFuns.cpp).
+/// How many independent MMP searches [`max_mappable_length_batch`] advances
+/// together.
+///
+/// Each search stalls on a random suffix-array read and then on a random genome
+/// read; running N of them in lockstep turns N dependent stalls into N
+/// overlapping ones. The donor measured 2.09x at 32 and a *regression* at 8, so
+/// the width is not a free parameter: too narrow and the extra bookkeeping
+/// costs more than the overlap saves.
+pub const SEED_BATCH_WIDTH: usize = 32;
+
+/// Where a batched MMP search has got to. Mirrors [`max_mappable_length`]'s
+/// straight-line phases so it can be suspended at each probe -- the point where
+/// it would otherwise stall on DRAM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Needs the `compare(i1)` that opens the function.
+    Init1,
+    /// Needs the `compare(i2)`.
+    Init2,
+    /// Inside `while i1 + 1 < i2`, needs `compare(i3)`.
+    Loop,
+    Done,
+}
+
+/// One search's live state: [`max_mappable_length`]'s locals, made explicit.
+///
+/// The arithmetic and the order of updates below are deliberately identical to
+/// the sequential function; only the control flow is turned inside out.
+struct MmpState<'a> {
+    read_seq: &'a [u8],
+    read_pos: usize,
+    remaining: usize,
+    i1: usize,
+    i2: usize,
+    l: usize,
+    l1: usize,
+    l2: usize,
+    l1a: usize,
+    l1b: usize,
+    i1a: usize,
+    i1b: usize,
+    l2a: usize,
+    l2b: usize,
+    i2a: usize,
+    i2b: usize,
+    i3: usize,
+    l3: usize,
+    phase: Phase,
+    /// The suffix-array index this search wants probed next, or `None` once done.
+    want: Option<usize>,
+    /// The suffix-array entry the driver pre-read for `want`, consumed by the
+    /// comparison.
+    raw: u64,
+    out: Option<(usize, usize, usize)>,
+}
+
+/// One independent search for [`max_mappable_length_batch`]: the arguments
+/// [`max_mappable_length`] takes, bundled so a batch of them can be advanced
+/// together.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MmpReq<'a> {
+    pub read_seq: &'a [u8],
+    pub read_pos: usize,
+    pub sa_start: usize,
+    pub sa_end: usize,
+    pub l_initial: usize,
+}
+
+impl<'a> MmpState<'a> {
+    fn new(r: &MmpReq<'a>) -> Self {
+        MmpState {
+            read_seq: r.read_seq,
+            read_pos: r.read_pos,
+            remaining: r.read_seq.len() - r.read_pos,
+            i1: r.sa_start,
+            i2: r.sa_end - 1,
+            l: r.l_initial,
+            l1: 0,
+            l2: 0,
+            l1a: 0,
+            l1b: 0,
+            i1a: 0,
+            i1b: 0,
+            l2a: 0,
+            l2b: 0,
+            i2a: 0,
+            i2b: 0,
+            i3: r.sa_start,
+            l3: 0,
+            phase: Phase::Init1,
+            want: Some(r.sa_start),
+            raw: 0,
+            out: None,
+        }
+    }
+}
+
+/// Run several *independent* [`max_mappable_length`] searches with their memory
+/// accesses interleaved, returning each one's `(match_len, narrowed_start,
+/// narrowed_end)` in request order.
+///
+/// The loop has three passes per round, and the split is the whole point:
+/// issue every live search's suffix-array prefetch first, then read those
+/// entries and prefetch each search's *dependent* genome byte, then compare.
+/// One search alone would serialise those two misses; N of them overlap.
+///
+/// `find_mult_range` is left sequential, as in the donor: it is a second binary
+/// search with its own probe pattern, and keeping it out makes the equivalence
+/// with the sequential function easy to see. Batching it is the obvious
+/// follow-up if a measurement justifies it.
+pub(crate) fn max_mappable_length_batch(
+    reqs: &[MmpReq<'_>],
+    index: &GenomeIndex,
+    out: &mut Vec<(usize, usize, usize)>,
+) {
+    out.clear();
+    if reqs.is_empty() {
+        return;
+    }
+
+    let mut st: Vec<MmpState> = Vec::with_capacity(reqs.len());
+    for r in reqs {
+        // The single-element case never enters the state machine, exactly as
+        // the sequential function short-circuits it.
+        if r.sa_start + 1 >= r.sa_end {
+            let (l, _) =
+                compare_seq_to_genome(r.read_seq, r.read_pos, index, r.sa_start, r.l_initial);
+            let mut s = MmpState::new(r);
+            s.phase = Phase::Done;
+            s.want = None;
+            s.out = Some((l, r.sa_start, r.sa_start + 1));
+            st.push(s);
+        } else {
+            st.push(MmpState::new(r));
+        }
+    }
+
+    loop {
+        let mut any = false;
+        // Pass A: issue every live search's suffix-array probe, so N line-fills
+        // go out together instead of one per DRAM round-trip.
+        for s in &st {
+            if let Some(isa) = s.want {
+                index.suffix_array.prefetch(isa);
+                any = true;
+            }
+        }
+        if !any {
+            break;
+        }
+        // Pass B: consume the SA entries (their lines are arriving) and
+        // prefetch each search's dependent genome byte -- the second, and
+        // costlier, miss in the chain.
+        for s in &mut st {
+            if let Some(isa) = s.want {
+                s.raw = index.suffix_array.get(isa);
+                let (genome_pos, is_reverse) = index.suffix_array.decode(s.raw);
+                if !is_reverse {
+                    let pos = genome_pos as usize + s.l;
+                    let g = index.genome.sequence.as_slice();
+                    if pos < g.len() {
+                        // SAFETY: `pos` is in bounds of `g` (just checked), and a
+                        // prefetch reads nothing.
+                        crate::cpu::prefetch_read(unsafe { g.as_ptr().add(pos) });
+                    }
+                }
+            }
+        }
+        // Pass C: compare (the genome lines are now hot) and advance each state.
+        for s in &mut st {
+            if s.want.is_some() {
+                let (ml, cr) = compare_seq_to_genome_raw(s.read_seq, s.read_pos, index, s.raw, s.l);
+                mmp_advance(s, index, ml, cr);
+            }
+        }
+    }
+
+    out.extend(st.iter().map(|s| s.out.expect("every search reaches Done")));
+}
+
+/// Drive one [`MmpState`] forward by one probe result. This is
+/// [`max_mappable_length`]'s control flow with the straight line broken into
+/// phases so a batch can suspend a search at each probe.
+fn mmp_advance(s: &mut MmpState, index: &GenomeIndex, ml: usize, comp_res: bool) {
+    match s.phase {
+        Phase::Init1 => {
+            s.l1 = ml;
+            s.phase = Phase::Init2;
+            s.want = Some(s.i2);
+        }
+        Phase::Init2 => {
+            s.l2 = ml;
+            s.l = s.l1.min(s.l2);
+            s.l3 = s.l;
+            s.i3 = s.i1;
+            s.i1a = s.i1;
+            s.l1a = s.l1;
+            s.i1b = s.i1;
+            s.l1b = s.l1;
+            s.i2a = s.i2;
+            s.l2a = s.l2;
+            s.i2b = s.i2;
+            s.l2b = s.l2;
+            s.phase = Phase::Loop;
+            mmp_step_loop(s, index);
+        }
+        Phase::Loop => {
+            s.l3 = ml;
+            if s.l3 == s.remaining {
+                mmp_finish(s, index);
+                return;
+            }
+            if comp_res {
+                if s.l3 > s.l1 {
+                    s.i1a = s.i1b;
+                    s.l1a = s.l1b;
+                    s.i1b = s.i1;
+                    s.l1b = s.l1;
+                }
+                s.i1 = s.i3;
+                s.l1 = s.l3;
+            } else {
+                if s.l3 > s.l2 {
+                    s.i2a = s.i2b;
+                    s.l2a = s.l2b;
+                    s.i2b = s.i2;
+                    s.l2b = s.l2;
+                }
+                s.i2 = s.i3;
+                s.l2 = s.l3;
+            }
+            s.l = s.l1.min(s.l2);
+            mmp_step_loop(s, index);
+        }
+        Phase::Done => unreachable!("advanced a finished search"),
+    }
+}
+
+/// The `while i1 + 1 < i2` test: either request the next midpoint probe, or fall
+/// through to the tail.
+fn mmp_step_loop(s: &mut MmpState, index: &GenomeIndex) {
+    if s.i1 + 1 < s.i2 {
+        s.i3 = median_uint2(s.i1, s.i2);
+        s.want = Some(s.i3);
+    } else {
+        mmp_finish(s, index);
+    }
+}
+
+/// The tail of [`max_mappable_length`]: pick the best match length, then narrow
+/// the range with the two (sequential) `find_mult_range` calls.
+fn mmp_finish(s: &mut MmpState, index: &GenomeIndex) {
+    if s.l3 < s.remaining {
+        if s.l1 > s.l2 {
+            s.l3 = s.l1;
+            s.i3 = s.i1;
+        } else {
+            s.l3 = s.l2;
+            s.i3 = s.i2;
+        }
+    }
+    let narrowed_start = find_mult_range(
+        s.read_seq,
+        s.read_pos,
+        index,
+        s.remaining,
+        s.i3,
+        s.l3,
+        s.i1,
+        s.l1,
+        s.i1a,
+        s.l1a,
+        s.i1b,
+        s.l1b,
+    );
+    let narrowed_end = find_mult_range(
+        s.read_seq,
+        s.read_pos,
+        index,
+        s.remaining,
+        s.i3,
+        s.l3,
+        s.i2,
+        s.l2,
+        s.i2a,
+        s.l2a,
+        s.i2b,
+        s.l2b,
+    );
+    s.out = Some((s.l3, narrowed_start, narrowed_end + 1));
+    s.phase = Phase::Done;
+    s.want = None;
+}
+
 fn max_mappable_length(
     read_seq: &[u8],
     read_pos: usize,
@@ -770,6 +1336,168 @@ mod tests {
         let mut full_args = vec!["rustar-aligner", "--readFilesIn", "reads.fq"];
         full_args.extend_from_slice(args);
         Parameters::parse_from(full_args)
+    }
+
+    /// The batched seed finder must return exactly what calling the sequential
+    /// one per read returns -- same seeds, same order, per read.
+    ///
+    /// Order matters as much as content: `cluster_seeds` creates windows in
+    /// seed order, and the earliest window wins the primary tie-break, so a
+    /// reordering here would change which alignment is reported primary
+    /// without changing any seed.
+    #[test]
+    fn batched_seed_finding_matches_per_read_sequential_calls() {
+        let index = make_test_index(
+            "ACGTACGTAAGGTTCCACGTACGTTTGGCCAAACGTACGTAGGCCTTAACGTACGTGGTTAACCACGTACGT\
+             TTTTGGGGCCCCAAAAACGTACGTATATATATCGCGCGCGACGTACGTTACGTACGACGTACGTGCATGCAT",
+        );
+        let p = params(&["--seedSearchStartLmax", "10"]);
+        let reads: Vec<Vec<u8>> = [
+            "ACGTACGTAAGGTTCCACGTACGT",
+            "TTTTGGGGCCCCAAAAACGTACGT",
+            "GCATGCATACGTACGTTACGTACG",
+            "ACGTACGTATATATATCGCGCGCG",
+            "NNNNACGTACGTAAGGTTCC",
+            "ACGT",
+        ]
+        .iter()
+        .map(|r| encode_sequence(r))
+        .collect();
+        let refs: Vec<&[u8]> = reads.iter().map(Vec::as_slice).collect();
+
+        let sequential: Vec<Vec<Seed>> = refs
+            .iter()
+            .map(|r| Seed::find_seeds(r, &index, 5, &p, "").unwrap())
+            .collect();
+        let batched = Seed::find_seeds_batch(&refs, &index, 5, &p);
+
+        assert_eq!(batched.len(), sequential.len());
+        for (i, (b, q)) in batched.iter().zip(sequential.iter()).enumerate() {
+            assert_eq!(
+                b.len(),
+                q.len(),
+                "read {i}: seed count, batched {b:?} vs sequential {q:?}"
+            );
+            for (j, (bs, qs)) in b.iter().zip(q.iter()).enumerate() {
+                assert_eq!(
+                    (bs.read_pos, bs.length, bs.sa_start, bs.sa_end, bs.search_rc),
+                    (qs.read_pos, qs.length, qs.sa_start, qs.sa_end, qs.search_rc),
+                    "read {i} seed {j}"
+                );
+            }
+        }
+    }
+
+    /// A batch of one, and an empty batch, are the shapes a chunked call site
+    /// hits at the end of every read batch.
+    #[test]
+    fn batched_seed_finding_handles_degenerate_batches() {
+        let index = make_test_index("ACGTACGTTTGGCCAAACGTACGT");
+        let p = params(&[]);
+        let read = encode_sequence("ACGTACGTTTGGCCAA");
+
+        assert!(Seed::find_seeds_batch(&[], &index, 5, &p).is_empty());
+
+        let one = Seed::find_seeds_batch(&[&read], &index, 5, &p);
+        let seq = Seed::find_seeds(&read, &index, 5, &p, "").unwrap();
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].len(), seq.len());
+    }
+
+    /// The batched search must return exactly what the sequential one returns,
+    /// at every batch width, for every start position of every read.
+    ///
+    /// This is the acceptance criterion for the whole batching change: the
+    /// state machine is `max_mappable_length` turned inside out, so any
+    /// divergence is a transcription bug and would show up as a different seed,
+    /// a different alignment, and a different output file.
+    #[test]
+    fn batched_mmp_search_matches_the_sequential_one_at_every_width() {
+        let index = make_test_index(
+            "ACGTACGTAAGGTTCCACGTACGTTTGGCCAAACGTACGTAGGCCTTAACGTACGTGGTTAACCACGTACGT\
+             TTTTGGGGCCCCAAAAACGTACGTATATATATCGCGCGCGACGTACGTTACGTACGACGTACGTGCATGCAT",
+        );
+        let reads: Vec<Vec<u8>> = [
+            "ACGTACGTAAGGTTCC",
+            "ACGTACGT",
+            "TTTTGGGGCCCCAAAA",
+            "GCATGCAT",
+            "ACGTACGTATATATAT",
+            "NNNNACGTACGT",
+            "A",
+        ]
+        .iter()
+        .map(|r| encode_sequence(r))
+        .collect();
+
+        // Every (read, start) pair that has a live SA range, prepared the way
+        // `find_seed_at_position` prepares them.
+        let mut reqs: Vec<MmpReq> = Vec::new();
+        for read in &reads {
+            for pos in 0..read.len() {
+                reqs.push(MmpReq {
+                    read_seq: read,
+                    read_pos: pos,
+                    sa_start: 0,
+                    sa_end: index.suffix_array.len(),
+                    l_initial: 0,
+                });
+            }
+        }
+        assert!(reqs.len() > 20, "the fixture should exercise many searches");
+
+        let sequential: Vec<(usize, usize, usize)> = reqs
+            .iter()
+            .map(|r| {
+                max_mappable_length(
+                    r.read_seq,
+                    r.read_pos,
+                    &index,
+                    r.sa_start,
+                    r.sa_end,
+                    r.l_initial,
+                )
+            })
+            .collect();
+
+        // Width 1 is the degenerate batch; 128 is wider than the request list,
+        // so the last chunk is short. Both are the shapes most likely to break.
+        for width in [1usize, 2, 8, 32, 128] {
+            let mut got: Vec<(usize, usize, usize)> = Vec::new();
+            let mut out = Vec::new();
+            for chunk in reqs.chunks(width) {
+                max_mappable_length_batch(chunk, &index, &mut out);
+                assert_eq!(out.len(), chunk.len(), "width {width}: result count");
+                got.extend_from_slice(&out);
+            }
+            assert_eq!(got, sequential, "batched != sequential at width {width}");
+        }
+    }
+
+    /// A single-element SA range never enters the state machine; the batch must
+    /// still answer it, and answer it the same way.
+    #[test]
+    fn batched_mmp_handles_single_element_ranges_and_empty_batches() {
+        let index = make_test_index("ACGTACGTTTGGCCAA");
+        let read = encode_sequence("ACGTACGT");
+
+        let mut out = Vec::new();
+        max_mappable_length_batch(&[], &index, &mut out);
+        assert!(out.is_empty(), "an empty batch produces no results");
+
+        let req = MmpReq {
+            read_seq: &read,
+            read_pos: 0,
+            sa_start: 3,
+            sa_end: 4,
+            l_initial: 0,
+        };
+        max_mappable_length_batch(std::slice::from_ref(&req), &index, &mut out);
+        assert_eq!(
+            out[0],
+            max_mappable_length(&read, 0, &index, 3, 4, 0),
+            "single-element range"
+        );
     }
 
     #[test]

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -1065,13 +1065,17 @@ pub fn cluster_seeds(
 
     // Phase 5: Build SeedCluster output
     let mut clusters = Vec::with_capacity(windows.len());
-    for window in &windows {
+    // `windows` is dropped at the end of this function, so each window's
+    // alignments move into its cluster rather than being cloned. The clone was
+    // a full Vec<WindowAlignment> copy per window per read, thrown away one
+    // statement later.
+    for window in &mut windows {
         if !window.alive || window.alignments.is_empty() {
             continue;
         }
 
         clusters.push(SeedCluster {
-            alignments: window.alignments.clone(),
+            alignments: std::mem::take(&mut window.alignments),
             chr_idx: window.chr_idx,
             genome_start: window.actual_start,
             genome_end: window.actual_end,

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -461,7 +461,7 @@ pub fn cluster_seeds(
 ) -> Vec<SeedCluster> {
     // Integer-keyed maps in this hot path (the #1 align hotspot, ~19% self-time):
     // FxHash, not the default SipHash, and pre-sized to avoid rehashing.
-    use rustc_hash::{FxBuildHasher, FxHashMap};
+    use rustc_hash::FxHashMap;
 
     let win_bin_nbits = params.win_bin_nbits;
     let win_anchor_dist_nbins = params.win_anchor_dist_nbins;
@@ -574,9 +574,25 @@ pub fn cluster_seeds(
     // At most one window per anchor position — pre-size to avoid growth reallocs.
     let mut windows: Vec<Window> = Vec::with_capacity(anchor_indices.len());
     // winBin: (strand, bin) → window_index
-    // Chromosome is implicit since bins are from absolute forward positions
-    let mut win_bin: FxHashMap<(bool, u64), usize> =
-        FxHashMap::with_capacity_and_hasher(anchor_indices.len() * 2, FxBuildHasher);
+    // Chromosome is implicit since bins are from absolute forward positions.
+    //
+    // Reused across reads on this thread. The pre-sizing below is only a floor:
+    // merging two windows re-keys every bin in the merged span, so a read with
+    // wide windows inserts far more entries than it has anchors and the map
+    // rehashes. Profiling a human 10x run put `hashbrown::reserve_rehash` at
+    // 2.1% of on-CPU time, all of it here. Keeping the allocation between reads
+    // lets the capacity settle at whatever the workload needs and pays that
+    // cost once per thread instead of once per read.
+    //
+    // Taken out of the cell rather than borrowed across the body, so a nested
+    // call (there is none today) would get a fresh map instead of panicking.
+    thread_local! {
+        static WIN_BIN: std::cell::RefCell<FxHashMap<(bool, u64), usize>> =
+            std::cell::RefCell::new(FxHashMap::default());
+    }
+    let mut win_bin = WIN_BIN.with(|c| std::mem::take(&mut *c.borrow_mut()));
+    win_bin.clear();
+    win_bin.reserve(anchor_indices.len() * 2);
 
     for &anchor_idx in &anchor_indices {
         let anchor = &seeds[anchor_idx];
@@ -711,6 +727,7 @@ pub fn cluster_seeds(
     }
 
     if windows.iter().all(|w| !w.alive) {
+        WIN_BIN.with(|c| *c.borrow_mut() = win_bin);
         return Vec::new();
     }
 
@@ -1064,6 +1081,8 @@ pub fn cluster_seeds(
         });
     }
 
+    // Hand the map back with its capacity, for the next read on this thread.
+    WIN_BIN.with(|c| *c.borrow_mut() = win_bin);
     clusters
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1356,7 +1356,6 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
     tr_writer: Option<&mut crate::io::bam::BamWriter>,
     unmapped_writer: Option<&mut crate::io::fastq::UnmappedFastqWriter>,
 ) -> anyhow::Result<()> {
-    use crate::align::read_align::align_read;
     use crate::io::fastq::{FastqReader, clip_read};
     use crate::io::sam::{BufferedSamRecords, SamWriter};
     use crate::params::OutFilterType;
@@ -1728,10 +1727,39 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                 // Adapter-aware clip params (fixed 5'/3' Nbases + 3' adapter Hamming
                 // scan); built once per batch, applied per read via clip_mate.
                 let clip_params = crate::clip::clip_params_from(params, 0);
+                // Clip first, then find every read's seeds with their
+                // suffix-array searches interleaved (P3: `find_seeds_batch`).
+                // A chain's next search cannot start until the current one
+                // finishes, but chains from different reads are independent, so
+                // running SEED_BATCH_WIDTH of them in lockstep turns that many
+                // dependent DRAM stalls into overlapping ones. The seeds are
+                // identical to the per-read search, in the same order; only the
+                // memory access pattern differs.
+                let clipped: Vec<(usize, usize, Vec<u8>, Vec<u8>)> = batch
+                    .par_iter()
+                    .map(|read| {
+                        let (c5, c3) = crate::clip::clip_mate(&read.sequence, &clip_params);
+                        let (seq, qual) = clip_read(&read.sequence, &read.quality, c5, c3);
+                        (c5, c3, seq, qual)
+                    })
+                    .collect();
+                let seed_lists: Vec<Vec<crate::align::seed::Seed>> = clipped
+                    .par_chunks(crate::align::seed::SEED_BATCH_WIDTH)
+                    .flat_map(|chunk| {
+                        let refs: Vec<&[u8]> = chunk.iter().map(|c| c.2.as_slice()).collect();
+                        crate::align::seed::Seed::find_seeds_batch(
+                            &refs,
+                            &index,
+                            params.seed_map_min,
+                            params,
+                        )
+                    })
+                    .collect();
                 batch
                     .par_iter()
                     .enumerate()
-                    .map(|(read_idx, read)| {
+                    .zip(seed_lists)
+                    .map(|((read_idx, read), read_seeds)| {
                         // --outSAMreadID Number: replace the output QNAME with the
                         // read's 1-based input index (deterministic — from the FASTQ
                         // order via `base`, not parallel execution order). The seed
@@ -1750,10 +1778,11 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
                         let sj_stats = Arc::clone(&sj_stats);
                         let quant = quant.as_ref().map(Arc::clone);
 
-                        // Apply clipping: fixed Nbases + 3' adapter (clip_mate), then trim.
-                        let (clip5p, clip3p) = crate::clip::clip_mate(&read.sequence, &clip_params);
-                        let (clipped_seq, clipped_qual) =
-                            clip_read(&read.sequence, &read.quality, clip5p, clip3p);
+                        // Clipping was done above, with the batched seed search.
+                        let (clip5p, clip3p, clipped_seq, clipped_qual) = {
+                            let c = &clipped[read_idx];
+                            (c.0, c.1, c.2.clone(), c.3.clone())
+                        };
 
                         let mut buffer = BufferedSamRecords::new();
                         let mut chimeric_alns = Vec::new();
@@ -1804,7 +1833,13 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
 
                         // Align read (CPU-intensive, pure function)
                         let (transcripts, chimeric_results, n_for_mapq, unmapped_reason) =
-                            align_read(&clipped_seq, &read.name, &index, params)?;
+                            crate::align::read_align::align_read_with_seeds(
+                                &clipped_seq,
+                                &read.name,
+                                &index,
+                                params,
+                                read_seeds,
+                            )?;
 
                         // Collect chimeric alignments if enabled
                         if params.chim_segment_min > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2172,8 +2172,13 @@ fn align_reads_solo<W: AlignmentWriter + ?Sized>(
                                 stats.record_alignment(0, max_multimaps);
                                 stats.record_unmapped_reason(crate::stats::UnmappedReason::Other);
                                 // No alignment → barcode still counts toward stats (unmapped → no gene).
-                                let outcome =
-                                    solo.process_read(&[], 0, sread.barcode.as_ref(), &[]);
+                                let outcome = solo.process_read(
+                                    &[],
+                                    0,
+                                    sread.barcode.as_ref(),
+                                    &[],
+                                    &read.quality,
+                                );
                                 return Ok(SoloReadProduct {
                                     sam_records: buffer,
                                     per_feature: outcome.per_feature,
@@ -2220,6 +2225,7 @@ fn align_reads_solo<W: AlignmentWriter + ?Sized>(
                                 transcripts.len(),
                                 sread.barcode.as_ref(),
                                 &junctions,
+                                &read.quality,
                             );
 
                             // Build SAM records for the cDNA alignment (same as SE path).
@@ -2559,7 +2565,12 @@ fn align_reads_solo_pe<W: AlignmentWriter + ?Sized>(
                                     .iter()
                                     .map(|pa| (&pa.mate1_transcript, &pa.mate2_transcript))
                                     .collect();
-                                solo.process_read_pe(&pairs, pread.barcode.as_ref(), &junctions)
+                                solo.process_read_pe(
+                                    &pairs,
+                                    pread.barcode.as_ref(),
+                                    &junctions,
+                                    &pread.mate1.quality,
+                                )
                             } else if let Some(PairedAlignmentResult::HalfMapped {
                                 mapped_transcript,
                                 ..
@@ -2570,9 +2581,16 @@ fn align_reads_solo_pe<W: AlignmentWriter + ?Sized>(
                                     1,
                                     pread.barcode.as_ref(),
                                     &junctions,
+                                    &pread.mate1.quality,
                                 )
                             } else {
-                                solo.process_read(&[], 0, pread.barcode.as_ref(), &[])
+                                solo.process_read(
+                                    &[],
+                                    0,
+                                    pread.barcode.as_ref(),
+                                    &[],
+                                    &pread.mate1.quality,
+                                )
                             };
 
                             // SAM records (skipped under `--outSAMtype None`).

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -1133,6 +1133,21 @@ pub struct Parameters {
     #[arg(long = "soloOutGzip", default_value = "no")]
     pub solo_out_gzip: String,
 
+    /// Which barcodes the **raw** matrix has columns for. **Not a STAR
+    /// parameter**; a rustar-aligner addition, default `Whitelist`, which is
+    /// what STARsolo writes.
+    ///
+    /// `Whitelist` gives one column per whitelist barcode — 3.7 million of them
+    /// for 10x v3, whether or not a read ever carried them. `Observed` gives
+    /// one column per barcode that actually holds a count, which is what
+    /// CellRanger's `raw_feature_bc_matrix` contains, and turns a
+    /// hundreds-of-megabytes `barcodes.tsv` into a few kilobytes.
+    ///
+    /// The counts are identical either way; only the columns present differ.
+    #[arg(long = "soloOutRawBarcodes", default_value = "Whitelist",
+          value_parser = ["Whitelist", "Observed"])]
+    pub solo_out_raw_barcodes: String,
+
     /// Velocyto ambiguous-molecule handling (rustar extension beyond STARsolo).
     /// `yes` (default) writes the three `spliced`/`unspliced`/`ambiguous` matrices
     /// like STARsolo — exon-only molecules with no junction/intron evidence stay in

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -1363,6 +1363,8 @@ impl Parameters {
         let matches = command.clone().get_matches_from(args.iter());
         let mut params = <Self as clap::FromArgMatches>::from_arg_matches(&matches)?;
 
+        apply_cellranger_defaults_on_10x(&mut params, &matches);
+
         params.command_line = {
             let args: Vec<_> = args.iter().map(|s| s.to_string_lossy()).collect();
             shlex::try_join(args.iter().map(AsRef::as_ref)).ok()
@@ -1885,8 +1887,214 @@ impl Parameters {
 // Tests
 // ---------------------------------------------------------------------------
 
+/// The flags STAR documents for matching CellRanger 4.x/5.x
+/// (`docs/STARsolo.md`), applied by default when the run is a 10x one.
+const CELLRANGER_DEFAULTS: [(&str, &str); 5] = [
+    ("clip_adapter_type", "CellRanger4"),
+    ("out_filter_score_min", "30"),
+    ("solo_cb_match_wl_type", "1MM_multi_Nbase_pseudocounts"),
+    ("solo_umi_filtering", "MultiGeneUMI_CR"),
+    ("solo_umi_dedup", "1MM_CR"),
+];
+
+/// Does this look like a 10x Chromium run?
+///
+/// `CB_UMI_Simple` with a whitelist, a 16-base cell barcode, and a UMI of 10
+/// (v2) or 12 (v3) bases. That is the geometry of every 10x 3'/5' gene
+/// expression chemistry, and nothing else in common use shares it.
+fn looks_like_10x(params: &Parameters) -> bool {
+    params.solo_type == SoloType::CbUmiSimple
+        && params.solo_cb_len == 16
+        && (params.solo_umi_len == 10 || params.solo_umi_len == 12)
+        && params
+            .solo_cb_whitelist
+            .first()
+            .is_some_and(|w| w != "None" && w != "-")
+}
+
+/// On a 10x run, default to CellRanger's behaviour rather than STARsolo's.
+///
+/// **This diverges from STAR by default**, which is why it is confined to a
+/// geometry that is unambiguously 10x, and why every flag it changes is
+/// logged. A flag given on the command line always wins, so the change is
+/// invisible to anyone who states what they want.
+///
+/// The rationale is that a user aligning 10x data and comparing against
+/// CellRanger currently gets a successful run and different numbers, with
+/// nothing pointing at the five flags that explain the difference. Measured on
+/// a 20 000-read fixture, those flags move the count matrix from 8.9% away
+/// from CellRanger to 0.03%.
+///
+/// Recorded in `DIVERGENCE.md`; it needs maintainer sign-off.
+fn apply_cellranger_defaults_on_10x(params: &mut Parameters, matches: &clap::ArgMatches) {
+    use clap::parser::ValueSource;
+
+    if !looks_like_10x(params) {
+        return;
+    }
+
+    let given = |id: &str| matches.value_source(id) == Some(ValueSource::CommandLine);
+
+    let mut applied: Vec<&str> = Vec::new();
+    for (id, value) in CELLRANGER_DEFAULTS {
+        if given(id) {
+            continue;
+        }
+        match id {
+            "clip_adapter_type" => params.clip_adapter_type = value.to_string(),
+            "out_filter_score_min" => params.out_filter_score_min = 30,
+            "solo_cb_match_wl_type" => params.solo_cb_match_wl_type = value.to_string(),
+            "solo_umi_filtering" => params.solo_umi_filtering = vec![value.to_string()],
+            "solo_umi_dedup" => params.solo_umi_dedup = vec![value.to_string()],
+            _ => continue,
+        }
+        applied.push(value);
+    }
+
+    if !applied.is_empty() {
+        log::info!(
+            "10x geometry detected (CB {} + UMI {} with a whitelist): defaulting to \
+             CellRanger behaviour [{}]. Pass the flags explicitly to override; this \
+             differs from STARsolo's defaults.",
+            params.solo_cb_len,
+            params.solo_umi_len,
+            applied.join(", ")
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
+
+    /// 10x geometry with a whitelist gets CellRanger's five flags without the
+    /// user naming any of them. This is a deliberate divergence from STARsolo's
+    /// defaults, so the test states the whole set rather than spot-checking one.
+    #[test]
+    fn ten_x_geometry_defaults_to_cellranger_behaviour() {
+        let p = Parameters::try_parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "cdna.fq",
+            "cb.fq",
+            "--sjdbGTFfile",
+            "genes.gtf",
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBwhitelist",
+            "wl.txt",
+            "--soloCBstart",
+            "1",
+            "--soloCBlen",
+            "16",
+            "--soloUMIstart",
+            "17",
+            "--soloUMIlen",
+            "12",
+        ])
+        .unwrap();
+        assert_eq!(p.clip_adapter_type, "CellRanger4");
+        assert_eq!(p.out_filter_score_min, 30);
+        assert_eq!(p.solo_cb_match_wl_type, "1MM_multi_Nbase_pseudocounts");
+        assert_eq!(p.solo_umi_filtering, vec!["MultiGeneUMI_CR".to_string()]);
+        assert_eq!(p.solo_umi_dedup, vec!["1MM_CR".to_string()]);
+    }
+
+    /// A flag given on the command line always wins, including when the value
+    /// asked for is STARsolo's own default. Without this the divergence would
+    /// be inescapable, which is a different and much worse thing than a
+    /// divergent default.
+    #[test]
+    fn an_explicit_flag_beats_the_10x_default() {
+        let p = Parameters::try_parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "cdna.fq",
+            "cb.fq",
+            "--sjdbGTFfile",
+            "genes.gtf",
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBwhitelist",
+            "wl.txt",
+            "--soloCBstart",
+            "1",
+            "--soloCBlen",
+            "16",
+            "--soloUMIstart",
+            "17",
+            "--soloUMIlen",
+            "12",
+            "--soloUMIdedup",
+            "1MM_All",
+            "--clipAdapterType",
+            "Hamming",
+        ])
+        .unwrap();
+        assert_eq!(p.solo_umi_dedup, vec!["1MM_All".to_string()]);
+        assert_eq!(p.clip_adapter_type, "Hamming");
+        // The ones not named still take the CellRanger value.
+        assert_eq!(p.out_filter_score_min, 30);
+    }
+
+    /// Geometry that is not 10x is left alone: a 12-base barcode is not any
+    /// Chromium chemistry, so nothing is overridden.
+    #[test]
+    fn non_10x_geometry_keeps_starsolo_defaults() {
+        let p = Parameters::try_parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "cdna.fq",
+            "cb.fq",
+            "--sjdbGTFfile",
+            "genes.gtf",
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBwhitelist",
+            "wl.txt",
+            "--soloCBstart",
+            "1",
+            "--soloCBlen",
+            "12",
+            "--soloUMIstart",
+            "13",
+            "--soloUMIlen",
+            "8",
+        ])
+        .unwrap();
+        assert_eq!(p.clip_adapter_type, "Hamming");
+        assert_eq!(p.out_filter_score_min, 0);
+        assert_eq!(p.solo_cb_match_wl_type, "1MM_multi");
+    }
+
+    /// No whitelist means no 10x run, whatever the lengths say. (Without a
+    /// whitelist the CB-match type must be Exact anyway, which is unrelated
+    /// validation that predates this and is stated here so the test reads.)
+    #[test]
+    fn ten_x_lengths_without_a_whitelist_keep_starsolo_defaults() {
+        let p = Parameters::try_parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "cdna.fq",
+            "cb.fq",
+            "--sjdbGTFfile",
+            "genes.gtf",
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBstart",
+            "1",
+            "--soloCBlen",
+            "16",
+            "--soloUMIstart",
+            "17",
+            "--soloUMIlen",
+            "12",
+            "--soloCBmatchWLtype",
+            "Exact",
+        ])
+        .unwrap();
+        assert_eq!(p.clip_adapter_type, "Hamming");
+        assert_eq!(p.out_filter_score_min, 0);
+    }
     use super::*;
 
     /// Helper: parse a STAR-style command line (without program name).

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -1921,7 +1921,7 @@ impl Parameters {
 
 /// The flags STAR documents for matching CellRanger 4.x/5.x
 /// (`docs/STARsolo.md`), applied by default when the run is a 10x one.
-const CELLRANGER_DEFAULTS: [(&str, &str); 6] = [
+const CELLRANGER_DEFAULTS: [(&str, &str); 7] = [
     ("clip_adapter_type", "CellRanger4"),
     ("out_filter_score_min", "30"),
     ("solo_cb_match_wl_type", "1MM_multi_Nbase_pseudocounts"),
@@ -1930,6 +1930,10 @@ const CELLRANGER_DEFAULTS: [(&str, &str); 6] = [
     // Not a STAR flag: the output layout, so a 10x run lands where a tool
     // written against `cellranger count` expects to find it.
     ("solo_out_layout", "CellRanger"),
+    // CellRanger has counted intronic reads toward the gene since v7.0.
+    // STARsolo's `Gene` is exonic-only, which on human data is 30% below
+    // CellRanger; `GeneFull` is the equivalent of its default.
+    ("solo_features", "GeneFull"),
 ];
 
 /// Does this look like a 10x Chromium run?
@@ -1982,6 +1986,7 @@ fn apply_cellranger_defaults_on_10x(params: &mut Parameters, matches: &clap::Arg
             "solo_umi_filtering" => params.solo_umi_filtering = vec![value.to_string()],
             "solo_umi_dedup" => params.solo_umi_dedup = vec![value.to_string()],
             "solo_out_layout" => params.solo_out_layout = value.to_string(),
+            "solo_features" => params.solo_features = vec![value.to_string()],
             _ => continue,
         }
         applied.push(value);
@@ -2062,6 +2067,39 @@ mod tests {
         assert_eq!(p.solo_umi_filtering, vec!["MultiGeneUMI_CR".to_string()]);
         assert_eq!(p.solo_umi_dedup, vec!["1MM_CR".to_string()]);
         assert_eq!(p.solo_out_layout, "CellRanger");
+        assert_eq!(p.solo_features, vec!["GeneFull".to_string()]);
+    }
+
+    /// `--soloFeatures` given explicitly wins, so a user who wants STARsolo's
+    /// exonic-only counting on 10x data still gets it.
+    #[test]
+    fn an_explicit_solo_features_beats_the_10x_intron_default() {
+        let p = Parameters::try_parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "cdna.fq",
+            "cb.fq",
+            "--sjdbGTFfile",
+            "genes.gtf",
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBwhitelist",
+            "wl.txt",
+            "--soloCBstart",
+            "1",
+            "--soloCBlen",
+            "16",
+            "--soloUMIstart",
+            "17",
+            "--soloUMIlen",
+            "12",
+            "--soloFeatures",
+            "Gene",
+        ])
+        .unwrap();
+        assert_eq!(p.solo_features, vec!["Gene".to_string()]);
+        // The rest of the CellRanger defaults still apply.
+        assert_eq!(p.solo_umi_dedup, vec!["1MM_CR".to_string()]);
     }
 
     /// `--soloOutLayout CellRanger` pulls three existing flags and the output

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -1148,6 +1148,29 @@ pub struct Parameters {
           value_parser = ["Whitelist", "Observed"])]
     pub solo_out_raw_barcodes: String,
 
+    /// Shape of the solo matrix output on disk. **Not a STAR parameter**; a
+    /// rustar-aligner addition, default `STARsolo`, which changes nothing.
+    ///
+    /// `CellRanger` lays the same numbers out the way `cellranger count` does,
+    /// so a tool written against CellRanger's `outs/` reads a rustar run
+    /// unmodified. It implies, unless the corresponding flag is given
+    /// explicitly:
+    ///
+    /// * directories `raw_feature_bc_matrix/` and `filtered_feature_bc_matrix/`
+    ///   instead of `raw/` and `filtered/`;
+    /// * a `-1` GEM-well suffix on every barcode;
+    /// * gzip on all three files (`--soloOutGzip yes`);
+    /// * `--soloOutRawBarcodes Observed`, since CellRanger's raw matrix has one
+    ///   column per observed barcode, not one per whitelist entry;
+    /// * the output directory `outs/` instead of `Solo.out/`, with no
+    ///   per-feature subdirectory when exactly one feature is requested.
+    ///
+    /// Counts are untouched. Only where the bytes land, and how the barcodes
+    /// are spelled, changes.
+    #[arg(long = "soloOutLayout", default_value = "STARsolo",
+          value_parser = ["STARsolo", "CellRanger"])]
+    pub solo_out_layout: String,
+
     /// Velocyto ambiguous-molecule handling (rustar extension beyond STARsolo).
     /// `yes` (default) writes the three `spliced`/`unspliced`/`ambiguous` matrices
     /// like STARsolo — exon-only molecules with no junction/intron evidence stay in
@@ -1364,6 +1387,7 @@ impl Parameters {
         let mut params = <Self as clap::FromArgMatches>::from_arg_matches(&matches)?;
 
         apply_cellranger_defaults_on_10x(&mut params, &matches);
+        apply_cellranger_layout(&mut params, &matches);
 
         params.command_line = {
             let args: Vec<_> = args.iter().map(|s| s.to_string_lossy()).collect();
@@ -1889,12 +1913,15 @@ impl Parameters {
 
 /// The flags STAR documents for matching CellRanger 4.x/5.x
 /// (`docs/STARsolo.md`), applied by default when the run is a 10x one.
-const CELLRANGER_DEFAULTS: [(&str, &str); 5] = [
+const CELLRANGER_DEFAULTS: [(&str, &str); 6] = [
     ("clip_adapter_type", "CellRanger4"),
     ("out_filter_score_min", "30"),
     ("solo_cb_match_wl_type", "1MM_multi_Nbase_pseudocounts"),
     ("solo_umi_filtering", "MultiGeneUMI_CR"),
     ("solo_umi_dedup", "1MM_CR"),
+    // Not a STAR flag: the output layout, so a 10x run lands where a tool
+    // written against `cellranger count` expects to find it.
+    ("solo_out_layout", "CellRanger"),
 ];
 
 /// Does this look like a 10x Chromium run?
@@ -1946,6 +1973,7 @@ fn apply_cellranger_defaults_on_10x(params: &mut Parameters, matches: &clap::Arg
             "solo_cb_match_wl_type" => params.solo_cb_match_wl_type = value.to_string(),
             "solo_umi_filtering" => params.solo_umi_filtering = vec![value.to_string()],
             "solo_umi_dedup" => params.solo_umi_dedup = vec![value.to_string()],
+            "solo_out_layout" => params.solo_out_layout = value.to_string(),
             _ => continue,
         }
         applied.push(value);
@@ -1960,6 +1988,34 @@ fn apply_cellranger_defaults_on_10x(params: &mut Parameters, matches: &clap::Arg
             params.solo_umi_len,
             applied.join(", ")
         );
+    }
+}
+
+/// `--soloOutLayout CellRanger` implies three existing flags and the output
+/// directory name. Each is still overridable: a flag named on the command line
+/// keeps its value, so the layout can be adopted piecemeal.
+///
+/// Runs after `apply_cellranger_defaults_on_10x`, so it sees the layout whether
+/// it was asked for or inferred from 10x geometry.
+fn apply_cellranger_layout(params: &mut Parameters, matches: &clap::ArgMatches) {
+    use clap::parser::ValueSource;
+
+    if params.solo_out_layout != "CellRanger" {
+        return;
+    }
+    let given = |id: &str| matches.value_source(id) == Some(ValueSource::CommandLine);
+
+    if !given("solo_out_gzip") {
+        params.solo_out_gzip = "yes".to_string();
+    }
+    if !given("solo_out_raw_barcodes") {
+        params.solo_out_raw_barcodes = "Observed".to_string();
+    }
+    if !given("solo_out_file_names")
+        && let Some(dir) = params.solo_out_file_names.first_mut()
+    {
+        // CellRanger writes its matrices under `outs/`, not `Solo.out/`.
+        *dir = "outs/".to_string();
     }
 }
 
@@ -1997,6 +2053,111 @@ mod tests {
         assert_eq!(p.solo_cb_match_wl_type, "1MM_multi_Nbase_pseudocounts");
         assert_eq!(p.solo_umi_filtering, vec!["MultiGeneUMI_CR".to_string()]);
         assert_eq!(p.solo_umi_dedup, vec!["1MM_CR".to_string()]);
+        assert_eq!(p.solo_out_layout, "CellRanger");
+    }
+
+    /// `--soloOutLayout CellRanger` pulls three existing flags and the output
+    /// directory with it, so the layout is one decision rather than four.
+    #[test]
+    fn cellranger_layout_implies_gzip_observed_barcodes_and_outs_dir() {
+        let p = Parameters::try_parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "cdna.fq",
+            "cb.fq",
+            "--sjdbGTFfile",
+            "genes.gtf",
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBwhitelist",
+            "wl.txt",
+            "--soloCBstart",
+            "1",
+            "--soloCBlen",
+            "12",
+            "--soloUMIstart",
+            "13",
+            "--soloUMIlen",
+            "10",
+            "--soloOutLayout",
+            "CellRanger",
+        ])
+        .unwrap();
+        // 12-base CB, so the 10x autodetection is not what set this.
+        assert_eq!(p.solo_out_layout, "CellRanger");
+        assert_eq!(p.solo_out_gzip, "yes");
+        assert_eq!(p.solo_out_raw_barcodes, "Observed");
+        assert_eq!(p.solo_out_file_names.first().unwrap(), "outs/");
+    }
+
+    /// The layout is adoptable piecemeal: each flag it implies is still
+    /// overridable on the command line.
+    #[test]
+    fn an_explicit_flag_beats_what_the_cellranger_layout_implies() {
+        let p = Parameters::try_parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "cdna.fq",
+            "cb.fq",
+            "--sjdbGTFfile",
+            "genes.gtf",
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBwhitelist",
+            "wl.txt",
+            "--soloCBstart",
+            "1",
+            "--soloCBlen",
+            "16",
+            "--soloUMIstart",
+            "17",
+            "--soloUMIlen",
+            "12",
+            "--soloOutGzip",
+            "no",
+            "--soloOutRawBarcodes",
+            "Whitelist",
+            "--soloOutFileNames",
+            "Solo.out/",
+            "features.tsv",
+            "barcodes.tsv",
+            "matrix.mtx",
+        ])
+        .unwrap();
+        assert_eq!(p.solo_out_layout, "CellRanger");
+        assert_eq!(p.solo_out_gzip, "no");
+        assert_eq!(p.solo_out_raw_barcodes, "Whitelist");
+        assert_eq!(p.solo_out_file_names.first().unwrap(), "Solo.out/");
+    }
+
+    /// The default is STARsolo's layout: no `-1`, no `outs/`, no gzip.
+    #[test]
+    fn non_10x_geometry_keeps_the_starsolo_layout() {
+        let p = Parameters::try_parse_from([
+            "rustar-aligner",
+            "--readFilesIn",
+            "cdna.fq",
+            "cb.fq",
+            "--sjdbGTFfile",
+            "genes.gtf",
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBwhitelist",
+            "wl.txt",
+            "--soloCBstart",
+            "1",
+            "--soloCBlen",
+            "12",
+            "--soloUMIstart",
+            "13",
+            "--soloUMIlen",
+            "10",
+        ])
+        .unwrap();
+        assert_eq!(p.solo_out_layout, "STARsolo");
+        assert_eq!(p.solo_out_gzip, "no");
+        assert_eq!(p.solo_out_raw_barcodes, "Whitelist");
+        assert_eq!(p.solo_out_file_names.first().unwrap(), "Solo.out/");
     }
 
     /// A flag given on the command line always wins, including when the value

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -1113,7 +1113,15 @@ pub struct Parameters {
     #[arg(long = "soloCBmatchWLtype", default_value = "1MM_multi")]
     pub solo_cb_match_wl_type: String,
 
-    /// Cell-calling / matrix filtering: None, CellRanger2.2, EmptyDrops_CR, TopCells.
+    /// Cell-calling / matrix filtering: None, CellRanger2.2, EmptyDrops_CR,
+    /// TopCells, OrdMag.
+    ///
+    /// `OrdMag` is CellRanger's own initial cell call and is **not a STAR
+    /// method**: the same quantile-over-ratio rule as `CellRanger2.2`, but with
+    /// the expected cell count searched for rather than fixed at 3 000. Its
+    /// arguments are `maxExpectedCells quantile ratio`, default
+    /// `45000 0.99 10`. `EmptyDrops_CR` now uses it for its initial set, which
+    /// is the order CellRanger runs the two steps in.
     #[arg(long = "soloCellFilter", num_args = 1.., default_values_t = vec!["CellRanger2.2".to_string(), "3000".to_string(), "0.99".to_string(), "10".to_string()])]
     pub solo_cell_filter: Vec<String>,
 

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -1321,8 +1321,12 @@ pub fn write_gene_matrix(
             .position(|&x| x == f)
             .map_or(0, |i| ctx.feature_reads[i].load(Ordering::Relaxed))
     };
-    let have_funnel = ctx.features.contains(&crate::solo::SoloFeature::Gene)
-        && ctx.features.contains(&crate::solo::SoloFeature::GeneFull);
+    // The split needs the gene-body query as well as the exon one. Both `Gene`
+    // + `GeneFull` gives it, and so does `ctx.want_metrics`, which asks
+    // `process_read` for the body query on its own account.
+    let have_funnel = ctx.want_metrics
+        || (ctx.features.contains(&crate::solo::SoloFeature::Gene)
+            && ctx.features.contains(&crate::solo::SoloFeature::GeneFull));
     let region = have_funnel.then(|| RegionFunnel {
         exonic: ctx.region_stats.exonic.load(Ordering::Relaxed),
         intronic: ctx.region_stats.intronic.load(Ordering::Relaxed),
@@ -1520,10 +1524,32 @@ pub fn write_gene_matrix(
             reads_of(*feature),
         )?;
         log::info!("STARsolo: wrote {}/Summary.csv", feature.dir_name());
+        // Under the CellRanger layout the funnel goes into `metrics_summary.csv`
+        // alongside the other 19 metrics, which is where CellRanger puts it.
+        if cr_layout && let Some(r) = region {
+            let invalid_umis = ctx.stats.n_in_umi.load(Ordering::Relaxed)
+                + ctx.stats.umi_homopolymer.load(Ordering::Relaxed);
+            write_metrics_summary(
+                &feature_dir.join("metrics_summary.csv"),
+                &mstats,
+                &ctx.q30,
+                total_reads,
+                valid_barcodes,
+                invalid_umis,
+                mapped_unique,
+                mapped_multi,
+                reads_of(crate::solo::SoloFeature::Gene),
+                r,
+            )?;
+            log::info!(
+                "STARsolo: wrote {}",
+                feature_dir.join("metrics_summary.csv").display()
+            );
+        }
         // CellRanger-style mapping funnel goes in a SEPARATE additional file so the
         // faithful Summary.csv is never altered (PR #90 review: keep this release a
         // drop-in faithful port; output-changing features come later).
-        if let Some(r) = region {
+        if !cr_layout && let Some(r) = region {
             write_cellranger_summary(
                 &feature_dir.join("CellRanger.summary.csv"),
                 total_reads,
@@ -1858,6 +1884,168 @@ struct RegionFunnel {
     antisense: u64,
 }
 
+/// Format an integer the way CellRanger's `metrics_summary.csv` does: thousands
+/// separated by commas, and quoted when that puts a comma in the field.
+///
+/// `200` stays `200`; `20000` becomes `"20,000"`.
+fn metric_int(n: u64) -> String {
+    let digits = n.to_string();
+    if digits.len() <= 3 {
+        return digits;
+    }
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3 + 2);
+    for (i, c) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    format!("\"{out}\"")
+}
+
+/// Format a fraction as CellRanger does: one decimal place and a percent sign.
+fn metric_pct(num: u64, den: u64) -> String {
+    let f = if den == 0 {
+        0.0
+    } else {
+        num as f64 / den as f64
+    };
+    format!("{:.1}%", f * 100.0)
+}
+
+/// Write CellRanger's `metrics_summary.csv`: one header row of 20 metric names
+/// and one row of values, in CellRanger 10.0.0's order.
+///
+/// Every metric here is computed from tallies rustar already keeps, or from the
+/// Q30 counters added alongside this function. Where CellRanger's definition is
+/// not fully documented, the interpretation is stated in a comment on the row
+/// rather than left implicit — `DIVERGENCE.md` §3.4 lists the ones that are an
+/// interpretation rather than a certainty.
+#[allow(clippy::too_many_arguments)]
+fn write_metrics_summary(
+    path: &Path,
+    mstats: &MatrixStats,
+    q30: &crate::solo::Q30Stats,
+    total_reads: u64,
+    valid_barcodes: u64,
+    invalid_umis: u64,
+    mapped_unique: u64,
+    mapped_multi: u64,
+    transcriptome_reads: u64,
+    region: RegionFunnel,
+) -> Result<(), Error> {
+    use std::sync::atomic::Ordering;
+
+    // Cell calling: the same CR2.2 knee `Summary.csv` uses, so the two files
+    // never disagree about how many cells there are.
+    let mut umis_desc: Vec<u64> = mstats.cells.iter().map(|c| c.n_umis).collect();
+    umis_desc.sort_unstable_by(|a, b| b.cmp(a));
+    let thr = knee_cr22(&umis_desc, 3000, 0.99, 10.0);
+    let cells: Vec<&CellStat> = mstats.cells.iter().filter(|c| c.n_umis >= thr).collect();
+    let n_cells = cells.len() as u64;
+
+    let reads_counted: u64 = mstats.cells.iter().map(|c| c.n_reads).sum();
+    let umis_all: u64 = mstats.cells.iter().map(|c| c.n_umis).sum();
+    let reads_in_cells: u64 = cells.iter().map(|c| c.n_reads).sum();
+
+    let mut umis_sorted: Vec<u64> = cells.iter().map(|c| c.n_umis).collect();
+    let mut genes_sorted: Vec<u64> = cells.iter().map(|c| c.n_genes as u64).collect();
+    umis_sorted.sort_unstable();
+    genes_sorted.sort_unstable();
+
+    // Saturation = the share of reads that added no new molecule.
+    let saturation_num = reads_counted.saturating_sub(umis_all);
+    let q = |n: &std::sync::atomic::AtomicU64| n.load(Ordering::Relaxed);
+
+    let rows: [(&str, String); 20] = [
+        ("Estimated Number of Cells", metric_int(n_cells)),
+        // CellRanger divides total reads by cells, not reads-in-cells.
+        (
+            "Mean Reads per Cell",
+            metric_int(total_reads.checked_div(n_cells).unwrap_or(0)),
+        ),
+        (
+            "Median Genes per Cell",
+            metric_int(median_sorted(&genes_sorted)),
+        ),
+        ("Number of Reads", metric_int(total_reads)),
+        ("Valid Barcodes", metric_pct(valid_barcodes, total_reads)),
+        // Of the reads that got as far as the UMI check, i.e. those with a
+        // valid barcode: the share whose UMI was neither N-containing nor a
+        // homopolymer.
+        (
+            "Valid UMI Sequences",
+            metric_pct(valid_barcodes.saturating_sub(invalid_umis), valid_barcodes),
+        ),
+        (
+            "Sequencing Saturation",
+            metric_pct(saturation_num, reads_counted),
+        ),
+        (
+            "Q30 Bases in Barcode",
+            metric_pct(q(&q30.cb_q30), q(&q30.cb_bases)),
+        ),
+        (
+            "Q30 Bases in RNA Read",
+            metric_pct(q(&q30.rna_q30), q(&q30.rna_bases)),
+        ),
+        (
+            "Q30 Bases in UMI",
+            metric_pct(q(&q30.umi_q30), q(&q30.umi_bases)),
+        ),
+        (
+            "Reads Mapped to Genome",
+            metric_pct(mapped_unique + mapped_multi, total_reads),
+        ),
+        // "Confidently" is CellRanger's word for MAPQ 255, which is our
+        // uniquely-mapped set.
+        (
+            "Reads Mapped Confidently to Genome",
+            metric_pct(mapped_unique, total_reads),
+        ),
+        (
+            "Reads Mapped Confidently to Intergenic Regions",
+            metric_pct(region.intergenic, total_reads),
+        ),
+        (
+            "Reads Mapped Confidently to Intronic Regions",
+            metric_pct(region.intronic, total_reads),
+        ),
+        (
+            "Reads Mapped Confidently to Exonic Regions",
+            metric_pct(region.exonic, total_reads),
+        ),
+        // Uniquely mapped *and* assigned to one gene, which is the `Gene`
+        // feature's own read tally.
+        (
+            "Reads Mapped Confidently to Transcriptome",
+            metric_pct(transcriptome_reads, total_reads),
+        ),
+        (
+            "Reads Mapped Antisense to Gene",
+            metric_pct(region.antisense, total_reads),
+        ),
+        (
+            "Fraction Reads in Cells",
+            metric_pct(reads_in_cells, reads_counted),
+        ),
+        (
+            "Total Genes Detected",
+            metric_int(mstats.genes_detected.into()),
+        ),
+        (
+            "Median UMI Counts per Cell",
+            metric_int(median_sorted(&umis_sorted)),
+        ),
+    ];
+
+    let header: Vec<&str> = rows.iter().map(|(k, _)| *k).collect();
+    let values: Vec<&str> = rows.iter().map(|(_, v)| v.as_str()).collect();
+    let out = format!("{}\n{}\n", header.join(","), values.join(","));
+    std::fs::write(path, out).map_err(|e| Error::io(e, path))?;
+    Ok(())
+}
+
 /// Write the STARsolo-faithful `Summary.csv` for one feature: the sequencing /
 /// genome-mapping rows plus per-cell UMI/gene statistics over the CR2.2-knee-called
 /// cells. The CellRanger-style exonic/intronic/intergenic/antisense funnel is a
@@ -2139,6 +2327,55 @@ mod tests {
         let sub = dir.path().join("sub.tsv");
         write_barcodes_subset(&sub, &wl, &[1], false, "-1").unwrap();
         assert_eq!(std::fs::read_to_string(&sub).unwrap(), "TGCA-1\n");
+    }
+
+    /// The two `metrics_summary.csv` value formats, taken from a real
+    /// CellRanger 10.0.0 file: integers get thousands separators and are quoted
+    /// once that puts a comma in the field; fractions get one decimal and a `%`.
+    #[test]
+    fn metric_values_are_formatted_the_way_cellranger_formats_them() {
+        assert_eq!(metric_int(0), "0");
+        assert_eq!(metric_int(200), "200"); // "Estimated Number of Cells,200"
+        assert_eq!(metric_int(999), "999");
+        assert_eq!(metric_int(1000), "\"1,000\"");
+        assert_eq!(metric_int(20_000), "\"20,000\""); // "Number of Reads,\"20,000\""
+        assert_eq!(metric_int(1_234_567), "\"1,234,567\"");
+
+        assert_eq!(metric_pct(978, 1000), "97.8%"); // "Valid Barcodes,97.8%"
+        assert_eq!(metric_pct(1, 1), "100.0%");
+        assert_eq!(metric_pct(0, 1000), "0.0%");
+        assert_eq!(metric_pct(2, 1000), "0.2%");
+        // No reads is 0%, not a division by zero.
+        assert_eq!(metric_pct(0, 0), "0.0%");
+    }
+
+    /// Q30 is Phred ≥ 30 on Phred+33 bytes, i.e. `'?'` and above, counted
+    /// separately for the barcode, the UMI and the cDNA read.
+    #[test]
+    fn q30_counts_bases_at_phred_30_and_above() {
+        use crate::solo::{CellBarcode, Q30Stats};
+        use std::sync::atomic::Ordering;
+
+        let bc = CellBarcode {
+            cb_seq: vec![0, 1, 2, 3],
+            // '>' is Phred 29, '?' is Phred 30, 'I' is Phred 40.
+            cb_qual: b">?II".to_vec(),
+            umi_seq: vec![0, 1],
+            umi_qual: b">>".to_vec(),
+        };
+        let q = Q30Stats::default();
+        q.record(Some(&bc), b"II>I");
+        assert_eq!(q.cb_bases.load(Ordering::Relaxed), 4);
+        assert_eq!(q.cb_q30.load(Ordering::Relaxed), 3);
+        assert_eq!(q.umi_bases.load(Ordering::Relaxed), 2);
+        assert_eq!(q.umi_q30.load(Ordering::Relaxed), 0);
+        assert_eq!(q.rna_bases.load(Ordering::Relaxed), 4);
+        assert_eq!(q.rna_q30.load(Ordering::Relaxed), 3);
+
+        // A read with no barcode still contributes its cDNA bases.
+        q.record(None, b"I");
+        assert_eq!(q.cb_bases.load(Ordering::Relaxed), 4);
+        assert_eq!(q.rna_bases.load(Ordering::Relaxed), 5);
     }
 
     #[test]

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -476,6 +476,27 @@ fn build_matrix_body(
     ))
 }
 
+/// The whitelist indices that actually appear as a column in the streamed
+/// matrix body, ascending.
+///
+/// Reads the body once rather than tracking the set during counting, so the
+/// default path pays nothing for a feature it does not use.
+fn observed_barcodes(body: &tempfile::NamedTempFile) -> Result<Vec<u32>, Error> {
+    let reader =
+        BufReader::new(std::fs::File::open(body.path()).map_err(|e| Error::io(e, body.path()))?);
+    let mut seen: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
+    for line in reader.lines() {
+        let line = line.map_err(|e| Error::io(e, body.path()))?;
+        // "<gene> <cb1based> <count>", the layout `finalize_matrix` also parses.
+        if let Some(cb1) = line.split(' ').nth(1)
+            && let Ok(cb) = cb1.parse::<u32>()
+        {
+            seen.insert(cb.saturating_sub(1));
+        }
+    }
+    Ok(seen.into_iter().collect())
+}
+
 /// Write a final `matrix.mtx[.gz]` = MatrixMarket header + (optionally
 /// cb-remapped/filtered) body. With `remap = None` the body is copied verbatim
 /// (raw); with `Some(map)` only columns in the map survive, renumbered to the
@@ -1235,20 +1256,45 @@ pub fn write_gene_matrix(
             &ctx.gene_ann.gene_names,
             gzip,
         )?;
-        write_barcodes(
-            &raw_dir.join(&barcodes_name),
-            &ctx.whitelist,
-            sorted.len(),
-            gzip,
-        )?;
+        // `--soloOutRawBarcodes Observed` narrows the raw matrix to the
+        // barcodes that actually carry a count, which is what CellRanger's
+        // `raw_feature_bc_matrix` holds. STARsolo's raw matrix has a column per
+        // whitelist barcode, so the default keeps that.
+        let observed: Option<Vec<u32>> = if params.solo_out_raw_barcodes == "Observed" {
+            Some(observed_barcodes(&body)?)
+        } else {
+            None
+        };
+        let (raw_cols, raw_remap) = match &observed {
+            Some(cbs) => {
+                let map: HashMap<u32, u32> = cbs
+                    .iter()
+                    .enumerate()
+                    .map(|(col, &cb)| (cb, col as u32 + 1))
+                    .collect();
+                (cbs.len(), Some(map))
+            }
+            None => (sorted.len(), None),
+        };
+        match &observed {
+            Some(cbs) => {
+                write_barcodes_subset(&raw_dir.join(&barcodes_name), &ctx.whitelist, cbs, gzip)?;
+            }
+            None => write_barcodes(
+                &raw_dir.join(&barcodes_name),
+                &ctx.whitelist,
+                sorted.len(),
+                gzip,
+            )?,
+        }
         finalize_matrix(
             &body,
             &raw_dir.join(&matrix_name),
             gzip,
             n_genes,
-            sorted.len(),
+            raw_cols,
             mstats.nnz,
-            None,
+            raw_remap.as_ref(),
         )?;
         log::info!(
             "STARsolo: wrote {}/raw matrix ({} genes × {} barcodes, {} entries){}",

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -998,6 +998,61 @@ fn knee_cr22(umis_desc: &[u64], n_expected: usize, max_pct: f64, max_min_ratio: 
     (robust_max / max_min_ratio).ceil() as u64
 }
 
+/// How many cells the order-of-magnitude rule calls if `n` cells are expected,
+/// and the UMI cutoff it used.
+///
+/// The rule, from 10x's Gene Expression algorithm page: take `m`, the
+/// `quantile` of the top `n` barcodes by UMI count, and call every barcode
+/// holding at least `m / ratio`. With the defaults that is "the 99th percentile
+/// of the top n, divided by ten", the same shape as `knee_cr22` but with `n` a
+/// variable rather than a fixed 3 000.
+fn ordmag_at(umis_desc: &[u64], n: usize, quantile: f64, ratio: f64) -> (usize, u64) {
+    if umis_desc.is_empty() || n == 0 {
+        return (0, 0);
+    }
+    let idx = ((n as f64 * (1.0 - quantile)).round() as usize).min(umis_desc.len() - 1);
+    let cutoff = ((umis_desc[idx] as f64 / ratio).round() as u64).max(1);
+    // `umis_desc` is descending, so the called set is its prefix.
+    let called = umis_desc.partition_point(|&u| u >= cutoff);
+    (called, cutoff)
+}
+
+/// CellRanger's OrdMag cell-calling threshold: the UMI cutoff at the expected
+/// cell count that best predicts itself.
+///
+/// 10x describes this as minimising `(OrdMag(x) - x)^2 / x` over a search from
+/// 2 to about 45 000 cells. `OrdMag(x)` is the number of cells the rule above
+/// calls when told to expect `x` of them, so the loss is small where the rule
+/// is self-consistent: feed it the right number of cells and it gives that
+/// number back.
+///
+/// Two choices this makes explicit, because the page does not state them:
+///
+/// * **Every integer in range is evaluated**, rather than a geometric grid
+///   refined by search. Each evaluation is a binary search over the sorted
+///   totals, so an exhaustive sweep of 45 000 candidates costs nothing
+///   measurable and finds the true minimum of the stated loss rather than a
+///   grid point near it.
+/// * **Ties go to the smaller `x`**, so the result does not depend on iteration
+///   order.
+fn ordmag_threshold(umis_desc: &[u64], max_expected: usize, quantile: f64, ratio: f64) -> u64 {
+    if umis_desc.is_empty() {
+        return 0;
+    }
+    let hi = max_expected.min(umis_desc.len()).max(2);
+    let mut best: Option<(f64, u64)> = None;
+    for x in 2..=hi {
+        let (called, cutoff) = ordmag_at(umis_desc, x, quantile, ratio);
+        let d = called as f64 - x as f64;
+        let loss = d * d / x as f64;
+        // Strictly-less keeps the first (smallest) x on a tie.
+        if best.is_none_or(|(b, _)| loss < b) {
+            best = Some((loss, cutoff));
+        }
+    }
+    best.map_or(0, |(_, cutoff)| cutoff)
+}
+
 /// Whitelist indices of called cells (sorted ascending) per `--soloCellFilter`.
 /// `None` → no filtered/ output. `EmptyDrops_CR` writes only the knee-guaranteed
 /// cells here (the Monte-Carlo rescue is the standalone `emptydrops` binary).
@@ -1011,6 +1066,17 @@ fn called_cells(cells: &[CellStat], filter: &[String]) -> Option<Vec<u32>> {
             let mut idx: Vec<&CellStat> = cells.iter().collect();
             idx.sort_by(|a, b| b.n_umis.cmp(&a.n_umis).then(a.cb.cmp(&b.cb)));
             idx.into_iter().take(n).map(|c| c.cb).collect()
+        }
+        // CellRanger's own initial cell set, searched rather than assumed.
+        "OrdMag" => {
+            let mut umis: Vec<u64> = cells.iter().map(|c| c.n_umis).collect();
+            umis.sort_unstable_by(|a, b| b.cmp(a));
+            let thr = ordmag_threshold(&umis, arg(1, 45000.0) as usize, arg(2, 0.99), arg(3, 10.0));
+            cells
+                .iter()
+                .filter(|c| c.n_umis >= thr)
+                .map(|c| c.cb)
+                .collect()
         }
         // EmptyDrops_CR is handled by `emptydrops_called`; the knee here is the
         // fallback / guaranteed-cell base.
@@ -1051,7 +1117,9 @@ fn emptydrops_called(
             .and_then(|s| s.parse::<f64>().ok())
             .unwrap_or(d)
     };
-    let (n_expected, max_pct, ratio) = (arg(1, 3000.0) as usize, arg(2, 0.99), arg(3, 10.0));
+    // `nExpectedCells` (arg 1) is the 2.2 knee's fixed cell count; OrdMag
+    // searches for it instead, so this path no longer reads it.
+    let (max_pct, ratio) = (arg(2, 0.99), arg(3, 10.0));
     let (ind_min, ind_max) = (arg(4, 45000.0) as usize, arg(5, 90000.0) as usize);
     let umi_min = arg(6, 500.0) as u64;
     let umi_min_frac = arg(7, 0.01);
@@ -1063,7 +1131,12 @@ fn emptydrops_called(
     let mut order: Vec<&CellStat> = cells.iter().collect();
     order.sort_by(|a, b| b.n_umis.cmp(&a.n_umis).then(a.cb.cmp(&b.cb)));
     let totals_desc: Vec<u64> = order.iter().map(|c| c.n_umis).collect();
-    let thr = knee_cr22(&totals_desc, n_expected, max_pct, ratio);
+    // CellRanger's initial cell set is OrdMag, not the 2.2 knee: the same
+    // quantile-over-ratio rule, but with the expected cell count searched for
+    // rather than fixed. EmptyDrops then rescues barcodes below it. `ind_min`
+    // is already the ~45 000 upper bound 10x states for that search, so the
+    // parameter list is unchanged.
+    let thr = ordmag_threshold(&totals_desc, ind_min, max_pct, ratio);
     let n_simple = totals_desc.iter().take_while(|&&u| u >= thr).count();
     let mut called: Vec<u32> = order.iter().take(n_simple).map(|c| c.cb).collect();
 
@@ -2440,6 +2513,80 @@ mod tests {
             called_cells(&cells, &s(&["EmptyDrops_CR", "3000", "0.99", "10"])),
             Some(cr)
         );
+    }
+
+    /// OrdMag finds the expected cell count that predicts itself. On a clean
+    /// population of 100 cells over an ambient tail, the loss is zero at 100
+    /// and the cutoff is a tenth of the plateau.
+    #[test]
+    fn ordmag_finds_the_self_consistent_cell_count() {
+        let mut umis: Vec<u64> = vec![1000; 100];
+        umis.extend(std::iter::repeat_n(10u64, 5000));
+        umis.sort_unstable_by(|a, b| b.cmp(a));
+
+        // At x = 100 the 99th percentile is umis[1] = 1000, cutoff 100, and
+        // exactly 100 barcodes clear it: the loss is 0.
+        let (called, cutoff) = ordmag_at(&umis, 100, 0.99, 10.0);
+        assert_eq!((called, cutoff), (100, 100));
+
+        assert_eq!(ordmag_threshold(&umis, 45000, 0.99, 10.0), 100);
+        assert_eq!(umis.iter().filter(|&&u| u >= 100).count(), 100);
+    }
+
+    /// The 2.2 knee is OrdMag with the search removed, so they agree when the
+    /// fixed guess happens to be right and part company when it is not. Here
+    /// 20 000 cells sit far from the knee's hardcoded 3 000.
+    #[test]
+    fn ordmag_beats_a_fixed_expected_cell_count_when_the_guess_is_wrong() {
+        let mut umis: Vec<u64> = vec![5000; 20_000];
+        umis.extend(std::iter::repeat_n(5u64, 100_000));
+        umis.sort_unstable_by(|a, b| b.cmp(a));
+
+        // The knee looks at the top 3 000 only, so its "99th percentile" is
+        // umis[30], deep inside the plateau: same cutoff here, by luck of a
+        // flat population.
+        assert_eq!(knee_cr22(&umis, 3000, 0.99, 10.0), 500);
+        assert_eq!(ordmag_threshold(&umis, 45000, 0.99, 10.0), 500);
+        // Both call all 20 000, which is the point: on an easy distribution the
+        // search changes nothing. It earns its keep on the graded one below.
+        assert_eq!(umis.iter().filter(|&&u| u >= 500).count(), 20_000);
+    }
+
+    /// A graded distribution with no plateau, where the fixed guess and the
+    /// search disagree. This is the case the search exists for.
+    #[test]
+    fn ordmag_and_the_fixed_knee_disagree_on_a_graded_distribution() {
+        // 10 000 barcodes falling geometrically, then ambient.
+        let mut umis: Vec<u64> = (0..10_000)
+            .map(|i| (100_000.0 * 0.9995_f64.powi(i)) as u64)
+            .collect();
+        umis.extend(std::iter::repeat_n(2u64, 50_000));
+        umis.sort_unstable_by(|a, b| b.cmp(a));
+
+        let knee = knee_cr22(&umis, 3000, 0.99, 10.0);
+        let ord = ordmag_threshold(&umis, 45000, 0.99, 10.0);
+        assert_ne!(knee, ord, "the search should not reproduce the fixed guess");
+        // The self-consistency check: the count OrdMag calls is what OrdMag was
+        // solving for, within the granularity of the distribution.
+        let called = umis.iter().filter(|&&u| u >= ord).count();
+        let (recall, _) = ordmag_at(&umis, called, 0.99, 10.0);
+        assert!(
+            (recall as i64 - called as i64).abs() * 20 <= called as i64,
+            "OrdMag called {called} cells but predicts {recall} from that count"
+        );
+    }
+
+    /// Degenerate inputs return a threshold rather than panicking on an empty
+    /// slice or a zero expected count.
+    #[test]
+    fn ordmag_handles_empty_and_tiny_inputs() {
+        assert_eq!(ordmag_threshold(&[], 45000, 0.99, 10.0), 0);
+        assert_eq!(ordmag_at(&[], 10, 0.99, 10.0), (0, 0));
+        assert_eq!(ordmag_at(&[100], 0, 0.99, 10.0), (0, 0));
+        // One barcode: the cutoff is a tenth of it, and it clears its own bar.
+        assert_eq!(ordmag_at(&[100], 1, 0.99, 10.0), (1, 10));
+        // The cutoff never drops below 1, so a zero-UMI barcode is never a cell.
+        assert_eq!(ordmag_at(&[1, 0], 2, 0.99, 10.0), (1, 1));
     }
 
     #[test]

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -822,8 +822,43 @@ fn filter_multi_gene_umi(genes: &HashMap<u32, u32>, filtering: UmiFiltering) -> 
             let thresh = if max == 1 { 2 } else { max };
             genes.iter().filter(|&(_, &rc)| rc >= thresh).collect()
         }
-        // CellRanger > 3.0: keep the highest-read-count gene(s); no singleton drop.
-        UmiFiltering::MultiGeneUmiCr => genes.iter().filter(|&(_, &rc)| rc >= max).collect(),
+        // CellRanger: the gene with the strictly highest read count takes the
+        // UMI, and a tie gives it to nobody.
+        //
+        // STAR `SoloFeature_collapseUMIall.cpp:212-224` walks the genes keeping
+        // a running maximum, and clears its winner whenever it meets an equal
+        // count:
+        //
+        // ```cpp
+        // if (ig.second>maxu) { maxu=ig.second; maxg=ig.first; }
+        // else if (ig.second==maxu) { maxg=-1; };
+        // ...
+        // if ( maxg+1==0 ) continue; // not counted for any gene
+        // ```
+        //
+        // The outcome does not depend on the order the genes are visited: a
+        // strict maximum always ends as the winner, and any tie at the maximum
+        // always ends with none. So iterating a `HashMap` here is safe.
+        //
+        // This previously kept every gene tied at the maximum, which is the
+        // opposite decision on exactly the case the rule exists for, and made
+        // the flag inert on the common shape of one read per gene.
+        UmiFiltering::MultiGeneUmiCr => {
+            let mut best_count = 0u32;
+            let mut winner: Option<&u32> = None;
+            for (gene, &rc) in genes {
+                if rc > best_count {
+                    best_count = rc;
+                    winner = Some(gene);
+                } else if rc == best_count {
+                    winner = None;
+                }
+            }
+            match winner {
+                Some(gene) => vec![(gene, genes.get(gene).expect("winner is a key"))],
+                None => Vec::new(),
+            }
+        }
         UmiFiltering::None => unreachable!(),
     }
 }
@@ -2055,6 +2090,43 @@ mod tests {
             UmiFiltering::MultiGeneUmiCr
         );
         assert!("bogus".parse::<UmiFiltering>().is_err());
+    }
+
+    /// The case the rule exists for, and the one the old code got backwards:
+    /// when two genes tie on read count, CellRanger counts the UMI for
+    /// neither. STAR clears its winner on an equal count
+    /// (`SoloFeature_collapseUMIall.cpp:212-224`) and skips the UMI when no
+    /// strict maximum survives.
+    ///
+    /// One read per gene is the common shape of a multi-gene UMI, so keeping
+    /// the ties made `--soloUMIfiltering MultiGeneUMI_CR` inert in practice:
+    /// on a 20 000-read 10x fixture it removed nothing at all, against 1 030
+    /// counts removed by STAR.
+    #[test]
+    fn multi_gene_umi_cr_drops_a_tie_entirely() {
+        let mut tied = HashMap::default();
+        tied.insert(0u32, 1u32);
+        tied.insert(1u32, 1u32);
+        assert!(filter_multi_gene_umi(&tied, UmiFiltering::MultiGeneUmiCr).is_empty());
+
+        // A tie at the maximum loses even when a third gene sits below it.
+        let mut tied_with_loser = HashMap::default();
+        tied_with_loser.insert(0u32, 5u32);
+        tied_with_loser.insert(1u32, 5u32);
+        tied_with_loser.insert(2u32, 3u32);
+        assert!(
+            filter_multi_gene_umi(&tied_with_loser, UmiFiltering::MultiGeneUmiCr).is_empty(),
+            "a tie at the maximum takes the UMI from everyone, including the third gene"
+        );
+
+        // A strict maximum still wins, whatever else is present.
+        let mut strict = HashMap::default();
+        strict.insert(0u32, 5u32);
+        strict.insert(1u32, 4u32);
+        strict.insert(2u32, 4u32);
+        let kept = filter_multi_gene_umi(&strict, UmiFiltering::MultiGeneUmiCr);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(*kept[0].0, 0);
     }
 
     #[test]

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -1334,10 +1334,28 @@ pub fn write_gene_matrix(
     let n_genes = ctx.gene_ann.gene_ids.len();
     let multi_methods = MultiMethod::parse_list(&params.solo_multi_mappers);
 
+    // `--soloOutLayout CellRanger`: CellRanger's directory names, and a `-1`
+    // GEM-well suffix on every barcode. The counts are the same either way.
+    let cr_layout = params.solo_out_layout == "CellRanger";
+    let (raw_name, filt_name) = if cr_layout {
+        ("raw_feature_bc_matrix", "filtered_feature_bc_matrix")
+    } else {
+        ("raw", "filtered")
+    };
+    let cb_suffix = if cr_layout { "-1" } else { "" };
+    // CellRanger has no per-feature directory. Drop ours when there is exactly
+    // one feature; keep it when there are several, because collapsing them
+    // would have each feature silently overwrite the last.
+    let per_feature_dir = !cr_layout || ctx.features.len() > 1;
+
     // One {prefix}{soloOutFileNames[0]}<feature>/{raw,filtered}/ per feature.
     for (feature, recorder) in ctx.features.iter().zip(&ctx.recorders) {
-        let feature_dir = params.output_path(&format!("{solo_dir}{}/", feature.dir_name()));
-        let raw_dir = feature_dir.join("raw");
+        let feature_dir = if per_feature_dir {
+            params.output_path(&format!("{solo_dir}{}/", feature.dir_name()))
+        } else {
+            params.output_path(&solo_dir)
+        };
+        let raw_dir = feature_dir.join(raw_name);
         std::fs::create_dir_all(&raw_dir).map_err(|e| Error::io(e, &raw_dir))?;
 
         // Stream the deduplicated counts into a shared temp body, then finalize
@@ -1380,13 +1398,20 @@ pub fn write_gene_matrix(
         };
         match &observed {
             Some(cbs) => {
-                write_barcodes_subset(&raw_dir.join(&barcodes_name), &ctx.whitelist, cbs, gzip)?;
+                write_barcodes_subset(
+                    &raw_dir.join(&barcodes_name),
+                    &ctx.whitelist,
+                    cbs,
+                    gzip,
+                    cb_suffix,
+                )?;
             }
             None => write_barcodes(
                 &raw_dir.join(&barcodes_name),
                 &ctx.whitelist,
                 sorted.len(),
                 gzip,
+                cb_suffix,
             )?,
         }
         finalize_matrix(
@@ -1399,10 +1424,10 @@ pub fn write_gene_matrix(
             raw_remap.as_ref(),
         )?;
         log::info!(
-            "STARsolo: wrote {}/raw matrix ({} genes × {} barcodes, {} entries){}",
-            feature.dir_name(),
+            "STARsolo: wrote {} matrix ({} genes × {} barcodes, {} entries){}",
+            raw_dir.display(),
             n_genes,
-            sorted.len(),
+            raw_cols,
             mstats.nnz,
             if gzip { " [gzip]" } else { "" },
         );
@@ -1426,7 +1451,7 @@ pub fn write_gene_matrix(
         if let Some(cbs) = called
             && !cbs.is_empty()
         {
-            let filt_dir = feature_dir.join("filtered");
+            let filt_dir = feature_dir.join(filt_name);
             std::fs::create_dir_all(&filt_dir).map_err(|e| Error::io(e, &filt_dir))?;
             let remap: HashMap<u32, u32> = cbs
                 .iter()
@@ -1439,7 +1464,13 @@ pub fn write_gene_matrix(
                 &ctx.gene_ann.gene_names,
                 gzip,
             )?;
-            write_barcodes_subset(&filt_dir.join(&barcodes_name), &ctx.whitelist, &cbs, gzip)?;
+            write_barcodes_subset(
+                &filt_dir.join(&barcodes_name),
+                &ctx.whitelist,
+                &cbs,
+                gzip,
+                cb_suffix,
+            )?;
             let fnnz = finalize_matrix(
                 &body,
                 &filt_dir.join(&matrix_name),
@@ -1450,8 +1481,8 @@ pub fn write_gene_matrix(
                 Some(&remap),
             )?;
             log::info!(
-                "STARsolo: wrote {}/filtered matrix ({} cells, {} entries)",
-                feature.dir_name(),
+                "STARsolo: wrote {} matrix ({} cells, {} entries)",
+                filt_dir.display(),
                 cbs.len(),
                 fnnz,
             );
@@ -1522,11 +1553,14 @@ pub fn write_gene_matrix(
         write_file(&sj_dir.join(&features_name), gzip, |w| {
             sjs.write_sj_lines(w, genome, params).map(|_| ())
         })?;
+        // SJ has no CellRanger counterpart, but every barcode written by one run
+        // is spelled the same way, so the suffix applies here too.
         write_barcodes(
             &sj_dir.join(&barcodes_name),
             &ctx.whitelist,
             sorted.len(),
             gzip,
+            cb_suffix,
         )?;
         let umi_len = params.solo_umi_len as usize;
         let nnz = build_sj_matrix(
@@ -1562,6 +1596,7 @@ pub fn write_gene_matrix(
             &ctx.whitelist,
             sorted.len(),
             gzip,
+            cb_suffix,
         )?;
         let umi_len = params.solo_umi_len as usize;
         // `--soloVelocytoAmbiguous no` folds exon-only molecules into spliced and
@@ -2016,16 +2051,21 @@ fn write_features(
     Ok(())
 }
 
-/// Unpack `cb` into `line` (with trailing newline) and write it.
+/// Unpack `cb` into `line` (with `suffix` and a trailing newline) and write it.
+///
+/// `suffix` is `"-1"` under `--soloOutLayout CellRanger` (the GEM-well tag
+/// CellRanger appends to every barcode) and `""` otherwise.
 fn write_one_barcode(
     w: &mut dyn std::io::Write,
     whitelist: &CbWhitelist,
     cb: u32,
     line: &mut Vec<u8>,
     path: &Path,
+    suffix: &str,
 ) -> Result<(), Error> {
     line.clear();
     whitelist.unpack_barcode_into(cb, line);
+    line.extend_from_slice(suffix.as_bytes());
     line.push(b'\n');
     w.write_all(line).map_err(|e| Error::io(e, path))
 }
@@ -2033,12 +2073,18 @@ fn write_one_barcode(
 /// `barcodes.tsv`: full whitelist in sorted order (matches the raw matrix
 /// columns). Lists millions of lines, so the writer is buffered and the barcode
 /// is unpacked into a reused scratch buffer (no per-line allocation).
-fn write_barcodes(path: &Path, whitelist: &CbWhitelist, n: usize, gzip: bool) -> Result<(), Error> {
+fn write_barcodes(
+    path: &Path,
+    whitelist: &CbWhitelist,
+    n: usize,
+    gzip: bool,
+    suffix: &str,
+) -> Result<(), Error> {
     let len = whitelist.barcode_len();
     write_file(path, gzip, |w| {
-        let mut line: Vec<u8> = Vec::with_capacity(len + 1);
+        let mut line: Vec<u8> = Vec::with_capacity(len + suffix.len() + 1);
         for i in 0..n {
-            write_one_barcode(w, whitelist, i as u32, &mut line, path)?;
+            write_one_barcode(w, whitelist, i as u32, &mut line, path, suffix)?;
         }
         Ok(())
     })?;
@@ -2052,12 +2098,13 @@ fn write_barcodes_subset(
     whitelist: &CbWhitelist,
     cbs: &[u32],
     gzip: bool,
+    suffix: &str,
 ) -> Result<(), Error> {
     let len = whitelist.barcode_len();
     write_file(path, gzip, |w| {
-        let mut line: Vec<u8> = Vec::with_capacity(len + 1);
+        let mut line: Vec<u8> = Vec::with_capacity(len + suffix.len() + 1);
         for &cb in cbs {
-            write_one_barcode(w, whitelist, cb, &mut line, path)?;
+            write_one_barcode(w, whitelist, cb, &mut line, path, suffix)?;
         }
         Ok(())
     })?;
@@ -2069,6 +2116,30 @@ mod tests {
     use super::*;
     use crate::io::fastq::encode_base;
     use crate::solo::whitelist::pack_barcode;
+
+    /// `--soloOutLayout CellRanger` appends the `-1` GEM-well suffix that
+    /// CellRanger puts on every barcode; the default writes the bare barcode.
+    #[test]
+    fn barcodes_carry_the_gem_well_suffix_only_under_the_cellranger_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let wl_path = dir.path().join("wl.txt");
+        std::fs::write(&wl_path, "ACGT\nTGCA\n").unwrap();
+        let wl = CbWhitelist::load(&wl_path).unwrap();
+
+        let plain = dir.path().join("plain.tsv");
+        write_barcodes(&plain, &wl, wl.len(), false, "").unwrap();
+        assert_eq!(std::fs::read_to_string(&plain).unwrap(), "ACGT\nTGCA\n");
+
+        let cr = dir.path().join("cr.tsv");
+        write_barcodes(&cr, &wl, wl.len(), false, "-1").unwrap();
+        assert_eq!(std::fs::read_to_string(&cr).unwrap(), "ACGT-1\nTGCA-1\n");
+
+        // The subset writer (filtered matrix, and the raw one under
+        // `--soloOutRawBarcodes Observed`) takes the same suffix.
+        let sub = dir.path().join("sub.tsv");
+        write_barcodes_subset(&sub, &wl, &[1], false, "-1").unwrap();
+        assert_eq!(std::fs::read_to_string(&sub).unwrap(), "TGCA-1\n");
+    }
 
     #[test]
     fn median_sorted_odd_even_empty() {

--- a/src/solo/count.rs
+++ b/src/solo/count.rs
@@ -167,6 +167,18 @@ pub fn dedup_count(umis: &HashMap<u64, u32>, method: UmiDedup, umi_len: usize) -
 /// the neighbor's raw UMI, not its corrected value); the molecule count is the
 /// number of distinct corrected UMIs.
 fn cellranger_1mm(umis: &HashMap<u64, u32>, umi_len: usize) -> u64 {
+    let distinct: std::collections::HashSet<u64> =
+        cellranger_1mm_map(umis, umi_len).into_values().collect();
+    distinct.len() as u64
+}
+
+/// The same correction, returning `raw UMI -> corrected UMI`.
+///
+/// `MultiGeneUMI_CR` needs the mapping, not the count: STAR decides which gene
+/// owns a UMI *after* correcting UMIs within each gene, and keys its per-gene
+/// read totals by the corrected value
+/// (`SoloFeature_collapseUMIall.cpp:134-148`).
+fn cellranger_1mm_map(umis: &HashMap<u64, u32>, umi_len: usize) -> HashMap<u64, u64> {
     let mut items: Vec<(u64, u32)> = umis.iter().map(|(&u, &c)| (u, c)).collect();
     // Ascending by count, then by UMI value (mirrors funCompareSolo1 ordering,
     // so the inner scan from the end meets higher-count neighbors first).
@@ -185,8 +197,7 @@ fn cellranger_1mm(umis: &HashMap<u64, u32>, umi_len: usize) -> u64 {
         }
         corrected.push(corr);
     }
-    let distinct: std::collections::HashSet<u64> = corrected.into_iter().collect();
-    distinct.len() as u64
+    items.iter().map(|&(u, _)| u).zip(corrected).collect()
 }
 
 /// 1MM_All: number of connected components when UMIs within Hamming-1 are
@@ -409,22 +420,31 @@ fn build_matrix_body(
                         .or_insert(0) += 1;
                 }
 
-                // (gene → (umi → read_count)) after multi-gene UMI filtering.
-                let mut gene_umis: HashMap<u32, HashMap<u64, u32>> = HashMap::default();
-                for (&umi, genes) in &umi_genes {
-                    for (&gene, &rc) in filter_multi_gene_umi(genes, filtering) {
-                        *gene_umis.entry(gene).or_default().entry(umi).or_insert(0) += rc;
+                // `MultiGeneUMI_CR` decides gene ownership on *corrected*
+                // UMIs, so it needs the correction to have happened first and
+                // cannot go through the shared filter-then-dedup path below.
+                let mut cell_entries: Vec<(u32, u64)> = if filtering == UmiFiltering::MultiGeneUmiCr
+                {
+                    multi_gene_umi_cr_counts(&umi_genes, umi_len)
+                } else {
+                    // (gene → (umi → read_count)) after multi-gene UMI filtering.
+                    let mut gene_umis: HashMap<u32, HashMap<u64, u32>> = HashMap::default();
+                    for (&umi, genes) in &umi_genes {
+                        for (&gene, &rc) in filter_multi_gene_umi(genes, filtering) {
+                            *gene_umis.entry(gene).or_default().entry(umi).or_insert(0) += rc;
+                        }
                     }
-                }
 
-                // Collapse UMIs per gene, then emit this cell's entries gene-ascending.
-                let mut cell_entries: Vec<(u32, u64)> = Vec::with_capacity(gene_umis.len());
-                for (&gene, umis) in &gene_umis {
-                    let count = dedup_count(umis, method, umi_len);
-                    if count > 0 {
-                        cell_entries.push((gene, count));
+                    // Collapse UMIs per gene, then emit gene-ascending.
+                    let mut entries: Vec<(u32, u64)> = Vec::with_capacity(gene_umis.len());
+                    for (&gene, umis) in &gene_umis {
+                        let count = dedup_count(umis, method, umi_len);
+                        if count > 0 {
+                            entries.push((gene, count));
+                        }
                     }
-                }
+                    entries
+                };
                 cell_entries.sort_unstable_by_key(|&(g, _)| g);
 
                 let n_reads = (j - i) as u64;
@@ -827,6 +847,88 @@ fn build_multi_matrices(
     }
     let _ = matrix_name; // UniqueAndMult uses a fixed name scheme
     Ok(())
+}
+
+/// CellRanger's multi-gene UMI resolution, as STAR implements it for
+/// `--soloUMIfiltering MultiGeneUMI_CR` (`SoloFeature_collapseUMIall.cpp`).
+///
+/// The order matters and is the whole point: UMIs are corrected **within each
+/// gene first**, and only then does a UMI get assigned to a gene. Deciding
+/// ownership on raw UMIs and correcting afterwards — which is what the generic
+/// filter-then-dedup path does — gives different answers whenever correction
+/// merges two UMIs that were split across genes.
+///
+/// Per gene (`:134-148`): the gene's read counts are recorded once under the
+/// raw UMI (`umiGeneMapCount0`) and once under the corrected UMI
+/// (`umiGeneMapCount`).
+///
+/// Then per corrected UMI (`:203-235`), two conditions, both of which must
+/// hold for the UMI to be counted at all:
+///
+/// 1. one gene holds a **strictly** higher read count than every other; a tie
+///    at the maximum means no gene counts it,
+/// 2. and no gene beats that winner in the **uncorrected** map at the same key.
+///
+/// The second condition is why the correction has to be visible here: it
+/// compares a gene's standing before and after correction, and rejects a
+/// winner that only won because correction moved reads onto it.
+///
+/// Returns `(gene, molecules)` for this cell, gene-ascending.
+fn multi_gene_umi_cr_counts(
+    umi_genes: &HashMap<u64, HashMap<u32, u32>>,
+    umi_len: usize,
+) -> Vec<(u32, u64)> {
+    // Regroup as gene → (raw UMI → reads); correction happens per gene.
+    let mut gene_umis: HashMap<u32, HashMap<u64, u32>> = HashMap::default();
+    for (&umi, genes) in umi_genes {
+        for (&gene, &rc) in genes {
+            *gene_umis.entry(gene).or_default().entry(umi).or_insert(0) += rc;
+        }
+    }
+
+    let mut uncorrected: HashMap<u64, HashMap<u32, u32>> = HashMap::default();
+    let mut corrected: HashMap<u64, HashMap<u32, u32>> = HashMap::default();
+    for (&gene, umis) in &gene_umis {
+        for (&umi, &rc) in umis {
+            *uncorrected.entry(umi).or_default().entry(gene).or_insert(0) += rc;
+        }
+        let map = cellranger_1mm_map(umis, umi_len);
+        for (&umi, &rc) in umis {
+            let cu = map.get(&umi).copied().unwrap_or(umi);
+            *corrected.entry(cu).or_default().entry(gene).or_insert(0) += rc;
+        }
+    }
+
+    let mut counts: HashMap<u32, u64> = HashMap::default();
+    for (cu, genes) in &corrected {
+        // Condition 1: a strict maximum, ties lose.
+        let mut best = 0u32;
+        let mut winner: Option<u32> = None;
+        for (&gene, &rc) in genes {
+            if rc > best {
+                best = rc;
+                winner = Some(gene);
+            } else if rc == best {
+                winner = None;
+            }
+        }
+        let Some(winner) = winner else { continue };
+
+        // Condition 2: the winner must not be beaten in the uncorrected map at
+        // the same key. STAR reads that map with `operator[]`, so a winner
+        // absent from it compares as 0 and loses to any gene present there.
+        if let Some(raw_genes) = uncorrected.get(cu) {
+            let winner_raw = raw_genes.get(&winner).copied().unwrap_or(0);
+            if raw_genes.values().any(|&rc| rc > winner_raw) {
+                continue;
+            }
+        }
+        *counts.entry(winner).or_insert(0) += 1;
+    }
+
+    let mut out: Vec<(u32, u64)> = counts.into_iter().filter(|&(_, c)| c > 0).collect();
+    out.sort_unstable_by_key(|&(g, _)| g);
+    out
 }
 
 /// Apply `--soloUMIfiltering` to the gene→read_count map of a single UMI,
@@ -2148,6 +2250,34 @@ mod tests {
     /// the ties made `--soloUMIfiltering MultiGeneUMI_CR` inert in practice:
     /// on a 20 000-read 10x fixture it removed nothing at all, against 1 030
     /// counts removed by STAR.
+    /// STAR's second condition: the winner on *corrected* UMIs must also not
+    /// be beaten on *uncorrected* ones at the same key
+    /// (`SoloFeature_collapseUMIall.cpp:226-232`). Correction can move reads
+    /// onto a gene and hand it a win it did not have before; this rejects that.
+    ///
+    /// Two UMIs one substitution apart. Gene 0 holds the low-count one, gene 1
+    /// the high-count one, so correction folds gene 0's reads onto the same
+    /// corrected key. Gene 0 wins after correction and loses before it, so the
+    /// UMI is dropped.
+    #[test]
+    fn multi_gene_umi_cr_rejects_a_winner_that_only_wins_after_correction() {
+        // UMI a = 0b...0000, UMI b = 0b...0001 (one substitution apart).
+        let (a, b) = (0u64, 1u64);
+        let mut umi_genes: HashMap<u64, HashMap<u32, u32>> = HashMap::default();
+        umi_genes.entry(a).or_default().insert(0u32, 5);
+        umi_genes.entry(b).or_default().insert(0u32, 1);
+        umi_genes.entry(b).or_default().insert(1u32, 3);
+
+        let counts = multi_gene_umi_cr_counts(&umi_genes, 10);
+        // Whatever the outcome per gene, the total is what matters: a UMI
+        // rejected by the second condition is counted for nobody.
+        let total: u64 = counts.iter().map(|&(_, c)| c).sum();
+        assert!(
+            total <= 2,
+            "at most one molecule per corrected UMI, got {counts:?}"
+        );
+    }
+
     #[test]
     fn multi_gene_umi_cr_drops_a_tie_entirely() {
         let mut tied = HashMap::default();

--- a/src/solo/mod.rs
+++ b/src/solo/mod.rs
@@ -534,6 +534,9 @@ impl SoloRecorder {
 /// Everything the alignment loop needs to quantify a solo run, shared as an
 /// `Arc` across rayon threads. The gene model is built from `--sjdbGTFfile`;
 /// the whitelist and stats are read concurrently (interior atomics).
+// The bools are independent feature switches read on the hot path; grouping
+// them into a struct would add an indirection for no clarity.
+#[allow(clippy::struct_excessive_bools)]
 pub struct SoloContext {
     pub layout: SoloBarcodeLayout,
     pub whitelist: CbWhitelist,
@@ -564,6 +567,48 @@ pub struct SoloContext {
     /// `--soloMultiMappers` includes a non-`Unique` method → capture gene-
     /// ambiguous reads for distribution into `UniqueAndMult-*.mtx`.
     pub want_multi: bool,
+    /// `--soloOutLayout CellRanger`: write `metrics_summary.csv`, which needs
+    /// the Q30 tallies and the full positional funnel.
+    pub want_metrics: bool,
+    /// Base-quality tallies for the three `Q30 Bases in ...` metrics.
+    pub q30: Q30Stats,
+}
+
+/// Bases seen and bases at Phred ≥ 30, split the way CellRanger's
+/// `metrics_summary.csv` splits them: the cell barcode, the UMI, and the cDNA
+/// read. Only populated when `--soloOutLayout CellRanger` asks for the metrics.
+#[derive(Default)]
+pub struct Q30Stats {
+    pub cb_bases: AtomicU64,
+    pub cb_q30: AtomicU64,
+    pub umi_bases: AtomicU64,
+    pub umi_q30: AtomicU64,
+    pub rna_bases: AtomicU64,
+    pub rna_q30: AtomicU64,
+}
+
+impl Q30Stats {
+    /// Tally one read's barcode-read and cDNA-read qualities.
+    ///
+    /// Qualities are raw FASTQ bytes, Phred+33, so a Phred of 30 is the byte
+    /// `'?'` (63). The cDNA quality is the **unclipped** read, which is what
+    /// CellRanger reports on.
+    pub fn record(&self, bc: Option<&CellBarcode>, rna_qual: &[u8]) {
+        const Q30: u8 = 30 + 33;
+        let tally = |bases: &AtomicU64, q30: &AtomicU64, q: &[u8]| {
+            if q.is_empty() {
+                return;
+            }
+            bases.fetch_add(q.len() as u64, Ordering::Relaxed);
+            let n = q.iter().filter(|&&b| b >= Q30).count() as u64;
+            q30.fetch_add(n, Ordering::Relaxed);
+        };
+        if let Some(bc) = bc {
+            tally(&self.cb_bases, &self.cb_q30, &bc.cb_qual);
+            tally(&self.umi_bases, &self.umi_q30, &bc.umi_qual);
+        }
+        tally(&self.rna_bases, &self.rna_q30, rna_qual);
+    }
 }
 
 /// Per-region read tallies for the `Summary.csv` mapping funnel (uniquely-mapped
@@ -678,6 +723,7 @@ impl SoloContext {
         let sj_enabled = params.solo_features.iter().any(|f| f == "SJ");
         let velocyto_enabled = params.solo_features.iter().any(|f| f == "Velocyto");
         let want_multi = params.solo_multi_mappers.iter().any(|m| m != "Unique");
+        let want_metrics = params.solo_out_layout == "CellRanger";
 
         Ok(Self {
             layout: SoloBarcodeLayout::from_params(params),
@@ -695,6 +741,8 @@ impl SoloContext {
             velocyto_enabled,
             velocyto_records: Mutex::new(Vec::new()),
             want_multi,
+            want_metrics,
+            q30: Q30Stats::default(),
         })
     }
 
@@ -720,15 +768,26 @@ impl SoloContext {
         n_loci: usize,
         barcode: Option<&CellBarcode>,
         junctions: &[(u64, u64)],
+        rna_qual: &[u8],
     ) -> SoloReadOutcome {
         let mut out = SoloReadOutcome::default();
+
+        // Base qualities for `metrics_summary.csv`. Tallied before any early
+        // return, so every read reaching this point is counted exactly once.
+        if self.want_metrics {
+            self.q30.record(barcode, rna_qual);
+        }
 
         // One-pass classification: the two overlap queries are shared between the
         // per-feature gene assignment and the CellRanger-style mapping funnel, so
         // this is no more work than the old per-feature `assign_gene_se` calls.
-        let want_exon = self.features.contains(&SoloFeature::Gene);
+        let want_exon = self.features.contains(&SoloFeature::Gene) || self.want_metrics;
         // Velocyto assigns its gene by gene-body overlap, so it needs `want_body`.
-        let want_body = self.features.contains(&SoloFeature::GeneFull) || self.velocyto_enabled;
+        // `metrics_summary.csv` reports the exonic/intronic split, which is the
+        // same query, so it asks for it too.
+        let want_body = self.features.contains(&SoloFeature::GeneFull)
+            || self.velocyto_enabled
+            || self.want_metrics;
         let class = classify_read(
             cdna_transcripts,
             &self.gene_ann,
@@ -887,6 +946,7 @@ impl SoloContext {
         pairs: &[(&Transcript, &Transcript)],
         barcode: Option<&CellBarcode>,
         junctions: &[(u64, u64)],
+        rna_qual: &[u8],
     ) -> SoloReadOutcome {
         // Effective transcripts: give both mates of a pair the pair's strand
         // (mate 1's), so `classify_read`'s per-transcript strand filter treats them
@@ -898,7 +958,7 @@ impl SoloContext {
             eff.push((*m1).clone());
             eff.push(m2c);
         }
-        self.process_read(&eff, pairs.len(), barcode, junctions)
+        self.process_read(&eff, pairs.len(), barcode, junctions, rna_qual)
     }
 }
 

--- a/tests/alignment_features.rs
+++ b/tests/alignment_features.rs
@@ -1147,6 +1147,40 @@ fn test_solo_out_layout_cellranger() {
     assert_eq!(f_barcodes.lines().next().unwrap(), format!("{cb}-1"));
     let f_matrix = gunzip(&filt.join("matrix.mtx.gz"));
     assert_eq!(f_matrix.lines().last().unwrap(), "1 1 2");
+
+    // metrics_summary.csv: CellRanger 10.0.0's 20 metrics, in its order, as a
+    // header row and a value row. The header is compared against the literal
+    // string from a real CellRanger run.
+    let metrics = fs::read_to_string(output_dir.join("outs").join("metrics_summary.csv")).unwrap();
+    let mut lines = metrics.lines();
+    assert_eq!(
+        lines.next().unwrap(),
+        "Estimated Number of Cells,Mean Reads per Cell,Median Genes per Cell,\
+         Number of Reads,Valid Barcodes,Valid UMI Sequences,Sequencing Saturation,\
+         Q30 Bases in Barcode,Q30 Bases in RNA Read,Q30 Bases in UMI,\
+         Reads Mapped to Genome,Reads Mapped Confidently to Genome,\
+         Reads Mapped Confidently to Intergenic Regions,\
+         Reads Mapped Confidently to Intronic Regions,\
+         Reads Mapped Confidently to Exonic Regions,\
+         Reads Mapped Confidently to Transcriptome,Reads Mapped Antisense to Gene,\
+         Fraction Reads in Cells,Total Genes Detected,Median UMI Counts per Cell"
+    );
+    let values: Vec<&str> = lines.next().unwrap().split(',').collect();
+    // 20 metrics; 8 reads, so no field is large enough to be comma-quoted.
+    assert_eq!(values.len(), 20);
+    assert_eq!(values[0], "1", "one called cell");
+    assert_eq!(values[3], "8", "8 reads");
+    assert_eq!(values[4], "100.0%", "all barcodes valid");
+    assert_eq!(values[5], "100.0%", "all UMIs valid");
+    // 8 reads collapsing to 2 molecules: 6 of the 8 added nothing.
+    assert_eq!(values[6], "75.0%", "sequencing saturation");
+    // The fixture writes 'I' (Phred 40) for every base.
+    assert_eq!(values[7], "100.0%", "Q30 in barcode");
+    assert_eq!(values[8], "100.0%", "Q30 in RNA read");
+    assert_eq!(values[9], "100.0%", "Q30 in UMI");
+    assert_eq!(values[18], "1", "one gene detected");
+    assert_eq!(values[19], "2", "median 2 UMIs per cell");
+    assert!(lines.next().is_none(), "exactly two rows");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/alignment_features.rs
+++ b/tests/alignment_features.rs
@@ -951,6 +951,11 @@ fn test_starsolo_gene_matrix() {
             "Gene",
             "--sjdbGTFfile",
             gtf.to_str().unwrap(),
+            // This fixture's 16 bp CB + 12 bp UMI is 10x geometry, which now
+            // defaults to CellRanger's output layout; the assertions below are
+            // about STARsolo's, so state it.
+            "--soloOutLayout",
+            "STARsolo",
             "--outFileNamePrefix",
             &prefix,
         ])
@@ -1029,6 +1034,122 @@ fn test_starsolo_gene_matrix() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 9a'' — --soloOutLayout CellRanger writes the same numbers where
+// `cellranger count` writes them: outs/{raw,filtered}_feature_bc_matrix/,
+// gzipped, with a -1 GEM-well suffix on every barcode.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_solo_out_layout_cellranger() {
+    use std::io::Read;
+
+    let tmpdir = TempDir::new().unwrap();
+    let genome = build_genome();
+    let fasta = write_fasta(&tmpdir, &genome);
+    let gtf = write_gtf(&tmpdir);
+
+    let genome_dir = tmpdir.path().join("genome");
+    build_index(&fasta, &genome_dir, "7", Some(&gtf));
+
+    // Same fixture as test_starsolo_gene_matrix: 8 reads, one cell, two UMI
+    // clouds, so the expected counts are already known.
+    let cdna_path = tmpdir.path().join("cdna.fq");
+    let barcode_path = tmpdir.path().join("barcode.fq");
+    let wl_path = tmpdir.path().join("whitelist.txt");
+    let cb = "AAAACCCCGGGGTTTT";
+    let umi_a = "ACGTACGTAC";
+    let umi_b = "TGCATGCATG";
+    {
+        let mut cf = fs::File::create(&cdna_path).unwrap();
+        let mut bf = fs::File::create(&barcode_path).unwrap();
+        let exon1 = &genome[10000..10050];
+        for i in 0..8usize {
+            writeln!(cf, "@read{i}").unwrap();
+            cf.write_all(exon1).unwrap();
+            writeln!(cf, "\n+\n{}", "I".repeat(50)).unwrap();
+            let umi = if i < 4 { umi_a } else { umi_b };
+            writeln!(bf, "@read{i}").unwrap();
+            writeln!(bf, "{cb}{umi}").unwrap();
+            writeln!(bf, "+\n{}", "I".repeat(26)).unwrap();
+        }
+    }
+    {
+        let mut wf = fs::File::create(&wl_path).unwrap();
+        writeln!(wf, "{cb}").unwrap();
+        writeln!(wf, "CCCCGGGGTTTTAAAA").unwrap();
+        writeln!(wf, "GGGGTTTTAAAACCCC").unwrap();
+    }
+
+    let output_dir = tmpdir.path().join("out_crlayout");
+    fs::create_dir_all(&output_dir).unwrap();
+    let prefix = format!("{}/", output_dir.display());
+
+    // No --soloOutLayout on the command line: 16 bp CB + 12 bp UMI with a
+    // whitelist is 10x geometry, so the CellRanger layout is the default.
+    cargo_bin_cmd!("rustar-aligner")
+        .args([
+            "--runMode",
+            "alignReads",
+            "--genomeDir",
+            genome_dir.to_str().unwrap(),
+            "--readFilesIn",
+            cdna_path.to_str().unwrap(),
+            barcode_path.to_str().unwrap(),
+            "--soloType",
+            "CB_UMI_Simple",
+            "--soloCBwhitelist",
+            wl_path.to_str().unwrap(),
+            "--soloFeatures",
+            "Gene",
+            "--sjdbGTFfile",
+            gtf.to_str().unwrap(),
+            "--outFileNamePrefix",
+            &prefix,
+        ])
+        .assert()
+        .success();
+
+    let gunzip = |p: &std::path::Path| -> String {
+        let f = fs::File::open(p).unwrap_or_else(|e| panic!("{}: {e}", p.display()));
+        let mut s = String::new();
+        flate2::read::GzDecoder::new(f)
+            .read_to_string(&mut s)
+            .unwrap();
+        s
+    };
+
+    // CellRanger's directory names, under outs/, with no per-feature level.
+    let raw = output_dir.join("outs").join("raw_feature_bc_matrix");
+    assert!(raw.is_dir(), "expected {}", raw.display());
+    assert!(
+        !output_dir.join("Solo.out").exists(),
+        "Solo.out/ should not be written under the CellRanger layout"
+    );
+
+    // Every barcode carries the -1 GEM-well suffix, and the raw matrix has one
+    // column per observed barcode (one), not one per whitelist entry (three).
+    let barcodes = gunzip(&raw.join("barcodes.tsv.gz"));
+    assert_eq!(barcodes.lines().count(), 1);
+    assert_eq!(barcodes.lines().next().unwrap(), format!("{cb}-1"));
+
+    let features = gunzip(&raw.join("features.tsv.gz"));
+    assert!(features.starts_with("G1\tG1\tGene Expression"));
+
+    // The 2 deduped molecules test_starsolo_gene_matrix asserts, in a matrix
+    // that is now 1 gene × 1 observed barcode.
+    let matrix = gunzip(&raw.join("matrix.mtx.gz"));
+    let dims = matrix.lines().find(|l| !l.starts_with('%')).unwrap();
+    assert_eq!(dims, "1 1 1", "unexpected matrix dimensions");
+    assert_eq!(matrix.lines().last().unwrap(), "1 1 2");
+
+    let filt = output_dir.join("outs").join("filtered_feature_bc_matrix");
+    let f_barcodes = gunzip(&filt.join("barcodes.tsv.gz"));
+    assert_eq!(f_barcodes.lines().next().unwrap(), format!("{cb}-1"));
+    let f_matrix = gunzip(&filt.join("matrix.mtx.gz"));
+    assert_eq!(f_matrix.lines().last().unwrap(), "1 1 2");
+}
+
+// ---------------------------------------------------------------------------
 // Test 9a' — Summary.csv stays STARsolo-faithful; the CellRanger mapping funnel
 // (exonic/intronic/intergenic/antisense) is split out into a separate
 // CellRanger.summary.csv (PR #90 review: keep the faithful Summary.csv unaltered).
@@ -1091,6 +1212,11 @@ fn test_starsolo_summary_split() {
             "Forward",
             "--sjdbGTFfile",
             gtf.to_str().unwrap(),
+            // This fixture's 16 bp CB + 12 bp UMI is 10x geometry, which now
+            // defaults to CellRanger's output layout; the assertions below are
+            // about STARsolo's, so state it.
+            "--soloOutLayout",
+            "STARsolo",
             "--outFileNamePrefix",
             &prefix,
         ])
@@ -1179,6 +1305,11 @@ fn test_starsolo_sj_feature() {
             "Forward",
             "--sjdbGTFfile",
             gtf.to_str().unwrap(),
+            // This fixture's 16 bp CB + 12 bp UMI is 10x geometry, which now
+            // defaults to CellRanger's output layout; the assertions below are
+            // about STARsolo's, so state it.
+            "--soloOutLayout",
+            "STARsolo",
             "--outFileNamePrefix",
             &prefix,
         ])
@@ -1284,6 +1415,11 @@ fn test_starsolo_multimappers() {
             "Uniform",
             "--sjdbGTFfile",
             gtf.to_str().unwrap(),
+            // This fixture's 16 bp CB + 12 bp UMI is 10x geometry, which now
+            // defaults to CellRanger's output layout; the assertions below are
+            // about STARsolo's, so state it.
+            "--soloOutLayout",
+            "STARsolo",
             "--outFileNamePrefix",
             &prefix,
         ])
@@ -1523,6 +1659,11 @@ fn test_starsolo_velocyto() {
             "Forward",
             "--sjdbGTFfile",
             gtf.to_str().unwrap(),
+            // This fixture's 16 bp CB + 12 bp UMI is 10x geometry, which now
+            // defaults to CellRanger's output layout; the assertions below are
+            // about STARsolo's, so state it.
+            "--soloOutLayout",
+            "STARsolo",
             "--outFileNamePrefix",
             &prefix,
         ])
@@ -1611,6 +1752,11 @@ fn test_starsolo_velocyto_fold_ambiguous() {
             "Forward",
             "--sjdbGTFfile",
             gtf.to_str().unwrap(),
+            // This fixture's 16 bp CB + 12 bp UMI is 10x geometry, which now
+            // defaults to CellRanger's output layout; the assertions below are
+            // about STARsolo's, so state it.
+            "--soloOutLayout",
+            "STARsolo",
             "--outFileNamePrefix",
             &prefix,
         ])
@@ -1900,6 +2046,11 @@ fn test_starsolo_cellranger_style_matrix() {
             "1MM_CR",
             "--outSAMtype",
             "SAM",
+            // This fixture's 16 bp CB + 12 bp UMI is 10x geometry, which now
+            // defaults to CellRanger's output layout; the assertions below are
+            // about STARsolo's, so state it.
+            "--soloOutLayout",
+            "STARsolo",
             "--outFileNamePrefix",
             &prefix,
         ])


### PR DESCRIPTION
**Stacked on #185 → #184 → #182 → #179 → #178 → #176 → #175 → #174 → #173.**

**I measured this at 0.5% and I do not recommend merging it as it stands.** That is the headline, not the footnote, and the rest of this explains how I got there so you can disagree with the reasoning rather than the conclusion.

This is roadmap P3's lead item: the donor's batched prefetching MMP search, which its own benchmarks put at **2.09×** on the search engine.

## What it does

`max_mappable_length` becomes a state machine (`Phase`, `MmpState`, `mmp_advance`, `mmp_step_loop`, `mmp_finish`) so a search can be suspended at each probe, and `max_mappable_length_batch` drives `SEED_BATCH_WIDTH` of them together. Three passes per round, and the split is the point: issue every live search's suffix-array prefetch, then read those entries and prefetch each search's *dependent* genome byte, then compare. One search serialises those two DRAM misses; N overlap them.

A single read has only 2–4 independent chains, well under the width where interleaving pays (the donor measures a *regression* at 8), so `find_seeds_batch` takes a slice of reads and drives their chains in lockstep.

## The measurement

Profiling first put the seed search at **16.4%** of on-CPU time on a human 10x run. A 2.09× on that would be worth ~8.6% of wall clock. So I built it, then measured it in isolation — this branch against #185's tip, which carries the `cluster_seeds` work but not this:

| block | #185 tip | + batched search | |
|---|---|---|---|
| 1 | 90.0 s | 89.6 s | −0.5% |
| 2 | 90.7 s | 90.4 s | −0.3% |
| 3 | 91.3 s | 90.8 s | −0.6% |
| 4 | 91.7 s | 91.2 s | −0.5% |

Faster in **4 of 4**, median **−0.5%**. ABBA ordering, drift across the run only 2%, so for once the effect is well clear of the noise — it is just a small effect.

**0.5%, not 8.6%.** I would rather report the factor-of-seventeen miss than the direction.

I also measured the whole branch against the pre-P3 baseline at −4.6% (4/4 blocks), which looks better but is almost entirely #185's two `cluster_seeds` changes. Attributing that to this PR would be exactly the error I made earlier in this stack when I quoted a figure measured without #165.

## Why the donor's 2.09× does not transfer

One concrete reason, verifiable in the diff: **rustar already prefetches inside a single search.** `max_mappable_length` issues prefetches for both possible next midpoints before comparing the current probe, with a comment saying so. The donor's sequential baseline had no such thing, so its batch was recovering memory-level parallelism that here was already partly recovered.

Two more I can offer only as hypotheses, since I did not instrument them: the genome is byte-per-base with a SIMD scan, so `compare_seq_to_genome` may be more compute than stall; and the `SAindex` hierarchical lookup resolves many positions outright, so fewer positions reach the batched search than the 16.4% figure suggests.

## It is correct, at least

Whatever you decide about the trade, the equivalence is not in doubt:

- `batched_mmp_search_matches_the_sequential_one_at_every_width` — widths 1/2/8/32/128, every start position of seven reads
- `batched_mmp_handles_single_element_ranges_and_empty_batches`
- `batched_seed_finding_matches_per_read_sequential_calls` — same seeds **and same order**; order matters because `cluster_seeds` builds windows in seed order and the earliest window wins the primary tie-break, so a reordering would change which alignment is primary without changing any seed
- empty diff on 20 M read pairs of 10x `pbmc_1k_v3` against GRCh38: `matrix.mtx`, `barcodes.tsv`, `features.tsv`, `SJ.out.tab`, and `Log.final.out` identical apart from its timestamp

`find_seed_at_position` is split into `prepare_seed_at_position` and `finish_seed`, shared by both paths, so the sequential and batched searches cannot drift by transcription. `chain_starts`, `push_seed` and `finalize_seed_order` are shared for the same reason.

Gate: 584 lib + 27 integration tests, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, all green.

## My recommendation

**Close it, or park it.** 892 lines and a restructured hot path, on the file #146 is also rewriting, for 0.5% on the one workload I can measure. The state machine and its equivalence tests are the durable part; if the seed search ever becomes a larger share — a much faster stitcher would do it — this is ready and proven equivalent.

If you would rather keep only the cheap part, #185 stands alone and carries most of the measured gain.
