### PR TITLE
perf(pipeline): size alignment batches so the result vector stays off the arena path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1057,6 +1057,35 @@ struct AlignmentBatchResults {
     signal_n_tr: usize,
 }
 
+/// Reads per alignment batch, chosen so a batch's result vector stays an
+/// ordinary-sized allocation.
+///
+/// [`run_batch_pipeline`] allocates a fresh `Vec<Result<T, Error>>` for every
+/// batch and drops it once consumed. mimalloc serves anything past its
+/// large-object threshold from the arena path rather than a thread-local page,
+/// so once that vector crosses roughly 512 KB each batch pays a fresh mapping
+/// and — with `arena_eager_commit` off, which `main` sets deliberately to keep
+/// RSS down — faults every page back in. At the previous fixed 10,000 reads the
+/// vector was 1.7 MB and that path accounted for ~38% of the samples in a solo
+/// run.
+///
+/// The ceiling is the measured one. Sweeping batch size on a 2M-read solo run
+/// (8 threads) put the optimum on a plateau from roughly 1000 to 2000 reads:
+/// 10,000 took 3.46s, 3000 2.29s, 2000 2.15s, 1500 2.13s, 1000 2.17s, 250 2.58s.
+/// Below the plateau per-batch dispatch starts to dominate, which is what the
+/// floor guards. Some of the per-batch cost tracks the read count rather than
+/// the result vector — sizing purely by bytes picked 4096 for the solo product
+/// and left time on the table — so the count is capped as well.
+///
+/// The byte rule still earns its place as the other half: it keeps the
+/// allocation under the threshold if the result struct grows later, rather than
+/// leaving a tuned constant to rot.
+fn batch_size_for<T>() -> usize {
+    const TARGET_BYTES: usize = 384 * 1024;
+    const MAX_READS: usize = 2048;
+    (TARGET_BYTES / std::mem::size_of::<Result<T, error::Error>>().max(1)).clamp(512, MAX_READS)
+}
+
 /// One `Result` per read/pair in an aligned batch.
 type BatchOut<T> = Vec<Result<T, error::Error>>;
 
@@ -1462,7 +1491,7 @@ fn align_reads_single_end<W: AlignmentWriter + ?Sized>(
         params.read_map_number as u64
     };
 
-    let batch_size = 10000;
+    let batch_size = batch_size_for::<AlignmentBatchResults>();
     let max_multimaps = params.out_filter_multimap_nmax as usize;
     // `--outSAMtype None` (e.g. quant-only) skips building SAM records.
     let emit_sam = params.emits_alignments();
@@ -2094,7 +2123,7 @@ fn align_reads_solo<W: AlignmentWriter + ?Sized>(
     } else {
         params.read_map_number as u64
     };
-    let batch_size = 10000;
+    let batch_size = batch_size_for::<SoloReadProduct>();
     let clip5p = params.clip5p(0);
     let clip3p = params.clip3p(0);
     let cr4_clip = params.clip_adapter_type == "CellRanger4";
@@ -2409,7 +2438,7 @@ fn align_reads_solo_pe<W: AlignmentWriter + ?Sized>(
     } else {
         params.read_map_number as u64
     };
-    let batch_size = 10000;
+    let batch_size = batch_size_for::<SoloReadProduct>();
     // Per-mate clip: mate 1 (--clip5pNbases[0], e.g. 39 to strip the 5' barcode
     // region) and mate 2 ([1], e.g. 0). CellRanger4 adapter clipping is not used
     // by the cellgeni 5' path (it uses clip5pNbases instead), so it is not applied.
@@ -2802,7 +2831,7 @@ fn align_reads_paired_end<W: AlignmentWriter + ?Sized>(
         params.read_map_number as u64
     };
 
-    let batch_size = 10000;
+    let batch_size = batch_size_for::<AlignmentBatchResults>();
     let max_multimaps = params.out_filter_multimap_nmax as usize;
     // `--outSAMtype None` (e.g. quant-only) skips building SAM records.
     let emit_sam = params.emits_alignments();


### PR DESCRIPTION
Independent of #256 / #257 — this touches only `src/lib.rs` and can merge in any order.

## What

`run_batch_pipeline` allocates a fresh `Vec<Result<T, Error>>` per batch and drops it once consumed. At the fixed 10,000 reads that vector is 1.7 MB, past mimalloc's large-object threshold, so every batch was served from the arena path rather than a thread-local page: a fresh mapping, and — with `arena_eager_commit` off, which `main` sets deliberately to keep RSS down on genome-scale runs — every page faulted back in.

Profiling a 2M-read solo run put **~38% of samples** under `mi_huge_page_alloc` / `_mi_arenas_page_alloc`, against 4,370 for the alignment itself. The allocator was costing nearly as much as the work.

`batch_size_for::<T>()` derives the count from the element size and caps it at a measured ceiling.

## The ceiling is measured

Sweeping batch size on the solo run, 8 threads:

| batch | 10000 | 3000 | 2000 | 1500 | 1000 | 500 | 250 |
|---|---|---|---|---|---|---|---|
| wall | 3.46s | 2.29s | 2.15s | 2.13s | 2.17s | 2.35s | 2.58s |

Plateau from ~1000 to 2000; below it per-batch dispatch starts to dominate, which is what the floor guards.

Sizing purely by bytes was not enough on its own: some per-batch cost tracks read count rather than the result vector, so the byte rule alone picked 4096 for the solo product and left time on the table (2.47s vs 2.14s). 4096 also cost ~1.5% on paired-end, which 2048 does not. Hence both a byte target and a count cap. The byte rule still earns its place — it keeps the allocation under the threshold if a result struct grows later, rather than leaving a tuned constant to rot.

## Measured

Apple M4 Max. Solo workload is 2M reads, 5000 barcodes, 4546 genes, `CB_UMI_Simple`.

| workload | before | after | change |
|---|---|---|---|
| solo, wall, 8 threads | 3.49s | 2.15s | **-38.4%** |
| solo, user CPU, 1 thread | 15.03s | 10.63s | **-29.3%** |
| yeast PE, user CPU, 1 thread | 18.72s | 18.68s | neutral |
| nfcore PE, user CPU, 1 thread | 25.44s | 25.48s | neutral |

Paired-end is unchanged because its per-read work already amortizes the batch allocation. The win lands on workloads whose per-read cost is small, which is what a clean solo run looks like — and, I would expect, a production 10x run.

## Correctness

Byte-identical: solo `Aligned.out.sam`, `matrix.mtx`, `barcodes.tsv`, `features.tsv`; and `Aligned.out.sam` + `SJ.out.tab` on both paired-end sets.

- 593 tests pass
- 0 clippy warnings (`--all-targets --release`)
- `cargo fmt --check` clean

## Note on the benchmark

There is no solo dataset in the repo big enough to measure (the checked-in one is 400 reads), so I generated one: a synthetic gene model over the yeast genome (4546 genes, 1-3 exons each), a 5000-barcode whitelist, and 2M reads with 2% single-base barcode errors so CB correction is actually exercised. 95.2% uniquely mapped. Happy to contribute the generator if a solo benchmark fixture would be useful to have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)