### PR TITLE
chore(deps): bump noodles 0.113 -> 0.115, noodles-bgzf 0.49 -> 0.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,13 @@ Sections commonly used: Features, Bug fixes, Other changes.
 - `caps-sa` → `0.5` (adds `build_ext_mem_for_filter*`; see the caps-sa
   v0.5.0 release notes).
 
+- `noodles` → `0.115`, `noodles-bgzf` → `0.51`. The bgzf releases move
+  the multithreaded reader/writer off rayon's global thread pool onto
+  their own local pools, restore the `with_worker_count` builders, and
+  sync the worker count to the number of managed buffers so that merely
+  constructing one no longer initialises rayon's global pool. No code
+  change was needed; BAM output is byte-identical.
+
 ### Other
 
 - New module `index::packed_stream` — bit-for-bit-compatible streaming

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.113.0"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f0a067d8afc481ba06abe5bd924e89368932d664bea15d671bee3559728421"
+checksum = "5ef86cb036ab589c660e76bc6d7741454fe8ff71ba3348f71812936f5c1a43f6"
 dependencies = [
  "noodles-bam",
  "noodles-bgzf",
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bam"
-version = "0.92.0"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e70c87dfebe1800c6a59f1b4fc9e6d69e165876c2d475b2b684862a06225a70"
+checksum = "e018289a9da86771349be387224f6634ad56ec48eb16a3a29a7670def5d206c2"
 dependencies = [
  "bstr",
  "indexmap",
@@ -720,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bgzf"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae8e8f7c1fd2e265d79241cea83e6f0ff7da2fa8922b5fe2f3eea8969823b60"
+checksum = "280d401d0358893ad706fb6094a18e7f9e8f3002630f4960889cb702b6e2714e"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-csi"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b522467eb7ae4a226b05182069e895940beda9206a3f4da9dd9395613ec9e5a8"
+checksum = "32789eeba9c4001d50de853a4c6a8f0551d586a91d6919c0008dd462231feacb"
 dependencies = [
  "bit-vec",
  "bstr",
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-sam"
-version = "0.87.0"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db484fde243408e8713278e6e83dbd67765cbd33612f2383f29b6359059d023f"
+checksum = "8063dd9e92825db46ae21813525589d41cff9ce2dcb2a0d25d99af86b274a1c5"
 dependencies = [
  "bitflags",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ log = "0.4"
 env_logger = "0.11"
 memmap2 = "0.9"
 byteorder = "1"
-noodles = { version = "0.113", features = ["fastq", "sam", "bam", "bgzf"] }
+noodles = { version = "0.115", features = ["fastq", "sam", "bam", "bgzf"] }
 bstr = "1"
 # Use the pure-Rust `zlib-rs` backend instead of flate2's default `miniz_oxide`:
 # ~2-3x faster inflate/deflate on the FASTQ decode + BGZF (BAM) paths, with no C
@@ -64,7 +64,7 @@ caps-sa = "0.6"
 mimalloc = { version = "0.1", default-features = false }
 libmimalloc-sys = { version = "0.1.49", features = ["extended"] } # mi_option_set (purge_delay); see main.rs
 libdeflater = "1.25.2"
-noodles-bgzf = { version = "0.49", features = ["libdeflate"] }
+noodles-bgzf = { version = "0.51", features = ["libdeflate"] }
 
 [dev-dependencies]
 assert_cmd = "2"


### PR DESCRIPTION
Closes #207.

Dependency bump only, no source change.

| Crate | Before | After |
|-------|--------|-------|
| `noodles` | `0.113` | `0.115` |
| `noodles-bgzf` | `0.49` | `0.51` |

Lockfile also moves `noodles-bam` 0.92 → 0.94, `noodles-sam` 0.87 → 0.89, `noodles-csi` 0.58 → 0.60
as transitive consequences.

## Why now

The two `noodles-bgzf` releases are about thread-pool ownership, which touches this project
directly because alignment runs on rayon:

* **0.50** — multithreaded readers and writers use exclusive local thread pools instead of rayon's
  default global pool, and the previously deprecated `with_worker_count` methods are supported
  again as the way to size them.
* **0.51** — the worker count is synced to the number of managed buffers rather than taken from
  rayon's global pool, so constructing one no longer initialises that pool as a side effect.

Today `src/io/bam.rs` only builds single-threaded `bgzf::io::Writer`s, so nothing in this PR
depends on that behaviour. It matters for the follow-up question of whether the BAM writer should
become multithreaded, which is tracked separately in #207 and deliberately **not** done here.

## What was verified

Everything below was run on this branch as submitted.

* `cargo fmt --check` — clean
* `cargo clippy --all-targets -- -D warnings` — clean
* `cargo test` — 593 tests pass, 0 failures (565 unit + 23 + 4 + 1 across the integration binaries)
* **BAM bytes unchanged.** Built the branch, then rebuilt with only `Cargo.toml`/`Cargo.lock`
  reverted to `origin/main`, and ran the identical command against the identical index and output
  prefix:

  ```sh
  ./target/debug/rustar-aligner --runMode genomeGenerate \
      --genomeDir /tmp/ab/idx --genomeFastaFiles test/simple.fa --genomeSAindexNbases 4
  ./target/debug/rustar-aligner --genomeDir /tmp/ab/idx --readFilesIn test/reads.fq \
      --outFileNamePrefix /tmp/ab/run/ --outSAMtype BAM SortedByCoordinate
  shasum -a 256 /tmp/ab/run/Aligned.sortedByCoord.out.bam
  ```

  Same digest `207b17d3…` on both. The `Genome` and `SA` index files are likewise identical
  (`4b09e0e7…` / `c398a82e…`).

  Note on scope: this uses the bundled `test/simple.fa` + `test/reads.fq` micro-fixture, so it
  proves the BGZF/BAM encoding path is unchanged, not that every code path in noodles is. The
  `--outFileNamePrefix` has to match between the two runs, because the `@PG CL:` header line
  records the command line and will otherwise differ on its own.

## What was not done

No move to the multithreaded BGZF writer, no `with_worker_count` plumbing, no behaviour change of
any kind. One theme per PR; the writer question stays in #207.
