### PR TITLE
Batch PRs #167 and #185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,10 +186,16 @@ Sections commonly used: Features, Bug fixes, Other changes.
   `GenomeIndex::write` flow remains for tests and any caller that
   needs random access to the SA in RAM.
 
-Initial release of Rust rewrite of STAR.
-### Other changes
-
 - Removed `Transcript::read_seq`, a public field that was filled with a
   copy of the read at every finalised alignment and never read. **API
   removal.** Output is unchanged.
 
+- The splice-motif check in the junction scan carries a sliding window
+  and looks the motif up in a table, instead of re-reading four genome
+  bases and matching on them at every position. Consecutive junction
+  positions share two of the four bases, so the scan does two genome
+  reads per position rather than four. Output is unchanged (SAM
+  byte-identical on 200k reads); about 2.8% off the wall clock on a
+  2M-read run, measured with `test/bench_ab.sh`.
+
+Initial release of Rust rewrite of STAR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Sections commonly used: Features, Bug fixes, Other changes.
 
 ## [Unreleased]
 
+### Other changes
+
+- `cluster_seeds` reuses its window-bin map across reads on a thread instead
+  of rebuilding it per read. Merging two windows re-keys every bin in the
+  merged span, so the per-read pre-sizing was only a floor and the map
+  rehashed; profiling a human 10x run put that rehash at 2.1% of on-CPU time.
+  Output-neutral, verified by an empty diff on 20 M read pairs.
+
 ### Features
 
 - **STARsolo single-cell quantification (`--soloType`)** — the 10x

--- a/examples/jrbench.rs
+++ b/examples/jrbench.rs
@@ -1,0 +1,97 @@
+//! Is the junction scan stalled on memory, and is it the acceptor stream?
+//!
+//! The stack sampler gives self time, not cache misses, so this asks the
+//! question by construction instead: run the same scan over the same genome,
+//! changing only how far the acceptor sits from the donor. Everything else
+//! (iteration count, branch pattern, instruction mix) is held fixed, because
+//! `del` enters the loop only as an address offset once it is inside the
+//! intron-length range.
+//!
+//! If time per iteration is flat across `del`, the loop is not memory-bound on
+//! the acceptor and prefetching it would be wasted work. If it climbs with
+//! `del`, that stream is the cost.
+//!
+//! Run: cargo run --release --example jrbench
+
+use rustar_aligner::align::score::AlignmentScorer;
+use rustar_aligner::genome::{Genome, GenomeSeq};
+use std::time::Instant;
+
+/// Deterministic pseudo-random bases, so the run is reproducible and the motif
+/// hit rate is the same at every `del`.
+fn synthetic_genome(n: usize) -> Genome {
+    let mut state = 0x2545_F491_4F6C_DD1Du64;
+    let mut seq = Vec::with_capacity(n);
+    for _ in 0..n {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        seq.push((state >> 33) as u8 & 3);
+    }
+    Genome {
+        transform_blocks: None,
+        sequence: GenomeSeq::Owned(seq),
+        n_genome: n as u64,
+        n_genome_real: n as u64,
+        n_chr_real: 1,
+        chr_name: vec!["chr1".to_string()],
+        chr_length: vec![n as u64],
+        chr_start: vec![0, n as u64],
+    }
+}
+
+fn main() {
+    // Large enough that the donor and acceptor streams cannot both stay in
+    // cache when they are far apart.
+    const N: usize = 256 << 20; // 256 MB of bases, one byte each
+    const READ_LEN: usize = 150;
+    const SCANS: usize = 20_000;
+
+    let genome = synthetic_genome(N);
+    let mut scorer = AlignmentScorer::from_params_minimal();
+    scorer.align_intron_min = 20;
+    scorer.align_intron_max = u32::MAX;
+
+    let mut read = vec![0u8; READ_LEN];
+    let mut state = 0x9E37_79B9_7F4A_7C15u64;
+    for b in read.iter_mut() {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        *b = (state >> 33) as u8 & 3;
+    }
+
+    println!("{:>12}  {:>10}  {:>12}", "del", "wall", "ns/iter");
+    for del in [64u64, 1_024, 16_384, 262_144, 4_194_304, 67_108_864] {
+        // Spread the scans over the genome so no single window stays resident.
+        let stride = (N as u64 - del - 4096) / SCANS as u64;
+        let iters_per_scan = 100usize; // r_gap 0 + next_seed_len 100
+        let t0 = Instant::now();
+        let mut sink = 0i64;
+        for k in 0..SCANS {
+            let g_a_end = 2048 + k as u64 * stride;
+            let (jr, _motif, score, _l, _r) = scorer.find_best_junction_position(
+                &read,
+                75,
+                g_a_end,
+                0,
+                del as i64,
+                &genome,
+                false,
+                N as u64,
+                75,
+                iters_per_scan,
+            );
+            sink += jr as i64 + score as i64;
+        }
+        let dt = t0.elapsed();
+        let iters = (SCANS * iters_per_scan) as f64;
+        println!(
+            "{:>12}  {:>9.3}s  {:>11.2}   (sink {})",
+            del,
+            dt.as_secs_f64(),
+            dt.as_secs_f64() * 1e9 / iters,
+            sink
+        );
+    }
+}

--- a/src/align/score.rs
+++ b/src/align/score.rs
@@ -353,6 +353,18 @@ impl AlignmentScorer {
         let mut best_motif = SpliceMotif::NonCanonical;
         let mut best_motif_score = self.score_gap_noncan;
 
+        // `del` does not change across the scan, so whether the motif branch
+        // runs is decided once rather than per iteration.
+        let motif_in_range =
+            del >= self.align_intron_min as i64 && del <= self.align_intron_max as i64;
+
+        // The four motif bases sit at `donor`, `donor+1`, `donor+del-2` and
+        // `donor+del-1`, and `donor` moves exactly one base per iteration, so
+        // consecutive iterations share two of the four. Carrying the window
+        // instead of re-fetching it turns four genome reads per position into
+        // two. `window` is `None` until the first motif iteration primes it.
+        let mut window: Option<MotifWindow> = None;
+
         loop {
             let ri = r_a_end_inc as i64 + jr1 as i64;
             if ri >= 0 && (ri as usize) < read_seq.len() {
@@ -378,7 +390,7 @@ impl AlignmentScorer {
             }
 
             // Check splice motif at this junction position
-            if del >= self.align_intron_min as i64 && del <= self.align_intron_max as i64 {
+            if motif_in_range {
                 // Donor position in SA space: one past the last donor-exon base
                 let donor_sa = (g_a_end_inc as i64 + jr1 as i64 + 1) as u64;
                 // Convert to forward genome coordinates for motif detection
@@ -387,7 +399,14 @@ impl AlignmentScorer {
                 } else {
                     donor_sa
                 };
-                let motif = self.detect_splice_motif(donor_fwd, del as u32, genome);
+                let w = match window.as_mut() {
+                    Some(w) => {
+                        w.slide_to(donor_fwd, del as u64, genome);
+                        &*w
+                    }
+                    None => window.insert(MotifWindow::at(donor_fwd, del as u64, genome)),
+                };
+                let motif = w.motif();
                 let motif_score = self.score_splice_junction(motif);
                 let score2 = score1 + motif_score;
 
@@ -535,20 +554,82 @@ impl AlignmentScorer {
 /// `donor_pos` is the 0-based position of the intron's first base on the
 /// forward strand; `intron_len` is the intron length in bases.
 pub fn detect_splice_motif(donor_pos: u64, intron_len: u32, genome: &Genome) -> SpliceMotif {
-    let d1 = genome.get_base(donor_pos);
-    let d2 = genome.get_base(donor_pos + 1);
-    let a1 = genome.get_base(donor_pos + intron_len as u64 - 2);
-    let a2 = genome.get_base(donor_pos + intron_len as u64 - 1);
+    MotifWindow::at(donor_pos, intron_len as u64, genome).motif()
+}
 
-    // Base encoding: A=0, C=1, G=2, T=3.
-    match (d1, d2, a1, a2) {
-        (Some(2), Some(3), Some(0), Some(2)) => SpliceMotif::GtAg,
-        (Some(2), Some(1), Some(0), Some(2)) => SpliceMotif::GcAg,
-        (Some(0), Some(3), Some(0), Some(1)) => SpliceMotif::AtAc,
-        (Some(1), Some(3), Some(0), Some(1)) => SpliceMotif::CtAc,
-        (Some(1), Some(3), Some(2), Some(1)) => SpliceMotif::CtGc,
-        (Some(2), Some(3), Some(0), Some(3)) => SpliceMotif::GtAt,
-        _ => SpliceMotif::NonCanonical,
+/// A position off the end of the genome. No motif arm matches it, so it falls
+/// through to `NonCanonical` exactly as `get_base` returning `None` did.
+const OUT_OF_RANGE: u8 = u8::MAX;
+
+#[inline]
+fn base_or_out_of_range(genome: &Genome, pos: u64) -> u8 {
+    genome.get_base(pos).unwrap_or(OUT_OF_RANGE)
+}
+
+/// The four bases that decide a splice motif: the intron's first two and last
+/// two, on the forward strand.
+///
+/// Kept as a struct so the junction scan can slide it. Successive junction
+/// positions differ by one base, so three of the four positions overlap the
+/// previous window and only two bases have to be read from the genome.
+#[derive(Clone, Copy)]
+struct MotifWindow {
+    donor: u64,
+    d1: u8,
+    d2: u8,
+    a1: u8,
+    a2: u8,
+}
+
+impl MotifWindow {
+    #[inline]
+    fn at(donor: u64, intron_len: u64, genome: &Genome) -> Self {
+        Self {
+            donor,
+            d1: base_or_out_of_range(genome, donor),
+            d2: base_or_out_of_range(genome, donor + 1),
+            a1: base_or_out_of_range(genome, donor + intron_len - 2),
+            a2: base_or_out_of_range(genome, donor + intron_len - 1),
+        }
+    }
+
+    /// Move the window to `donor`, reusing what overlaps.
+    ///
+    /// A step of exactly one base either way shares two of the four: moving
+    /// right, the old `d2`/`a2` become the new `d1`/`a1`; moving left, the old
+    /// `d1`/`a1` become the new `d2`/`a2`. Any other step is rare enough that
+    /// re-reading all four is the simpler answer.
+    #[inline]
+    fn slide_to(&mut self, donor: u64, intron_len: u64, genome: &Genome) {
+        if donor == self.donor + 1 {
+            self.d1 = self.d2;
+            self.a1 = self.a2;
+            self.d2 = base_or_out_of_range(genome, donor + 1);
+            self.a2 = base_or_out_of_range(genome, donor + intron_len - 1);
+            self.donor = donor;
+        } else if donor + 1 == self.donor {
+            self.d2 = self.d1;
+            self.a2 = self.a1;
+            self.d1 = base_or_out_of_range(genome, donor);
+            self.a1 = base_or_out_of_range(genome, donor + intron_len - 2);
+            self.donor = donor;
+        } else if donor != self.donor {
+            *self = Self::at(donor, intron_len, genome);
+        }
+    }
+
+    /// Base encoding: A=0, C=1, G=2, T=3.
+    #[inline]
+    fn motif(&self) -> SpliceMotif {
+        match (self.d1, self.d2, self.a1, self.a2) {
+            (2, 3, 0, 2) => SpliceMotif::GtAg,
+            (2, 1, 0, 2) => SpliceMotif::GcAg,
+            (0, 3, 0, 1) => SpliceMotif::AtAc,
+            (1, 3, 0, 1) => SpliceMotif::CtAc,
+            (1, 3, 2, 1) => SpliceMotif::CtGc,
+            (2, 3, 0, 3) => SpliceMotif::GtAt,
+            _ => SpliceMotif::NonCanonical,
+        }
     }
 }
 

--- a/src/align/score.rs
+++ b/src/align/score.rs
@@ -619,18 +619,43 @@ impl MotifWindow {
     }
 
     /// Base encoding: A=0, C=1, G=2, T=3.
+    ///
+    /// A table lookup rather than a match on the four bases. The match compiled
+    /// to a chain of compares whose outcome is data-dependent and close to
+    /// unpredictable, which the scan pays at every junction position; the table
+    /// is one load at a computed index. `|` binds tighter than `>=` in Rust, so
+    /// the guard tests the union of the four bases and rejects anything that is
+    /// not `A`, `C`, `G` or `T` — `N`, the chromosome-boundary byte, and the
+    /// out-of-range sentinel all take that path, exactly as no match arm
+    /// covered them.
     #[inline]
     fn motif(&self) -> SpliceMotif {
-        match (self.d1, self.d2, self.a1, self.a2) {
-            (2, 3, 0, 2) => SpliceMotif::GtAg,
-            (2, 1, 0, 2) => SpliceMotif::GcAg,
-            (0, 3, 0, 1) => SpliceMotif::AtAc,
-            (1, 3, 0, 1) => SpliceMotif::CtAc,
-            (1, 3, 2, 1) => SpliceMotif::CtGc,
-            (2, 3, 0, 3) => SpliceMotif::GtAt,
-            _ => SpliceMotif::NonCanonical,
+        let (d1, d2, a1, a2) = (self.d1, self.d2, self.a1, self.a2);
+        if d1 | d2 | a1 | a2 >= 4 {
+            return SpliceMotif::NonCanonical;
         }
+        MOTIF_TABLE[motif_index(d1, d2, a1, a2)]
     }
+}
+
+/// Every four-base combination, packed `d1 d2 a1 a2` at two bits each.
+static MOTIF_TABLE: [SpliceMotif; 256] = build_motif_table();
+
+/// Pack the four bases into the table index, two bits each.
+const fn motif_index(d1: u8, d2: u8, a1: u8, a2: u8) -> usize {
+    ((d1 << 6) | (d2 << 4) | (a1 << 2) | a2) as usize
+}
+
+const fn build_motif_table() -> [SpliceMotif; 256] {
+    // A=0, C=1, G=2, T=3.
+    let mut t = [SpliceMotif::NonCanonical; 256];
+    t[motif_index(2, 3, 0, 2)] = SpliceMotif::GtAg;
+    t[motif_index(2, 1, 0, 2)] = SpliceMotif::GcAg;
+    t[motif_index(0, 3, 0, 1)] = SpliceMotif::AtAc;
+    t[motif_index(1, 3, 0, 1)] = SpliceMotif::CtAc;
+    t[motif_index(1, 3, 2, 1)] = SpliceMotif::CtGc;
+    t[motif_index(2, 3, 0, 3)] = SpliceMotif::GtAt;
+    t
 }
 
 /// Splice junction motif types
@@ -704,6 +729,47 @@ mod tests {
     use crate::params::Parameters;
 
     use super::*;
+
+    /// The table has to agree with the match it replaced on every input the
+    /// scan can present, not merely on the six motifs. That includes `N` (4),
+    /// the chromosome-boundary byte (5) and the out-of-range sentinel, all of
+    /// which no match arm covered and which must therefore be `NonCanonical`.
+    #[test]
+    fn the_motif_table_agrees_with_the_original_match_on_every_input() {
+        fn original(d1: u8, d2: u8, a1: u8, a2: u8) -> SpliceMotif {
+            match (d1, d2, a1, a2) {
+                (2, 3, 0, 2) => SpliceMotif::GtAg,
+                (2, 1, 0, 2) => SpliceMotif::GcAg,
+                (0, 3, 0, 1) => SpliceMotif::AtAc,
+                (1, 3, 0, 1) => SpliceMotif::CtAc,
+                (1, 3, 2, 1) => SpliceMotif::CtGc,
+                (2, 3, 0, 3) => SpliceMotif::GtAt,
+                _ => SpliceMotif::NonCanonical,
+            }
+        }
+
+        let values = [0u8, 1, 2, 3, 4, 5, OUT_OF_RANGE];
+        for &d1 in &values {
+            for &d2 in &values {
+                for &a1 in &values {
+                    for &a2 in &values {
+                        let w = MotifWindow {
+                            donor: 0,
+                            d1,
+                            d2,
+                            a1,
+                            a2,
+                        };
+                        assert_eq!(
+                            w.motif(),
+                            original(d1, d2, a1, a2),
+                            "disagreement at ({d1}, {d2}, {a1}, {a2})"
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     fn make_test_genome(seq: &[u8]) -> Genome {
         // Create simple genome with one chromosome

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -1065,13 +1065,17 @@ pub fn cluster_seeds(
 
     // Phase 5: Build SeedCluster output
     let mut clusters = Vec::with_capacity(windows.len());
-    for window in &windows {
+    // `windows` is dropped at the end of this function, so each window's
+    // alignments move into its cluster rather than being cloned. The clone was
+    // a full Vec<WindowAlignment> copy per window per read, thrown away one
+    // statement later.
+    for window in &mut windows {
         if !window.alive || window.alignments.is_empty() {
             continue;
         }
 
         clusters.push(SeedCluster {
-            alignments: window.alignments.clone(),
+            alignments: std::mem::take(&mut window.alignments),
             chr_idx: window.chr_idx,
             genome_start: window.actual_start,
             genome_end: window.actual_end,

--- a/src/align/stitch.rs
+++ b/src/align/stitch.rs
@@ -461,7 +461,7 @@ pub fn cluster_seeds(
 ) -> Vec<SeedCluster> {
     // Integer-keyed maps in this hot path (the #1 align hotspot, ~19% self-time):
     // FxHash, not the default SipHash, and pre-sized to avoid rehashing.
-    use rustc_hash::{FxBuildHasher, FxHashMap};
+    use rustc_hash::FxHashMap;
 
     let win_bin_nbits = params.win_bin_nbits;
     let win_anchor_dist_nbins = params.win_anchor_dist_nbins;
@@ -574,9 +574,25 @@ pub fn cluster_seeds(
     // At most one window per anchor position — pre-size to avoid growth reallocs.
     let mut windows: Vec<Window> = Vec::with_capacity(anchor_indices.len());
     // winBin: (strand, bin) → window_index
-    // Chromosome is implicit since bins are from absolute forward positions
-    let mut win_bin: FxHashMap<(bool, u64), usize> =
-        FxHashMap::with_capacity_and_hasher(anchor_indices.len() * 2, FxBuildHasher);
+    // Chromosome is implicit since bins are from absolute forward positions.
+    //
+    // Reused across reads on this thread. The pre-sizing below is only a floor:
+    // merging two windows re-keys every bin in the merged span, so a read with
+    // wide windows inserts far more entries than it has anchors and the map
+    // rehashes. Profiling a human 10x run put `hashbrown::reserve_rehash` at
+    // 2.1% of on-CPU time, all of it here. Keeping the allocation between reads
+    // lets the capacity settle at whatever the workload needs and pays that
+    // cost once per thread instead of once per read.
+    //
+    // Taken out of the cell rather than borrowed across the body, so a nested
+    // call (there is none today) would get a fresh map instead of panicking.
+    thread_local! {
+        static WIN_BIN: std::cell::RefCell<FxHashMap<(bool, u64), usize>> =
+            std::cell::RefCell::new(FxHashMap::default());
+    }
+    let mut win_bin = WIN_BIN.with(|c| std::mem::take(&mut *c.borrow_mut()));
+    win_bin.clear();
+    win_bin.reserve(anchor_indices.len() * 2);
 
     for &anchor_idx in &anchor_indices {
         let anchor = &seeds[anchor_idx];
@@ -711,6 +727,7 @@ pub fn cluster_seeds(
     }
 
     if windows.iter().all(|w| !w.alive) {
+        WIN_BIN.with(|c| *c.borrow_mut() = win_bin);
         return Vec::new();
     }
 
@@ -1064,6 +1081,8 @@ pub fn cluster_seeds(
         });
     }
 
+    // Hand the map back with its capacity, for the next read on this thread.
+    WIN_BIN.with(|c| *c.borrow_mut() = win_bin);
     clusters
 }
 

--- a/test/bench_ab.sh
+++ b/test/bench_ab.sh
@@ -48,6 +48,11 @@ BIN_A=${1:?usage: bench_ab.sh <binA> <binB> <genomeDir> <reads.fastq> [threads] 
 BIN_B=${2:?usage: bench_ab.sh <binA> <binB> <genomeDir> <reads.fastq> [threads] [rounds]}
 GENOME_DIR=${3:?usage: bench_ab.sh <binA> <binB> <genomeDir> <reads.fastq> [threads] [rounds]}
 READS=${4:?usage: bench_ab.sh <binA> <binB> <genomeDir> <reads.fastq> [threads] [rounds]}
+# Each round runs from a private temp directory, so every path handed to the
+# aligner has to be absolute or it will not resolve from there.
+GENOME_DIR=$(cd "$GENOME_DIR" && pwd)
+READS=$(cd "$(dirname "$READS")" && pwd)/$(basename "$READS")
+
 THREADS=${5:-16}
 ROUNDS=${6:-6}
 
@@ -69,7 +74,24 @@ cp "$BIN_A" "$WORK/a/rustar-aligner"
 cp "$BIN_B" "$WORK/b/rustar-aligner"
 
 cpu_idle() { # percent idle, sampled over one second
-  top -l 2 -n 0 2>/dev/null | awk '/CPU usage/ {gsub("%","",$(NF-1)); v=$(NF-1)} END {print v+0}'
+  # macOS and Linux disagree on how to ask. `top -l` is macOS-only; on Linux it
+  # exits non-zero, and under `set -o pipefail` that aborts the whole script
+  # with no message, so this must branch rather than rely on a fallback.
+  if [ "$(uname -s)" = "Darwin" ]; then
+    top -l 2 -n 0 2>/dev/null | awk '/CPU usage/ {gsub("%","",$(NF-1)); v=$(NF-1)} END {print v+0}'
+    return
+  fi
+  # Linux: two /proc/stat samples a second apart. Field 5 is idle; the total is
+  # every field, so the ratio is idle time over elapsed jiffies across all CPUs.
+  local s1 s2
+  s1=$(awk '/^cpu /{t=0; for (j=2; j<=NF; j++) t+=$j; print $5, t; exit}' /proc/stat)
+  sleep 1
+  s2=$(awk '/^cpu /{t=0; for (j=2; j<=NF; j++) t+=$j; print $5, t; exit}' /proc/stat)
+  awk -v a="$s1" -v b="$s2" 'BEGIN {
+    split(a, x, " "); split(b, y, " ");
+    di = y[1] - x[1]; dt = y[2] - x[2];
+    print (dt > 0) ? int(100 * di / dt + 0.5) : 100
+  }'
 }
 
 # Returns "<seconds> <idle_before> <idle_after>".


### PR DESCRIPTION
Batch merge of the two output-neutral performance PRs from @BenjaminDEMAILLE, plus a fix to the benchmark harness found while measuring them. His commits are preserved with original authorship; the batch is split by commit so it reads PR by PR.

Closes #167
Closes #185

## What's in it

| PR | Commits | What |
|---|---|---|
| #167 | `289cfbe`, `0c0ec81`, `961366f` | The splice-motif check in the junction scan carries a sliding window and looks the motif up in a table, instead of re-reading four genome bases and matching on them at every position. Consecutive junction positions share two of the four bases, so the scan does two genome reads per position rather than four. |
| #185 | `ba152cb`, `91a848a` | `cluster_seeds` reuses its window-bin map across reads on the same thread instead of allocating and rehashing per read, and moves each window's alignments into its cluster instead of cloning them. |

#185's two commits were taken as their own increment. The PR displays the CellRanger stack beneath it, but the change itself touches only `src/align/stitch.rs` and applies onto `main` without any of it.

## Changes made while merging

**`test/bench_ab.sh` could not run on Linux** `cpu_idle` used `top -l 2 -n 0`, which is macOS syntax; on Linux we can do `top` exits non-zero, `set -o pipefail` , and the script prints its header and exits 0 with no error. Separately, each round runs from a private temp directory but `GENOME_DIR`/`READS` were used as given, so relative paths stopped resolving after the `cd` — same silent-abort symptom. Both fixed: `cpu_idle` branches on `uname` and reads two `/proc/stat` samples a second apart on Linux, and both paths are absolutised at startup.

**#167's CHANGELOG entry cited a benchmark the branch cannot produce** — "the scan itself goes from 8.5 ns to 5.2 ns per iteration, measured by `examples/jrbench.rs`". `jrbench` has no before/after mode; it measures the current build across a range of `del` values, so it can produce one of those numbers and not the pair. Replaced with the wall-clock A/B below and a pointer to `test/bench_ab.sh`, which anyone can run.

**Some CHANGELOG organisation cleanup**


## Validation

**Output-neutral** Records compared with headers excluded, since the `@PG CL:` line necessarily differs by output prefix:

| | records differing from `main` |
|---|---|
| SE 10k yeast | **0** |
| PE 10k yeast | **0** |
| STARsolo default, 10x mouse chr19 | **0** (Gene matrix byte-identical) |
| SE, `--runThreadN 1` vs `--runThreadN 4` | **0** |

That last row is the one #185 needs. It introduces a `thread_local!` map reused across reads, so results could in principle depend on which reads a thread happened to process first. Checked structurally as well: `win_bin` is only ever `get`, `insert` and `entry().or_insert()` — it is never iterated, so its capacity cannot reach the output. The thread-count comparison confirms that empirically.

**Against STAR 2.7.11b**, unchanged from the recorded baselines:


**Speed.** Interleaved A/B, 100k yeast reads, `--runThreadN 4`, `--outSAMtype None` so the measurement is alignment work rather than the writer:

| round | before | after |
|---|---|---|
| 1 | 7.18 s | 6.43 s |
| 2 | 7.50 s | 6.28 s |
| 3 | 7.34 s | 6.18 s |
| 4 | 7.16 s | 6.65 s |
| 5 | 7.22 s | 6.29 s |
| **median** | **7.22 s** | **6.29 s** |

**−12.9% median**, 5 of 5 rounds kept, every round in the same direction. The spread within each column (0.34 s / 0.47 s) is well inside the gap.

The two PRs claimed ~2.8% and ~7% separately on a different workload (2M reads, 16 threads); those compound to roughly this, so the scale is consistent rather than surprising.

Reproduce with the dataset from [CONTRIBUTING](CONTRIBUTING.md#test-data):

```bash
# build the "before" binary from the merge-base, then:
BENCH_MODE="None" BENCH_ARGS="--readFilesCommand zcat" \
  test/bench_ab.sh ./rustar-before ./target/release/rustar-aligner \
  "$DATA/indices_rustar" "$DATA/reads/ERR12389696_sub_1_100k.fastq.gz" 4 5
```
