### PR TITLE
chore(lint): fix clippy 1.98 pedantic lints breaking every PR

### DIFF
--- a/src/align/simd_scan.rs
+++ b/src/align/simd_scan.rs
@@ -28,11 +28,9 @@ pub fn find_stop(read: &[u8], genome: &[u8]) -> Option<usize> {
     debug_assert_eq!(read.len(), genome.len());
 
     let mut base = 0usize;
-    let mut r_chunks = read.chunks_exact(16);
-    let mut g_chunks = genome.chunks_exact(16);
-    while let (Some(rc), Some(gc)) = (r_chunks.next(), g_chunks.next()) {
-        let rc: &[u8; 16] = rc.try_into().unwrap();
-        let gc: &[u8; 16] = gc.try_into().unwrap();
+    let (r_chunks, r_rem) = read.as_chunks::<16>();
+    let (g_chunks, g_rem) = genome.as_chunks::<16>();
+    for (rc, gc) in r_chunks.iter().zip(g_chunks) {
         if !chunk_all_match(rc, gc) {
             for k in 0..16 {
                 if gc[k] >= 5 || rc[k] != gc[k] {
@@ -45,8 +43,6 @@ pub fn find_stop(read: &[u8], genome: &[u8]) -> Option<usize> {
     }
 
     // Tail shorter than 16 bytes: plain scalar scan.
-    let r_rem = r_chunks.remainder();
-    let g_rem = g_chunks.remainder();
     for (k, (&r, &g)) in r_rem.iter().zip(g_rem.iter()).enumerate() {
         if g >= 5 || r != g {
             return Some(base + k);

--- a/src/bam_dedup.rs
+++ b/src/bam_dedup.rs
@@ -314,7 +314,12 @@ fn collapse_group(recs: &mut [DedupRec], group: &[usize], mate2_bases_n: u32) ->
             .then_with(|| (ra.flag & 0x80).cmp(&(rb.flag & 0x80)))
     });
     // Pairs of adjacent (mate1, mate2) indices.
-    let mut pairs: Vec<(usize, usize)> = sorted.chunks_exact(2).map(|c| (c[0], c[1])).collect();
+    let mut pairs: Vec<(usize, usize)> = sorted
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|&[m1, m2]| (m1, m2))
+        .collect();
     // Sort pairs by the coordinate/flag/CIGAR key.
     pairs.sort_by(|&(a1, a2), &(b1, b2)| {
         cmp_pair(&recs[a1], &recs[a2], &recs[b1], &recs[b2], mate2_bases_n)

--- a/src/quant/mod.rs
+++ b/src/quant/mod.rs
@@ -320,7 +320,7 @@ impl GeneAnnotation {
                     out.push(chr[nlo].2);
                     continue;
                 }
-                let mid = (nlo + nhi) >> 1;
+                let mid = usize::midpoint(nlo, nhi);
                 stack[sp] = (2 * node, nlo, mid);
                 sp += 1;
                 stack[sp] = (2 * node + 1, mid, nhi);


### PR DESCRIPTION
## Why

`main` is red under the CI toolchain. Stable clippy 1.98 adds two pedantic lints that fire on existing code, and CI runs `cargo clippy --all-targets -- -D warnings`, so **every** PR opened today fails on files it never touched (seen on #235, a config-only change).

```
error: using `chunks_exact` with a constant chunk size
  --> src/align/simd_scan.rs:31:29
  --> src/align/simd_scan.rs:32:31
  --> src/bam_dedup.rs:317:49
error: manual implementation of `midpoint` which can overflow
  --> src/quant/mod.rs:323:27
```

Note for anyone who checked locally and saw nothing: cargo does not replay diagnostics for crates that are already fresh in the cache, so a warm-cache `cargo clippy` misses these. `touch src/lib.rs` first to reproduce.

## What

- `simd_scan::find_stop`: `as_chunks::<16>()` replaces `chunks_exact(16)` plus the two `try_into().unwrap()` casts; the tail comes from the same destructuring instead of `.remainder()`.
- `bam_dedup`: `as_chunks::<2>()` for the (mate1, mate2) pairing.
- `quant`: `usize::midpoint` for the segment-tree split point.

Behaviour is identical: `as_chunks` yields the same chunks and remainder as `chunks_exact`, and `midpoint` equals `(a + b) >> 1` for the non-overflowing indices here. The `unsafe` SIMD surface is untouched, and `chunk_all_match` now receives `&[u8; 16]` directly rather than through a checked cast.

MSRV 1.89 covers both APIs (`as_chunks` 1.88, `usize::midpoint` 1.85).

## Verification

`cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `cargo test` green (10 suites, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)